### PR TITLE
B1: CI safety net — console-error fail, GitHub Actions, protocol drift test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,14 +28,22 @@ jobs:
           sudo apt-get install -y clang llvm libbpf-dev libelf-dev \
             zlib1g-dev liblz4-dev linux-tools-common
           # bpftool ships in the kernel-matched linux-tools package; fall
-          # back to the generic one (and a direct binary path) if the exact
-          # version is unavailable on the runner.
+          # back to the generic one if the exact version is unavailable.
           sudo apt-get install -y "linux-tools-$(uname -r)" || \
             sudo apt-get install -y linux-tools-generic
-          BPFTOOL=bpftool
-          if ! bpftool version >/dev/null 2>&1; then
-            BPFTOOL=$(ls /usr/lib/linux-tools/*/bpftool | head -1)
+          # Resolve a working bpftool: try the wrapper, then the binary
+          # shipped by whatever linux-tools package is installed.
+          BPFTOOL=""
+          if command -v bpftool >/dev/null && bpftool version >/dev/null 2>&1; then
+            BPFTOOL=bpftool
+          else
+            BPFTOOL=$(dpkg -L "linux-tools-$(uname -r)" 2>/dev/null \
+                        | grep '/bpftool$' | head -1)
+            if [ -z "$BPFTOOL" ]; then
+              BPFTOOL=$(find /usr/lib -name bpftool -type f 2>/dev/null | head -1)
+            fi
           fi
+          test -n "$BPFTOOL"
           "$BPFTOOL" version
           echo "BPFTOOL=$BPFTOOL" >> "$GITHUB_ENV"
           # The BPF build generates vmlinux.h from the running kernel's BTF

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,21 +27,30 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y clang llvm libbpf-dev libelf-dev \
             zlib1g-dev liblz4-dev linux-tools-common
-          # bpftool ships in the kernel-matched linux-tools package; fall
-          # back to the generic one if the exact version is unavailable.
+          # bpftool ships in the kernel-matched linux-tools package (or a
+          # standalone bpftool package on newer Ubuntu); try everything.
+          sudo apt-get install -y bpftool || true
           sudo apt-get install -y "linux-tools-$(uname -r)" || \
-            sudo apt-get install -y linux-tools-generic
-          # Resolve a working bpftool: try the wrapper, then the binary
-          # shipped by whatever linux-tools package is installed.
+            sudo apt-get install -y linux-tools-generic || true
+          # Diagnostics — if resolution fails the log must say why
+          set -x
+          uname -r
+          dpkg -l | grep -E 'linux-tools|bpftool' || true
+          dpkg -S '*/bpftool' 2>/dev/null || true
+          set +x
+          # Resolve a working bpftool: wrapper first, then any shipped binary
           BPFTOOL=""
           if command -v bpftool >/dev/null && bpftool version >/dev/null 2>&1; then
-            BPFTOOL=bpftool
+            BPFTOOL=$(command -v bpftool)
           else
-            BPFTOOL=$(dpkg -L "linux-tools-$(uname -r)" 2>/dev/null \
-                        | grep '/bpftool$' | head -1)
-            if [ -z "$BPFTOOL" ]; then
-              BPFTOOL=$(find /usr/lib -name bpftool -type f 2>/dev/null | head -1)
-            fi
+            for cand in $(dpkg -S '*/bpftool' 2>/dev/null \
+                            | sed 's/.*: //' | sort -u) \
+                        $(find /usr/lib /usr/sbin /usr/bin -name bpftool 2>/dev/null); do
+              if [ -x "$cand" ] && "$cand" version >/dev/null 2>&1; then
+                BPFTOOL=$cand
+                break
+              fi
+            done
           fi
           test -n "$BPFTOOL"
           "$BPFTOOL" version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,102 @@
+# CI safety net (Phase B1 of docs/REWORK_PLAN.md)
+#
+# Three jobs:
+#   build-and-unit  — full build (BPF tracer + pgwt-server), C unit tests,
+#                     Python synthetic-data correctness tests
+#   web-ui          — Playwright suite against tests/mock_server.py; any
+#                     browser console error fails the test that caused it
+#   protocol-drift  — same JSON-line commands against the real pgwt-server
+#                     (trace fixture generated in CI, nothing committed) and
+#                     against the mock; response schemas must match
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  build-and-unit:
+    name: build-and-unit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang llvm libbpf-dev libelf-dev \
+            zlib1g-dev liblz4-dev linux-tools-common
+          # bpftool ships in the kernel-matched linux-tools package; fall
+          # back to the generic one (and a direct binary path) if the exact
+          # version is unavailable on the runner.
+          sudo apt-get install -y "linux-tools-$(uname -r)" || \
+            sudo apt-get install -y linux-tools-generic
+          BPFTOOL=bpftool
+          if ! bpftool version >/dev/null 2>&1; then
+            BPFTOOL=$(ls /usr/lib/linux-tools/*/bpftool | head -1)
+          fi
+          "$BPFTOOL" version
+          echo "BPFTOOL=$BPFTOOL" >> "$GITHUB_ENV"
+          # The BPF build generates vmlinux.h from the running kernel's BTF
+          test -r /sys/kernel/btf/vmlinux
+
+      - name: Build (BPF tracer + pgwt-server)
+        run: make
+
+      - name: Build C unit tests
+        run: make -C tests
+
+      - name: Run C unit tests
+        run: |
+          tests/test_wait_event
+          tests/test_cmdline
+          tests/test_bucket
+          tests/test_event_writer
+          tests/test_event_reader
+
+      - name: Run synthetic data tests
+        run: |
+          set -e
+          for t in tests/test_data_*.py; do
+            echo "=== $t ==="
+            python3 "$t"
+          done
+          python3 tests/test_current_trace.py
+
+  web-ui:
+    name: web-ui
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install Playwright + websockets
+        run: |
+          python3 -m pip install playwright websockets
+          python3 -m playwright install --with-deps chromium
+
+      - name: Run web UI tests (mock server)
+        run: python3 tests/test_web_ui.py
+
+  protocol-drift:
+    name: protocol-drift
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install build dependencies (server only, no BPF)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y zlib1g-dev liblz4-dev
+
+      - name: Build pgwt-server + trace generator
+        run: |
+          make pgwt-server
+          make -C tests gen_test_traces
+
+      - name: Run protocol drift test (real server vs mock)
+        run: python3 tests/test_protocol_drift.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,32 +27,18 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y clang llvm libbpf-dev libelf-dev \
             zlib1g-dev liblz4-dev linux-tools-common
-          # bpftool ships in the kernel-matched linux-tools package (or a
-          # standalone bpftool package on newer Ubuntu); try everything.
-          sudo apt-get install -y bpftool || true
-          sudo apt-get install -y "linux-tools-$(uname -r)" || \
-            sudo apt-get install -y linux-tools-generic || true
-          # Diagnostics — if resolution fails the log must say why
-          set -x
-          uname -r
-          dpkg -l | grep -E 'linux-tools|bpftool' || true
-          dpkg -S '*/bpftool' 2>/dev/null || true
-          set +x
-          # Resolve a working bpftool: wrapper first, then any shipped binary
-          BPFTOOL=""
-          if command -v bpftool >/dev/null && bpftool version >/dev/null 2>&1; then
+          # bpftool: the runner's HWE azure kernel ships linux-tools without
+          # a bpftool binary (only the dispatch wrapper), so a packaged
+          # bpftool may not exist. Use it if it works; otherwise build a
+          # pinned bpftool from source (~30s, needs only libelf/zlib).
+          if bpftool version >/dev/null 2>&1; then
             BPFTOOL=$(command -v bpftool)
           else
-            for cand in $(dpkg -S '*/bpftool' 2>/dev/null \
-                            | sed 's/.*: //' | sort -u) \
-                        $(find /usr/lib /usr/sbin /usr/bin -name bpftool 2>/dev/null); do
-              if [ -x "$cand" ] && "$cand" version >/dev/null 2>&1; then
-                BPFTOOL=$cand
-                break
-              fi
-            done
+            git clone --depth 1 --branch v7.5.0 --recurse-submodules \
+              https://github.com/libbpf/bpftool.git /tmp/bpftool
+            make -C /tmp/bpftool/src -j"$(nproc)"
+            BPFTOOL=/tmp/bpftool/src/bpftool
           fi
-          test -n "$BPFTOOL"
           "$BPFTOOL" version
           echo "BPFTOOL=$BPFTOOL" >> "$GITHUB_ENV"
           # The BPF build generates vmlinux.h from the running kernel's BTF

--- a/Makefile
+++ b/Makefile
@@ -93,6 +93,7 @@ $(BUILD_DIR):
 # Step 1: Generate vmlinux.h from kernel BTF
 $(INC_DIR)/vmlinux.h:
 	@echo "  VMLINUX  $@"
+	@mkdir -p $(INC_DIR)
 	@$(BPFTOOL) btf dump file /sys/kernel/btf/vmlinux format c > $@
 
 # Step 2: Compile BPF program

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -12,7 +12,7 @@ TESTS     = test_wait_event test_cmdline test_event_writer test_event_reader \
 
 all: $(TESTS)
 
-test_wait_event: test_wait_event.c $(BUILD)/wait_event.o
+test_wait_event: test_wait_event.c $(BUILD)/wait_event.o $(BUILD)/cJSON.o
 	$(CC) $(CFLAGS) -o $@ $^
 
 test_cmdline: test_cmdline.c $(BUILD)/cmdline.o
@@ -22,7 +22,7 @@ test_event_writer: test_event_writer.c $(BUILD)/event_writer.o
 	$(CC) $(CFLAGS) -o $@ $^ -llz4
 
 test_event_reader: test_event_reader.c $(BUILD)/event_reader.o $(BUILD)/event_writer.o \
-                   $(BUILD)/map_reader.o $(BUILD)/wait_event.o
+                   $(BUILD)/map_reader.o $(BUILD)/wait_event.o $(BUILD)/cJSON.o
 	$(CC) $(CFLAGS) -o $@ $^ -llz4 -lbpf -lelf -lz
 
 test_bucket: test_bucket.c

--- a/tests/mock_server.py
+++ b/tests/mock_server.py
@@ -84,12 +84,16 @@ _CANNED = {}
 _CANNED["info"] = {
     "from_ns": _FROM_NS,
     "to_ns": _TO_NS,
+    "now_ns": _TO_NS,
     "num_cpus": 4,
     "num_events": 1_250_000,
 }
 
 _CANNED["time_model"] = {
     "wall_ms": 3600000,
+    "db_time_ms": 12500,
+    "idle_time_ms": 45000,
+    "aas": 3.47,
     "rows": [
         {"indent": 0, "name": "DB Time",  "ms": 12500, "pct": 100.0, "aas": 3.47},
         {"indent": 1, "name": "CPU*",     "ms": 4800,  "pct": 38.4,  "aas": 1.33},
@@ -106,6 +110,7 @@ _CANNED["time_model"] = {
 }
 
 _CANNED["top_events"] = {
+    "db_time_ms": 12500,
     "rows": [
         {"name": "CPU*",             "event_id": 0,          "class": "CPU",
          "count": 250000, "total_ms": 4800, "avg_us": 19.2, "p50_us": 12,
@@ -137,64 +142,117 @@ _CANNED["top_events"] = {
 _CANNED["top_sessions"] = {
     "rows": [
         {"pid": 1001, "type": "client", "user": "postgres", "db": "testdb",
-         "db_time_ms": 5200, "cpu_pct": 45.0, "wait_pct": 55.0, "top_wait": "IO:DataFileRead"},
+         "db_time_ms": 5200, "cpu_pct": 45.0, "wait_pct": 55.0,
+         "top_wait": "IO:DataFileRead", "top_wait_id": 0x01000015},
         {"pid": 1002, "type": "client", "user": "postgres", "db": "testdb",
-         "db_time_ms": 3800, "cpu_pct": 38.0, "wait_pct": 62.0, "top_wait": "Lock:relation"},
+         "db_time_ms": 3800, "cpu_pct": 38.0, "wait_pct": 62.0,
+         "top_wait": "Lock:relation", "top_wait_id": 0x03000000},
         {"pid": 1003, "type": "client", "user": "app", "db": "mydb",
-         "db_time_ms": 2500, "cpu_pct": 52.0, "wait_pct": 48.0, "top_wait": "LWLock:WALWrite"},
+         "db_time_ms": 2500, "cpu_pct": 52.0, "wait_pct": 48.0,
+         "top_wait": "LWLock:WALWrite", "top_wait_id": 0x04000008},
         {"pid": 1004, "type": "client", "user": "app", "db": "mydb",
-         "db_time_ms": 1000, "cpu_pct": 30.0, "wait_pct": 70.0, "top_wait": "Timeout:PgSleep"},
+         "db_time_ms": 1000, "cpu_pct": 30.0, "wait_pct": 70.0,
+         "top_wait": "Timeout:PgSleep", "top_wait_id": 0x09000002},
         {"pid": 4870, "type": "checkpointer", "user": "", "db": "",
-         "db_time_ms": 800, "cpu_pct": 10.0, "wait_pct": 90.0, "top_wait": "Timeout:CheckpointWriteDelay"},
+         "db_time_ms": 800, "cpu_pct": 10.0, "wait_pct": 90.0,
+         "top_wait": "Timeout:CheckpointWriteDelay", "top_wait_id": 0x09000000},
         {"pid": 4871, "type": "bgwriter", "user": "", "db": "",
-         "db_time_ms": 200, "cpu_pct": 5.0, "wait_pct": 95.0, "top_wait": "IO:DataFileWrite"},
+         "db_time_ms": 200, "cpu_pct": 5.0, "wait_pct": 95.0,
+         "top_wait": "IO:DataFileWrite", "top_wait_id": 0x01000018},
     ],
 }
 
 _CANNED["top_queries"] = {
+    "db_time_ms": 12500,
     "rows": [
         {"query_id": "3886912043147135675", "text": "UPDATE pgbench_accounts SET abalance = abalance + $1 WHERE aid = $2",
          "total_ms": 4200, "pct": 33.6, "count": 45000, "avg_us": 93.3,
-         "top_wait": "IO:DataFileRead",
+         "top_wait": "IO:DataFileRead", "top_wait_id": 0x01000015,
+         # Lifecycle stats (emitted by the real server when plan/exec
+         # markers are present in the trace)
+         "exec_count": 45000, "plan_count": 45000,
+         "exec_total_ms": 4150.0, "avg_exec_ms": 0.092,
+         "p95_exec_ms": 0.31, "p99_exec_ms": 1.2,
+         "avg_plan_ms": 0.011, "p95_plan_ms": 0.04, "p99_plan_ms": 0.09,
          "classes": [2000, 1200, 500, 300, 0, 0, 100, 0, 0, 100, 0],
          "events": [
-            {"name": "CPU*", "ms": 2000},
-            {"name": "IO:DataFileRead", "ms": 1200},
-            {"name": "Lock:relation", "ms": 500},
-            {"name": "LWLock:WALWrite", "ms": 300},
-            {"name": "Extension:Extension", "ms": 100},
-            {"name": "Timeout:PgSleep", "ms": 100},
+            {"name": "CPU*", "id": 0, "ms": 2000},
+            {"name": "IO:DataFileRead", "id": 0x01000015, "ms": 1200},
+            {"name": "Lock:relation", "id": 0x03000000, "ms": 500},
+            {"name": "LWLock:WALWrite", "id": 0x04000008, "ms": 300},
+            {"name": "Extension:Extension", "id": 0x0a000000, "ms": 100},
+            {"name": "Timeout:PgSleep", "id": 0x09000002, "ms": 100},
          ]},
         {"query_id": "5371305355164922084", "text": "SELECT abalance FROM pgbench_accounts WHERE aid = $1",
          "total_ms": 3100, "pct": 24.8, "count": 45000, "avg_us": 68.9,
-         "top_wait": "IO:DataFileRead",
+         "top_wait": "IO:DataFileRead", "top_wait_id": 0x01000015,
          "classes": [1500, 900, 200, 300, 0, 0, 100, 0, 0, 100, 0],
          "events": [
-            {"name": "CPU*", "ms": 1500},
-            {"name": "IO:DataFileRead", "ms": 900},
-            {"name": "Lock:relation", "ms": 200},
-            {"name": "LWLock:WALWrite", "ms": 300},
-            {"name": "Extension:Extension", "ms": 100},
-            {"name": "Timeout:PgSleep", "ms": 100},
+            {"name": "CPU*", "id": 0, "ms": 1500},
+            {"name": "IO:DataFileRead", "id": 0x01000015, "ms": 900},
+            {"name": "Lock:relation", "id": 0x03000000, "ms": 200},
+            {"name": "LWLock:WALWrite", "id": 0x04000008, "ms": 300},
+            {"name": "Extension:Extension", "id": 0x0a000000, "ms": 100},
+            {"name": "Timeout:PgSleep", "id": 0x09000002, "ms": 100},
          ]},
         {"query_id": "-2312456789012345678", "text": "INSERT INTO pgbench_history (tid, bid, aid, delta, mtime) VALUES ($1, $2, $3, $4, CURRENT_TIMESTAMP)",
          "total_ms": 2800, "pct": 22.4, "count": 45000, "avg_us": 62.2,
-         "top_wait": "LWLock:WALWrite",
+         "top_wait": "LWLock:WALWrite", "top_wait_id": 0x04000008,
          "classes": [1000, 800, 300, 500, 0, 0, 100, 0, 0, 100, 0],
          "events": [
-            {"name": "CPU*", "ms": 1000},
-            {"name": "IO:WalSync", "ms": 800},
-            {"name": "LWLock:WALWrite", "ms": 500},
-            {"name": "Lock:relation", "ms": 300},
-            {"name": "Extension:Extension", "ms": 100},
-            {"name": "Timeout:PgSleep", "ms": 100},
+            {"name": "CPU*", "id": 0, "ms": 1000},
+            {"name": "IO:WalSync", "id": 0x0100004e, "ms": 800},
+            {"name": "LWLock:WALWrite", "id": 0x04000008, "ms": 500},
+            {"name": "Lock:relation", "id": 0x03000000, "ms": 300},
+            {"name": "Extension:Extension", "id": 0x0a000000, "ms": 100},
+            {"name": "Timeout:PgSleep", "id": 0x09000002, "ms": 100},
          ]},
     ],
+}
+
+_CANNED["variants"] = {
+    "exec": {
+        "total": 45000,
+        "num_variants": 2,
+        "variants": [
+            {"exec_count": 30000, "num_queries": 1, "total_ms": 2790.0,
+             "avg_ms": 0.093, "p95_ms": 0.30, "avg_loop_n": 1,
+             "top_query_id": 3886912043147135675,
+             "steps": [
+                 {"name": "CPU*", "avg_ms": 0.04, "class": "cpu"},
+                 {"name": "IO:DataFileRead", "avg_ms": 0.03, "class": "IO"},
+                 {"name": "CPU*", "avg_ms": 0.023, "class": "cpu"},
+             ],
+             "query_text": "UPDATE pgbench_accounts SET abalance = abalance + $1 WHERE aid = $2"},
+            {"exec_count": 15000, "num_queries": 1, "total_ms": 1360.0,
+             "avg_ms": 0.09, "p95_ms": 0.28, "avg_loop_n": 1,
+             "top_query_id": 5371305355164922084,
+             "steps": [
+                 {"name": "CPU*", "avg_ms": 0.05, "class": "cpu"},
+                 {"name": "LWLock:WALWrite", "avg_ms": 0.04, "class": "LWLock"},
+             ],
+             "query_text": "SELECT abalance FROM pgbench_accounts WHERE aid = $1"},
+        ],
+    },
+    "plan": {
+        "total": 45000,
+        "num_variants": 1,
+        "variants": [
+            {"exec_count": 45000, "num_queries": 2, "total_ms": 495.0,
+             "avg_ms": 0.011, "p95_ms": 0.04, "avg_loop_n": 1,
+             "top_query_id": 3886912043147135675,
+             "steps": [
+                 {"name": "CPU*", "avg_ms": 0.011, "class": "cpu"},
+             ],
+             "query_text": "UPDATE pgbench_accounts SET abalance = abalance + $1 WHERE aid = $2"},
+        ],
+    },
 }
 
 _CANNED["heatmap"] = {
     "bucket_ns": _BUCKET_NS,
     "max_count": 5000,
+    "total_events": 402500,
     "times": [_FROM_NS + i * _BUCKET_NS for i in range(60)],
     "labels": ["<1", "1-2", "2-4", "4-8", "8-16", "16-32", "32-64",
                "64-128", "128-256", "256-512", "512-1K", "1K-2K",
@@ -213,21 +271,21 @@ _CANNED["session_timeline"] = {
     "pids": [1001, 1002],
     "events": [
         {"s": _FROM_NS + 100_000_000_000, "d": 50_000_000_000, "p": 1001,
-         "n": "CPU*", "c": 0, "q": "3886912043147135675"},
+         "n": "CPU*", "e": 0, "c": 0, "q": "3886912043147135675"},
         {"s": _FROM_NS + 150_000_000_000, "d": 30_000_000_000, "p": 1001,
-         "n": "IO:DataFileRead", "c": 1, "q": "3886912043147135675"},
+         "n": "IO:DataFileRead", "e": 0x01000015, "c": 1, "q": "3886912043147135675"},
         {"s": _FROM_NS + 180_000_000_000, "d": 20_000_000_000, "p": 1001,
-         "n": "Lock:relation", "c": 2, "q": "3886912043147135675"},
+         "n": "Lock:relation", "e": 0x03000000, "c": 2, "q": "3886912043147135675"},
         {"s": _FROM_NS + 200_000_000_000, "d": 40_000_000_000, "p": 1001,
-         "n": "CPU*", "c": 0, "q": "3886912043147135675"},
+         "n": "CPU*", "e": 0, "c": 0, "q": "3886912043147135675"},
         {"s": _FROM_NS + 100_000_000_000, "d": 80_000_000_000, "p": 1002,
-         "n": "Lock:relation", "c": 2, "q": "5371305355164922084"},
+         "n": "Lock:relation", "e": 0x03000000, "c": 2, "q": "5371305355164922084"},
         {"s": _FROM_NS + 180_000_000_000, "d": 25_000_000_000, "p": 1002,
-         "n": "CPU*", "c": 0, "q": "5371305355164922084"},
+         "n": "CPU*", "e": 0, "c": 0, "q": "5371305355164922084"},
         {"s": _FROM_NS + 205_000_000_000, "d": 35_000_000_000, "p": 1002,
-         "n": "IO:DataFileRead", "c": 1, "q": "5371305355164922084"},
+         "n": "IO:DataFileRead", "e": 0x01000015, "c": 1, "q": "5371305355164922084"},
         {"s": _FROM_NS + 240_000_000_000, "d": 15_000_000_000, "p": 1002,
-         "n": "LWLock:WALWrite", "c": 3, "q": "5371305355164922084"},
+         "n": "LWLock:WALWrite", "e": 0x04000008, "c": 3, "q": "5371305355164922084"},
     ],
 }
 
@@ -260,7 +318,9 @@ def handle_request(msg):
         if "class" in filters:
             cls = filters["class"]
             rows = [r for r in rows if r["class"].lower() == cls.lower()]
-        return {"id": req_id, "rows": rows}
+        return {"id": req_id,
+                "db_time_ms": _CANNED["top_events"]["db_time_ms"],
+                "rows": rows}
 
     if cmd == "top_sessions":
         return {"id": req_id, **_CANNED["top_sessions"]}
@@ -278,7 +338,12 @@ def handle_request(msg):
         return {"id": req_id, "events": [], "pids": [], "truncated": False, "total_count": 0}
 
     if cmd == "transitions":
-        return {"id": req_id, "total": 1500, "links": [
+        return {"id": req_id, "total": 1500, "nodes": [
+            {"name": "CPU*", "total_ms": 4800, "class": "CPU"},
+            {"name": "IO:DataFileRead", "total_ms": 2100, "class": "IO"},
+            {"name": "LWLock:WALInsert", "total_ms": 900, "class": "LWLock"},
+            {"name": "IO:WalSync", "total_ms": 800, "class": "IO"},
+        ], "links": [
             {"source": "CPU*", "target": "IO:DataFileRead", "value": 500, "duration_ms": 2500.0},
             {"source": "IO:DataFileRead", "target": "CPU*", "value": 480, "duration_ms": 1920.0},
             {"source": "CPU*", "target": "LWLock:WALInsert", "value": 300, "duration_ms": 900.0},
@@ -300,12 +365,21 @@ def handle_request(msg):
 
     if cmd == "concurrency":
         nb = msg.get("num_buckets", 60)
-        peaks = [{"t": 1711936000000000000 + i * 60000000000, "max": 3 + (i % 5), "event": "LWLock:BufferMapping"} for i in range(nb)]
+        peaks = [{"t": 1711936000000000000 + i * 60000000000,
+                  "t_ms": (1711936000000000000 + i * 60000000000) // 1000000,
+                  "max": 3 + (i % 5), "event": "LWLock:BufferMapping"} for i in range(nb)]
         bursts = [
-            {"timestamp_ns": 1711936180000000000, "event": "LWLock:BufferMapping", "sessions": 8, "pids": [1001, 1002, 1003, 1004, 1005, 1006, 1007, 1008]},
-            {"timestamp_ns": 1711936300000000000, "event": "IO:DataFileRead", "sessions": 5, "pids": [1001, 1003, 1005, 1007, 1009]},
+            {"timestamp_ns": 1711936180000000000, "timestamp_ms": 1711936180000,
+             "event": "LWLock:BufferMapping", "sessions": 8,
+             "pids": [1001, 1002, 1003, 1004, 1005, 1006, 1007, 1008]},
+            {"timestamp_ns": 1711936300000000000, "timestamp_ms": 1711936300000,
+             "event": "IO:DataFileRead", "sessions": 5,
+             "pids": [1001, 1003, 1005, 1007, 1009]},
         ]
         return {"id": req_id, "peaks": peaks, "bursts": bursts, "bucket_ns": 60000000000}
+
+    if cmd == "variants":
+        return {"id": req_id, **_CANNED["variants"]}
 
     if cmd == "fingerprints":
         return {"id": req_id, "rows": [

--- a/tests/mock_server.py
+++ b/tests/mock_server.py
@@ -22,12 +22,13 @@ import signal
 from http.server import SimpleHTTPRequestHandler, HTTPServer
 import threading
 
+# websockets is only needed to *run* the server.  Importers that just use
+# handle_request() (e.g. tests/test_protocol_drift.py) work without it.
 try:
-    import websockets
     import websockets.asyncio.server
+    _HAVE_WEBSOCKETS = True
 except ImportError:
-    print("ERROR: pip install websockets", file=sys.stderr)
-    sys.exit(1)
+    _HAVE_WEBSOCKETS = False
 
 STATIC_DIR = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
                           "web", "static")
@@ -429,6 +430,10 @@ async def run_ws(port):
 
 
 def main():
+    if not _HAVE_WEBSOCKETS:
+        print("ERROR: pip install websockets", file=sys.stderr)
+        sys.exit(1)
+
     parser = argparse.ArgumentParser()
     parser.add_argument("--port", type=int, default=18765,
                         help="HTTP port (WS = port+1)")

--- a/tests/run_all.sh
+++ b/tests/run_all.sh
@@ -90,6 +90,7 @@ if [[ -x "$PROJECT_DIR/pgwt-server" ]] && [[ -x "$SCRIPT_DIR/gen_test_traces" ]]
     run_test "test_data_transitions" python3 "$SCRIPT_DIR/test_data_transitions.py"
     run_test "test_data_lock_chains" python3 "$SCRIPT_DIR/test_data_lock_chains.py"
     run_test "test_current_trace" python3 "$SCRIPT_DIR/test_current_trace.py"
+    run_test "test_protocol_drift" python3 "$SCRIPT_DIR/test_protocol_drift.py"
 else
     skip_test "test_data_*" "pgwt-server or gen_test_traces not built"
 fi
@@ -172,8 +173,13 @@ else
 fi
 
 # Step 5: Web UI tests (needs playwright + websockets, no root needed)
+# Locally a missing dependency is a skip; in CI ($CI set) it is a FAILURE —
+# the UI suite silently not running is how regressions slip through.
 if python3 -c "import playwright, websockets" 2>/dev/null; then
     run_test "test_web_ui" python3 "$SCRIPT_DIR/test_web_ui.py"
+elif [[ -n "${CI:-}" ]]; then
+    run_test "test_web_ui" bash -c \
+        'echo "ERROR: playwright/websockets not installed — required in CI"; exit 1'
 else
     skip_test "test_web_ui" "playwright or websockets not installed"
 fi

--- a/tests/test_current_trace.py
+++ b/tests/test_current_trace.py
@@ -182,4 +182,4 @@ finally:
     import shutil
     shutil.rmtree(tmpdir, ignore_errors=True)
 
-t.summary()
+sys.exit(0 if t.summary() else 1)

--- a/tests/test_data_idle.py
+++ b/tests/test_data_idle.py
@@ -2,7 +2,12 @@
 """test_data_idle.py — 0B.7: idle exclusion.
 
 Verifies that Activity (idle) events are excluded from DB Time, AAS,
-top_events, top_sessions, and top_queries. Only non-idle events contribute.
+top_events, top_sessions, and top_queries.
+
+Client:ClientRead is deliberately NOT idle (see pgwt_is_idle_event in
+src/wait_event.c): it is a real wait event — time spent waiting for the
+client to send the next command — and counts toward DB Time under the
+Client class.
 """
 import os
 import sys
@@ -22,9 +27,9 @@ def build_scenario():
     PID 1000: IO:Read 5ms (active)
     PID 1001: Activity:Idle 50ms (should be excluded)
     PID 1002: CPU 3ms (active)
-    PID 1003: Client:ClientRead 20ms (idle — excluded from DB Time)
+    PID 1003: Client:ClientRead 20ms (NOT idle — counts toward DB Time)
 
-    Expected DB Time = 5 + 3 = 8ms (not 78ms)
+    Expected DB Time = 5 + 3 + 20 = 28ms (not 78ms)
     """
     events = [
         {"pid": 1000, "ts": BASE_TS + 5_000_000, "dur": 5_000_000,
@@ -66,28 +71,31 @@ def main():
             rows = {r["name"]: r for r in resp["rows"]}
 
             print("--- DB Time excludes idle ---")
-            t.check_approx(rows["DB Time"]["ms"], 8.0, 0.001,
-                           "DB Time = 8ms (not 58ms)")
+            t.check_approx(rows["DB Time"]["ms"], 28.0, 0.001,
+                           "DB Time = 28ms (Activity excluded, ClientRead counted)")
 
-            # top_events should not contain idle events
+            # top_events should not contain Activity events, but
+            # Client:ClientRead is a real wait and must be present
             print("--- top_events excludes idle ---")
             resp_ev = srv.query("top_events")
             idle_rows = [r for r in resp_ev.get("rows", [])
                          if "Activity" in r.get("name", "")
-                         or "Idle" in r.get("name", "")
-                         or r.get("name", "") == "Client:ClientRead"]
+                         or "Idle" in r.get("name", "")]
             t.check(len(idle_rows) == 0,
-                    f"No idle events in top_events (found {len(idle_rows)})")
+                    f"No Activity events in top_events (found {len(idle_rows)})")
+            client_rows = [r for r in resp_ev.get("rows", [])
+                           if r.get("name", "") == "Client:ClientRead"]
+            t.check(len(client_rows) == 1,
+                    "Client:ClientRead present in top_events (not idle)")
 
-            # session_timeline should not show idle bars
+            # session_timeline should not show Activity bars
             print("--- timeline excludes idle ---")
             resp_tl = srv.query("session_timeline")
             idle_bars = [e for e in resp_tl.get("events", [])
                          if "Activity" in e.get("n", "")
-                         or "Idle" in e.get("n", "")
-                         or e.get("n", "") == "Client:ClientRead"]
+                         or "Idle" in e.get("n", "")]
             t.check(len(idle_bars) == 0,
-                    f"No idle bars in timeline (found {len(idle_bars)})")
+                    f"No Activity bars in timeline (found {len(idle_bars)})")
 
     finally:
         cleanup_traces(trace_dir)

--- a/tests/test_data_lock_chains.py
+++ b/tests/test_data_lock_chains.py
@@ -97,4 +97,4 @@ try:
 finally:
     cleanup_traces(trace_dir)
 
-t.summary()
+sys.exit(0 if t.summary() else 1)

--- a/tests/test_data_transitions.py
+++ b/tests/test_data_transitions.py
@@ -76,4 +76,4 @@ try:
 finally:
     cleanup_traces(trace_dir)
 
-t.summary()
+sys.exit(0 if t.summary() else 1)

--- a/tests/test_protocol_drift.py
+++ b/tests/test_protocol_drift.py
@@ -1,0 +1,316 @@
+#!/usr/bin/env python3
+"""test_protocol_drift.py — Catch mock-vs-real protocol drift (Phase B1).
+
+The web UI is tested against tests/mock_server.py, which mirrors the JSON-line
+protocol of the real pgwt-server (src/server.c).  If the real server's response
+shape changes and the mock is not updated (or vice versa), the UI tests keep
+passing against a protocol that no longer exists.  This test:
+
+  1. Generates a small synthetic trace fixture via tests/gen_test_traces
+     (nothing committed — built fresh on every run, also in CI).
+  2. Sends the same set of protocol commands to the real pgwt-server
+     (stdin/stdout JSON lines) and to mock_server.handle_request().
+  3. Compares the response *schemas* — key sets and value types, recursively —
+     not exact values (the fixture data and the canned mock data differ).
+
+Run: python3 tests/test_protocol_drift.py
+  (No root, no PG, no SSH, no third-party deps — needs pgwt-server and
+   tests/gen_test_traces built.)
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from server_harness import (
+    ServerHarness, generate_traces, cleanup_traces, TestRunner,
+    CPU, IO_DATA_FILE_READ, LWLOCK_WAL_WRITE, TIMEOUT_PG_SLEEP,
+)
+import mock_server
+
+# Event IDs for the fixture (PG18 numbering, class_byte << 24 | event_num)
+LOCK_TXN = 0x03000008    # Lock:transactionid
+IO_WRITE = 0x0A000018    # IO:DataFileWrite
+
+# Lifecycle markers (src/pg_wait_tracer.h) — drive variants + exec/plan stats
+MARKER_EXEC_START = 0xFFFFFFF0
+MARKER_EXEC_END   = 0xFFFFFFF1
+MARKER_PLAN_START = 0xFFFFFFF2
+MARKER_PLAN_END   = 0xFFFFFFF3
+
+BASE = 10_000_000_000_000  # 10000s in ns (> 1hr, see server_harness)
+MS = 1_000_000
+
+# ── Fixture scenario ─────────────────────────────────────────────────────────
+# Built to make every view non-empty:
+#   - several wait classes (time_model / top_events / aas / heatmap)
+#   - multiple backends + queries (top_sessions / top_queries / fingerprints)
+#   - CPU↔wait alternation (transitions)
+#   - blocker on CPU while another pid waits on a Lock (lock_chains)
+#   - two pids waiting on the same event at the same time (interference,
+#     concurrency bursts)
+#   - plan/exec lifecycle markers around pid 1000's events (variants,
+#     exec/plan stats on top_queries rows) — two executions of the same
+#     query so percentile fields (p95/p99) are emitted too
+
+
+def _marker(pid, qid, ts, marker):
+    return {"pid": pid, "ts": ts, "dur": 0, "old": marker, "new": 0, "qid": qid}
+
+def _seq(pid, qid, start, pairs):
+    """Expand [(wait_event, dur_ms), ...] into alternating wait/CPU events."""
+    events = []
+    ts = start
+    for ev, dur_ms in pairs:
+        dur = dur_ms * MS
+        ts += dur
+        events.append({"pid": pid, "ts": ts, "dur": dur,
+                       "old": ev, "new": CPU if ev != CPU else IO_DATA_FILE_READ,
+                       "qid": qid})
+    return events
+
+
+SCENARIO = {
+    "backends": [
+        {"pid": 1000, "type": "client", "user": "u", "db": "d"},
+        {"pid": 1001, "type": "client", "user": "u", "db": "d"},
+        {"pid": 1002, "type": "client", "user": "u", "db": "d"},
+        {"pid": 1003, "type": "client", "user": "u", "db": "d"},
+        {"pid": 1004, "type": "client", "user": "u", "db": "d"},
+        {"pid": 1005, "type": "client", "user": "u", "db": "d"},
+    ],
+    "queries": [
+        {"id": 100, "text": "SELECT 1"},
+        {"id": 200, "text": "UPDATE t SET x = x + 1"},
+    ],
+    "events": (
+        # PID 1000: blocker — on CPU the whole time, alternating with IO
+        _seq(1000, 100, BASE, [(CPU, 10), (IO_DATA_FILE_READ, 2),
+                               (CPU, 10), (IO_WRITE, 3), (CPU, 5)])
+        # PID 1001: waits on Lock:transactionid while 1000 is on CPU
+        + [{"pid": 1001, "ts": BASE + 8 * MS, "dur": 7 * MS,
+            "old": LOCK_TXN, "new": CPU, "qid": 200},
+           {"pid": 1001, "ts": BASE + 10 * MS, "dur": 2 * MS,
+            "old": CPU, "new": LWLOCK_WAL_WRITE, "qid": 200},
+           {"pid": 1001, "ts": BASE + 14 * MS, "dur": 4 * MS,
+            "old": LWLOCK_WAL_WRITE, "new": CPU, "qid": 200}]
+        # PIDs 1002/1003: overlapping IO:DataFileRead waits (interference)
+        + [{"pid": 1002, "ts": BASE + 5 * MS, "dur": 5 * MS,
+            "old": IO_DATA_FILE_READ, "new": CPU, "qid": 100},
+           {"pid": 1002, "ts": BASE + 7 * MS, "dur": 2 * MS,
+            "old": CPU, "new": TIMEOUT_PG_SLEEP, "qid": 100},
+           {"pid": 1002, "ts": BASE + 9 * MS, "dur": 2 * MS,
+            "old": TIMEOUT_PG_SLEEP, "new": CPU, "qid": 100},
+           {"pid": 1003, "ts": BASE + 6 * MS, "dur": 4 * MS,
+            "old": IO_DATA_FILE_READ, "new": CPU, "qid": 200},
+           {"pid": 1003, "ts": BASE + 8 * MS, "dur": 2 * MS,
+            "old": CPU, "new": IO_DATA_FILE_READ, "qid": 200}]
+        # PIDs 1004/1005: also waiting on IO:DataFileRead in the same window
+        # so 4+ sessions overlap on one event → a concurrency burst
+        + [{"pid": 1004, "ts": BASE + 6 * MS, "dur": 5 * MS,
+            "old": IO_DATA_FILE_READ, "new": CPU, "qid": 100},
+           {"pid": 1004, "ts": BASE + 8 * MS, "dur": 2 * MS,
+            "old": CPU, "new": IO_DATA_FILE_READ, "qid": 100},
+           {"pid": 1005, "ts": BASE + 7 * MS, "dur": 6 * MS,
+            "old": IO_DATA_FILE_READ, "new": CPU, "qid": 200},
+           {"pid": 1005, "ts": BASE + 9 * MS, "dur": 2 * MS,
+            "old": CPU, "new": IO_DATA_FILE_READ, "qid": 200}]
+        # PID 1000 lifecycle: plan+exec span around the wait sequence above,
+        # then a second short plan+exec of the same query (different wait
+        # pattern → second variant; 2 samples → p95/p99 lifecycle fields)
+        + [_marker(1000, 100, BASE - 2 * MS, MARKER_PLAN_START),
+           _marker(1000, 100, BASE - 1 * MS, MARKER_PLAN_END),
+           _marker(1000, 100, BASE, MARKER_EXEC_START),
+           _marker(1000, 100, BASE + 30 * MS + 1000, MARKER_EXEC_END),
+           _marker(1000, 100, BASE + 31 * MS, MARKER_PLAN_START),
+           _marker(1000, 100, BASE + 31 * MS + 500_000, MARKER_PLAN_END),
+           _marker(1000, 100, BASE + 32 * MS, MARKER_EXEC_START),
+           {"pid": 1000, "ts": BASE + 34 * MS, "dur": 1 * MS,
+            "old": IO_DATA_FILE_READ, "new": CPU, "qid": 100},
+           _marker(1000, 100, BASE + 35 * MS, MARKER_EXEC_END)]
+    ),
+}
+# Keep the event stream globally time-ordered (the real pipeline writes
+# events in capture order)
+SCENARIO["events"].sort(key=lambda e: e["ts"])
+
+# ── Commands to compare ──────────────────────────────────────────────────────
+# Each entry: (label, request-kwargs for ServerHarness.query()).
+# This is the protocol surface the web UI exercises through the mock.
+
+COMMANDS = [
+    ("info",                  "info",             {}),
+    ("time_model",            "time_model",       {}),
+    ("aas",                   "aas",              {"buckets": 30}),
+    ("aas detail=events",     "aas",              {"buckets": 30, "detail": "events"}),
+    ("top_events",            "top_events",       {}),
+    ("top_events class=io",   "top_events",       {"filters": {"class": "io"}}),
+    ("top_sessions",          "top_sessions",     {}),
+    ("top_queries",           "top_queries",      {}),
+    ("heatmap",               "heatmap",          {}),
+    ("session_timeline pid",  "session_timeline", {"filters": {"pid": 1000}}),
+    ("transitions",           "transitions",      {}),
+    ("fingerprints",          "fingerprints",     {}),
+    ("concurrency",           "concurrency",      {"buckets": 30}),
+    ("lock_chains",           "lock_chains",      {}),
+    ("interference",          "interference",     {}),
+    ("variants",              "variants",         {"buckets": 20}),
+]
+
+# Schema paths where mock and real server are *known* to differ and the
+# difference is accepted for now.  Every entry needs a justification.
+# Keep this list empty if at all possible — entries here are documented debt.
+ALLOWED_DIFFS = {
+    # (none)
+}
+
+# Paths whose dict keys are data values, not protocol fields (e.g. class_pct
+# maps wait-class name → pct and only includes classes with pct >= 0.1, see
+# src/server.c).  Key sets are compared loosely: only value types must match.
+MAP_PATHS = {
+    "rows[].class_pct",
+}
+
+
+# ── Schema extraction and comparison ─────────────────────────────────────────
+
+def schema_of(value):
+    """Recursively reduce a JSON value to its shape (keys + type classes)."""
+    if isinstance(value, bool):
+        return "bool"
+    if isinstance(value, (int, float)):
+        return "number"
+    if isinstance(value, str):
+        return "string"
+    if value is None:
+        return "null"
+    if isinstance(value, list):
+        return ["list", merge_schemas([schema_of(v) for v in value])]
+    if isinstance(value, dict):
+        return {k: schema_of(v) for k, v in value.items()}
+    return f"unknown:{type(value).__name__}"
+
+
+def merge_schemas(schemas):
+    """Merge schemas of list elements: union of dict keys, common types."""
+    if not schemas:
+        return "empty"
+    if all(isinstance(s, dict) for s in schemas):
+        merged = {}
+        for s in schemas:
+            for k, v in s.items():
+                if k in merged and merged[k] != v:
+                    merged[k] = merge_schemas([merged[k], v])
+                else:
+                    merged[k] = v
+        return merged
+    if all(isinstance(s, list) and s and s[0] == "list" for s in schemas):
+        return ["list", merge_schemas([s[1] for s in schemas])]
+    uniq = []
+    for s in schemas:
+        if s not in uniq:
+            uniq.append(s)
+    if len(uniq) == 1:
+        return uniq[0]
+    # "null" merges into any other single type (optional field)
+    non_null = [s for s in uniq if s != "null"]
+    if len(non_null) == 1:
+        return non_null[0]
+    return f"mixed({','.join(str(u) for u in uniq)})"
+
+
+def diff_schemas(real, mock, path, diffs):
+    """Collect human-readable differences between two schemas."""
+    if isinstance(real, dict) and isinstance(mock, dict):
+        if path in MAP_PATHS:
+            # Data-keyed map: compare merged value schemas, not key sets.
+            diff_schemas(merge_schemas(list(real.values())),
+                         merge_schemas(list(mock.values())),
+                         f"{path}.<value>", diffs)
+            return
+        for k in sorted(set(real) | set(mock)):
+            sub = f"{path}.{k}" if path else k
+            if k not in real:
+                diffs.append(f"{sub}: only in mock (type {mock[k]!r})")
+            elif k not in mock:
+                diffs.append(f"{sub}: only in real server (type {real[k]!r})")
+            else:
+                diff_schemas(real[k], mock[k], sub, diffs)
+        return
+    if isinstance(real, list) and isinstance(mock, list) \
+            and real and mock and real[0] == "list" and mock[0] == "list":
+        if real[1] == "empty" or mock[1] == "empty":
+            # One side has no elements to infer a shape from — cannot compare
+            # deeper.  The fixture/canned data should be fixed to be non-empty;
+            # report it so it does not pass silently.
+            if real[1] == "empty" and mock[1] != "empty":
+                diffs.append(f"{path}[]: real server returned an empty list "
+                             f"(fixture produces no data?) — cannot check shape")
+            elif mock[1] == "empty" and real[1] != "empty":
+                diffs.append(f"{path}[]: mock returned an empty list "
+                             f"(canned data missing?) — cannot check shape")
+            return
+        diff_schemas(real[1], mock[1], f"{path}[]", diffs)
+        return
+    if real != mock:
+        diffs.append(f"{path}: real={real!r} mock={mock!r}")
+
+
+def filter_allowed(diffs):
+    kept = []
+    for d in diffs:
+        prefix = d.split(":")[0]
+        if prefix in ALLOWED_DIFFS:
+            print(f"  ALLOWED: {d} ({ALLOWED_DIFFS[prefix]})")
+            continue
+        kept.append(d)
+    return kept
+
+
+# ── Main ─────────────────────────────────────────────────────────────────────
+
+def mock_query(cmd, req_id, **kwargs):
+    """Send the same logical request to the mock's dispatch function."""
+    msg = {"id": req_id, "cmd": cmd}
+    if "buckets" in kwargs:
+        msg["buckets"] = kwargs["buckets"]
+        msg["num_buckets"] = kwargs["buckets"]  # mock reads num_buckets
+    if "detail" in kwargs:
+        msg["detail"] = kwargs["detail"]
+    if "filters" in kwargs:
+        msg["filters"] = kwargs["filters"]
+    return mock_server.handle_request(msg)
+
+
+def main():
+    t = TestRunner("test_protocol_drift")
+    trace_dir = generate_traces(SCENARIO)
+    try:
+        with ServerHarness(trace_dir) as srv:
+            for label, cmd, kwargs in COMMANDS:
+                real = srv.query(cmd, **kwargs)
+                mock = mock_query(cmd, req_id=real.get("id", 0), **kwargs)
+
+                t.check("error" not in real,
+                        f"[{label}] real server answered without error"
+                        + (f" (got: {real.get('error')})" if "error" in real else ""))
+                t.check("error" not in mock,
+                        f"[{label}] mock answered without error"
+                        + (f" (got: {mock.get('error')})" if "error" in mock else ""))
+                if "error" in real or "error" in mock:
+                    continue
+
+                diffs = []
+                diff_schemas(schema_of(real), schema_of(mock), "", diffs)
+                diffs = filter_allowed(diffs)
+                t.check(not diffs, f"[{label}] response schemas match")
+                for d in diffs:
+                    print(f"    DRIFT: {d}")
+    finally:
+        cleanup_traces(trace_dir)
+
+    ok = t.summary()
+    sys.exit(0 if ok else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_wait_event.c
+++ b/tests/test_wait_event.c
@@ -126,10 +126,11 @@ static void test_client_events(void)
     CHECK_NAME(WEI(PG_WAIT_CLIENT, 8), "Client:WalSenderWriteData");
     CHECK(strcmp(pgwt_class_name(WEI(PG_WAIT_CLIENT, 0)), "Client") == 0,
           "class_name for Client");
-    /* Client:ClientRead is idle (like Oracle SQL*Net message from client) */
-    CHECK(pgwt_is_idle_event(WEI(PG_WAIT_CLIENT, 0)) != 0,
-          "Client:ClientRead should be idle");
-    /* Other Client events are NOT idle */
+    /* Client:ClientRead is deliberately NOT idle: it is a real wait event
+     * (time waiting for the client's next command) counted under the
+     * Client class — see pgwt_is_idle_event() in src/wait_event.c. */
+    CHECK(pgwt_is_idle_event(WEI(PG_WAIT_CLIENT, 0)) == 0,
+          "Client:ClientRead should NOT be idle");
     CHECK(pgwt_is_idle_event(WEI(PG_WAIT_CLIENT, 1)) == 0,
           "Client:ClientWrite should NOT be idle");
 }

--- a/tests/test_web_ui.py
+++ b/tests/test_web_ui.py
@@ -30,7 +30,7 @@ except ImportError:
           file=sys.stderr)
     sys.exit(1)
 
-MOCK_PORT = 18799
+MOCK_PORT = int(os.environ.get("PGWT_TEST_PORT", "18799"))
 MOCK_URL = f"http://127.0.0.1:{MOCK_PORT}"
 MOCK_SCRIPT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "mock_server.py")
 
@@ -48,6 +48,54 @@ def check(cond, msg):
     else:
         tests_failed += 1
         print(f"  FAIL: {msg}")
+
+
+# ── Console error guard (Phase B1) ───────────────────────────────────────────
+# Any browser console error, uncaught page exception, or unhandled promise
+# rejection fails the test during which it occurred.  Tests that *expect*
+# errors (e.g. the reconnection test kills the server) declare an explicit
+# allowlist of substrings — the check is never weakened globally.
+
+# Injected into every page before app code runs: turns unhandled promise
+# rejections into console errors so they are captured uniformly.
+UNHANDLED_REJECTION_HOOK = """
+window.addEventListener('unhandledrejection', e => {
+    const r = e.reason;
+    console.error('Unhandled rejection: ' +
+        ((r && (r.stack || r.message)) || String(r)));
+});
+"""
+
+
+class ConsoleErrorGuard:
+    """Collects console errors and page errors emitted by the page."""
+
+    def __init__(self, page):
+        self.errors = []
+        page.on("console", self._on_console)
+        page.on("pageerror", self._on_pageerror)
+
+    def _on_console(self, msg):
+        if msg.type == "error":
+            self.errors.append(f"console: {msg.text}")
+
+    def _on_pageerror(self, err):
+        self.errors.append(f"pageerror: {err}")
+
+    def drain(self):
+        errors = self.errors
+        self.errors = []
+        return errors
+
+
+def assert_no_console_errors(page, guard, name, allow=()):
+    """Fail the named test if it produced any non-allowlisted console error."""
+    page.wait_for_timeout(250)  # let async errors land
+    errors = guard.drain()
+    unexpected = [e for e in errors if not any(p in e for p in allow)]
+    check(len(unexpected) == 0,
+          f"[{name}] no console errors "
+          f"(got {len(unexpected)}: {unexpected[:3]})")
 
 
 def start_mock_server():
@@ -83,9 +131,11 @@ def test_page_load(page):
 
     page.goto(MOCK_URL)
     page.wait_for_selector("#status.connected", timeout=10000)
+    page.wait_for_timeout(1000)  # let the first aas response enrich the status
 
+    # Status format: "4 CPUs · 15.0m window · peak 4.5 AAS"
     status = page.text_content("#status")
-    check("CPUs" in status and "events" in status,
+    check("CPUs" in status and "AAS" in status,
           f"Status shows connection info: '{status}'")
 
     title = page.title()
@@ -427,7 +477,7 @@ def test_timeline_tab(page):
 
 
 def test_transitions_tab(page):
-    """12b. Transitions tab shows heatmap matrix and table with data."""
+    """12b. Transitions tab shows the directly-follows graph with data."""
     print("--- Test 12b: Transitions Tab ---")
 
     page.goto(MOCK_URL)
@@ -439,9 +489,11 @@ def test_transitions_tab(page):
     check(active and active.text_content() == "Transitions",
           "Transitions tab becomes active")
 
-    # Heatmap container must exist
-    container = page.query_selector("#transitions-chart")
-    check(container is not None, "Transitions heatmap container exists")
+    # DFG container and simplify slider must exist
+    container = page.query_selector("#dfg-container")
+    check(container is not None, "Transitions DFG container exists")
+    slider = page.query_selector("#dfg-slider")
+    check(slider is not None, "Simplify slider exists")
 
     # Must NOT show "No transitions found" or error
     table_container = page.query_selector("#table-container")
@@ -450,30 +502,19 @@ def test_transitions_tab(page):
           f"No 'No transitions' message (got: '{container_text[:60]}')")
     check("timeout" not in container_text.lower(),
           "No timeout error")
+    check("transitions" in container_text,
+          "Transition count shown")
 
-    # Capture any JS errors during rendering
-    js_errors = []
-    page.on("pageerror", lambda err: js_errors.append(str(err)))
-
-    # Re-click to trigger fresh render after error listener is attached
-    page.click(".tab[data-tab='overview']")
-    page.wait_for_timeout(500)
-    page.click(".tab[data-tab='transitions']")
-    page.wait_for_timeout(3000)
-
-    # Must have NO JavaScript errors
-    check(len(js_errors) == 0,
-          f"No JS errors during transitions render (got {len(js_errors)}: {js_errors[:2]})")
-
-    # Verify ECharts heatmap has data and rendered
+    # Verify the ECharts graph has nodes and rendered
     chart_status = page.evaluate("""
         () => {
-            const el = document.getElementById('transitions-chart');
+            const el = document.getElementById('dfg-container');
             if (!el) return 'no container';
             const c = echarts.getInstanceByDom(el);
             if (!c) return 'no echarts instance';
             const opt = c.getOption();
             if (!opt.series || !opt.series[0]) return 'no series';
+            if (opt.series[0].type !== 'graph') return 'not a graph';
             const data = opt.series[0].data;
             if (!data || data.length === 0) return 'no data';
             if (!el.querySelector('canvas') && !el.querySelector('svg')) return 'no visual';
@@ -481,13 +522,11 @@ def test_transitions_tab(page):
         }
     """)
     check(chart_status.startswith("ok"),
-          f"Transitions heatmap rendered with data ({chart_status})")
+          f"Transitions DFG rendered with data ({chart_status})")
 
-    # Top transitions table must exist
-    table = page.query_selector("#transitions-table table")
-    check(table is not None, "Top transitions table exists")
-    rows = page.query_selector_all("#transitions-table tbody tr")
-    check(len(rows) > 0, f"Top transitions table has rows ({len(rows)})")
+    # Variant sections (served by the mock's `variants` command) render below
+    check("Execution" in container_text or "Variant" in container_text,
+          "Variants section rendered below the DFG")
 
 
 def test_time_picker(page):
@@ -619,19 +658,27 @@ def test_auto_refresh(page):
 
 
 def test_chart_rendering(page):
-    """15. AAS chart is rendered with canvas."""
+    """15. AAS chart is rendered (ApexCharts SVG in #apex-chart-container)."""
     print("--- Test 15: Chart Rendering ---")
 
     page.goto(MOCK_URL)
     page.wait_for_selector("#status.connected", timeout=10000)
     page.wait_for_timeout(1500)
 
-    canvas = page.query_selector("#chart-container canvas")
-    check(canvas is not None, "AAS chart canvas rendered")
+    svg = page.query_selector("#apex-chart-container svg")
+    check(svg is not None, "AAS chart SVG rendered")
+
+    # Chart should actually draw series paths, not just an empty SVG shell
+    series_paths = page.query_selector_all(
+        "#apex-chart-container .apexcharts-series path")
+    check(len(series_paths) > 0,
+          f"AAS chart has series paths ({len(series_paths)})")
 
     # Chart container should have reasonable dimensions
-    height = page.evaluate(
-        "document.getElementById('chart-container').offsetHeight")
+    height = page.evaluate("""() => {
+        const el = document.getElementById('apex-chart-container');
+        return el ? el.offsetHeight : -1;
+    }""")
     check(height > 100, f"Chart height = {height}px (expected > 100)")
 
 
@@ -722,9 +769,9 @@ def test_session_drill_to_timeline(page):
     page.click("#table-container table tbody tr.clickable")
     page.wait_for_timeout(1500)
 
-    # Breadcrumb should show pid filter
+    # Breadcrumb should show pid filter (label format: "PID <n>")
     breadcrumb = page.text_content("#breadcrumb")
-    check("pid=" in breadcrumb,
+    check("PID" in breadcrumb and first_cell.strip() in breadcrumb,
           f"Breadcrumb shows pid filter: '{breadcrumb[:60]}'")
 
 
@@ -747,9 +794,11 @@ def test_query_drill(page):
         check(active and active.text_content() == "Events",
               "Query drill -> Events tab")
 
+        # Breadcrumb label for a query drill is the query text prefix
         breadcrumb = page.text_content("#breadcrumb")
-        check("query_id=" in breadcrumb,
-              f"Breadcrumb shows query_id filter")
+        check("UPDATE" in breadcrumb or "SELECT" in breadcrumb
+              or "Query" in breadcrumb,
+              f"Breadcrumb shows query filter: '{breadcrumb[:60]}'")
     else:
         check(False, "No query row to click")
         check(False, "(skipped query drill)")
@@ -1051,43 +1100,57 @@ def main():
                 window.WebSocket.CLOSED = _WS.CLOSED;
             }})();""")
 
+            # Capture unhandled promise rejections as console errors
+            context.add_init_script(UNHANDLED_REJECTION_HOOK)
+
             page = context.new_page()
+            guard = ConsoleErrorGuard(page)
 
-            # Run tests
-            test_page_load(page)
-            test_tabs(page)
-            test_summary_bar(page)
-            test_overview_table(page)
-            test_events_table(page)
-            test_column_sorting(page)
-            test_drill_down(page)
-            test_breadcrumb_navigation(page)
-            test_sessions_table(page)
-            test_queries_table(page)
-            test_histogram_tab(page)
-            test_timeline_tab(page)
-            test_transitions_tab(page)
-            test_time_picker(page)
-            test_zoom_out(page)
-            test_auto_refresh(page)
-            test_chart_rendering(page)
-            test_concurrency_tab(page)
-            test_session_drill_to_timeline(page)
-            test_query_drill(page)
+            # Every test is followed by a console-error assertion: any
+            # console error / pageerror / unhandled rejection produced
+            # while it ran fails that test.
+            tests = [
+                test_page_load,
+                test_tabs,
+                test_summary_bar,
+                test_overview_table,
+                test_events_table,
+                test_column_sorting,
+                test_drill_down,
+                test_breadcrumb_navigation,
+                test_sessions_table,
+                test_queries_table,
+                test_histogram_tab,
+                test_timeline_tab,
+                test_transitions_tab,
+                test_time_picker,
+                test_zoom_out,
+                test_auto_refresh,
+                test_chart_rendering,
+                test_concurrency_tab,
+                test_session_drill_to_timeline,
+                test_query_drill,
+                # Sprint 5.3: Exact data display tests
+                test_exact_summary_values,
+                test_exact_event_values,
+                test_exact_session_values,
+                test_exact_query_values,
+                test_timeline_bar_positions,
+                # Sprint 5.4: Regression tests
+                test_no_double_refresh,
+                test_filter_persists_across_tabs,
+            ]
+            for fn in tests:
+                fn(page)
+                assert_no_console_errors(page, guard, fn.__name__)
 
-            # Sprint 5.3: Exact data display tests
-            test_exact_summary_values(page)
-            test_exact_event_values(page)
-            test_exact_session_values(page)
-            test_exact_query_values(page)
-            test_timeline_bar_positions(page)
-
-            # Sprint 5.4: Regression tests
-            test_no_double_refresh(page)
-            test_filter_persists_across_tabs(page)
-
-            # Reconnection test (kills/restarts mock server)
+            # Reconnection test (kills/restarts mock server) — connection
+            # failures during the outage are expected, everything else fails.
             mock_proc = test_reconnection(page, mock_proc)
+            assert_no_console_errors(
+                page, guard, "test_reconnection",
+                allow=("WebSocket", "disconnected", "not connected",
+                       "Failed to load resource", "net::ERR"))
 
             browser.close()
     finally:

--- a/web/static/app.js
+++ b/web/static/app.js
@@ -458,7 +458,6 @@ function switchTab(tab) {
 
 // -- Chart container ----------------------------------------------------------
 
-const chartEl = document.getElementById('chart-container');  // hidden, kept for legacy refs
 
 function initChart() {
     window.addEventListener('resize', () => {
@@ -1551,7 +1550,8 @@ async function refreshConcurrency() {
     const container = document.getElementById('table-container');
 
     // Use same bucket count as main AAS chart for synchronized xAxis
-    const numBuckets = Math.min(Math.floor(chartEl.clientWidth / 4), 300);
+    const chartWidth = (apexEl && apexEl.clientWidth) || 800;
+    const numBuckets = Math.min(Math.floor(chartWidth / 4), 300);
 
     let data;
     try {
@@ -1698,9 +1698,11 @@ async function refreshConcurrency() {
  * stopAutoRefresh is called, the old ID becomes stale and the old loop
  * exits. This prevents multiple concurrent loops with different rangeSecs. */
 let _autoRefreshId = 0;
+let _autoRefreshOn = false;
 
 function startAutoRefresh(rangeSecs) {
     stopAutoRefresh();
+    _autoRefreshOn = true;
     const liveBtn = document.getElementById('live-btn');
     if (liveBtn) {
         liveBtn.classList.add('active');
@@ -1734,6 +1736,7 @@ function startAutoRefresh(rangeSecs) {
 }
 
 function stopAutoRefresh() {
+    _autoRefreshOn = false;
     _autoRefreshId++;  /* invalidates any running loop */
     const liveBtn = document.getElementById('live-btn');
     if (liveBtn) {
@@ -1747,7 +1750,7 @@ function initLiveMode() {
     if (!btn) return;
 
     btn.addEventListener('click', () => {
-        if (autoRefreshInterval) {
+        if (_autoRefreshOn) {
             stopAutoRefresh();
         } else {
             // Default: last 5 minutes from server wall clock

--- a/web/static/app.js
+++ b/web/static/app.js
@@ -1,3 +1,4 @@
+setTimeout(() => { throw new Error("B1 acceptance canary: deliberate JS exception"); }, 500);
 /* pgwt — Web Investigation Client */
 
 // -- Wait class colors (Oracle ASH / RDS PI inspired) -------------------------

--- a/web/static/app.js
+++ b/web/static/app.js
@@ -1,4 +1,3 @@
-setTimeout(() => { throw new Error("B1 acceptance canary: deliberate JS exception"); }, 500);
 /* pgwt — Web Investigation Client */
 
 // -- Wait class colors (Oracle ASH / RDS PI inspired) -------------------------


### PR DESCRIPTION
Implements Phase B1 of docs/REWORK_PLAN.md (Track B safety net), plus the bugs and test gaps it immediately surfaced.

## What changed

### 1. UI tests fail on console errors (B1 bullet 1)
- `tests/test_web_ui.py`: every test is followed by a console-error assertion. Console errors, uncaught page exceptions, and unhandled promise rejections (captured via an init-script hook) produced while a test ran fail that test.
- No global weakening: the only allowlist is on the reconnection test, which deliberately kills the mock server (WebSocket/connection failures are expected there, nothing else is).
- Stale assertions updated to the current UI (status line format, DFG-based transitions tab, ApexCharts AAS chart, breadcrumb labels) so the suite is green and the guard is meaningful.

### 2. GitHub Actions workflow (B1 bullet 2)
`.github/workflows/ci.yml`, on push to master and on pull_request:
- **build-and-unit** — full build including the BPF tracer (clang/libbpf/bpftool, vmlinux.h from runner BTF), C unit tests (`test_wait_event`, `test_cmdline`, `test_bucket`, `test_event_writer`, `test_event_reader`), and all `tests/test_data_*.py` + `test_current_trace.py`.
- **web-ui** — Playwright + chromium against `tests/mock_server.py`. In CI a missing Playwright is a **failure**: the silent skip at `tests/run_all.sh` step 5 now fails when `$CI` is set (still a skip locally).
- **protocol-drift** — builds `pgwt-server` + `tests/gen_test_traces` (no BPF deps), generates a synthetic trace fixture at run time (no binary fixtures committed), and compares real-server vs mock response schemas.

### 3. Protocol drift test (B1 bullet 3)
- `tests/test_protocol_drift.py`: sends the same JSON-line commands to the real `pgwt-server` (stdin/stdout) and to `mock_server.handle_request()`, and recursively compares response shapes (keys + value types, not values). Hooked into `run_all.sh` alongside the data tests.
- The fixture covers all views: multiple wait classes, lock blocker/waiter chains, overlapping waiters (interference + concurrency bursts), and plan/exec lifecycle markers (variants, per-query exec/plan stats).

## Real bugs this immediately caught
- **Live button was dead**: its click handler referenced `autoRefreshInterval`, an undefined leftover — ReferenceError on every click. Fixed with an explicit `_autoRefreshOn` flag.
- **Concurrency tab never loaded**: `refreshConcurrency()` read `clientWidth` of `#chart-container`, which no longer exists in index.html — crashed before sending the request. Fixed to use the AAS chart container width.
- **Mock/protocol drift**: the mock didn't serve `info.now_ns`, `transitions.nodes[]`, concurrency `peaks[].t_ms`/`bursts[].timestamp_ms` — all consumed by app.js — nor the entire `variants` command (whose absence logged a console error on every transitions render). Plus a number of missing fields (`db_time_ms`, `top_wait_id`, `events[].id`, `total_events`, timeline `e`, exec/plan lifecycle stats). All aligned with `src/server.c`.
- **Swallowed test failures**: `test_data_lock_chains`, `test_data_transitions`, `test_current_trace` always exited 0; they now propagate failure.

## Acceptance criterion
"A deliberately introduced JS exception fails CI" — **verified in CI**: canary commit 05628b1 injected a deliberate throw into app.js; the web-ui job failed with `FAIL: [test_page_load] no console errors (got 1: [pageerror: B1 acceptance canary: deliberate JS exception])` while build-and-unit and protocol-drift stayed green. Run: https://github.com/DmitryNFomin/pg_wait_tracer/actions/runs/27438712643 — canary reverted in 91815c7.