### PR TITLE
A0: daemon control socket + self-metrics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ LDFLAGS    = -lbpf -lelf -lz -llz4
 
 USER_SRCS  = $(SRC_DIR)/pg_wait_tracer.c \
              $(SRC_DIR)/daemon.c \
+             $(SRC_DIR)/control.c \
              $(SRC_DIR)/backend.c \
              $(SRC_DIR)/discovery.c \
              $(SRC_DIR)/map_reader.c \

--- a/src/backend.c
+++ b/src/backend.c
@@ -126,6 +126,7 @@ int pgwt_scan_existing_backends(struct pgwt_daemon *d)
         be->wp_fd = pgwt_open_watchpoint(pid, ptr, wp_prog_fd);
         if (be->wp_fd < 0) {
             /* Silently skip — process likely exited before attach */
+            d->counters.wp_attach_failures_total++;
             be->is_alive = false;
             be->pid = 0;
             continue;
@@ -209,6 +210,7 @@ int pgwt_handle_fork(struct pgwt_daemon *d, pid_t child_pid)
             return pgwt_handle_init(d, child_pid, ptr);
         }
         /* Silently skip — process exited before bootstrap attach */
+        d->counters.wp_attach_failures_total++;
         be->is_alive = false;
         be->pid = 0;
         return -1;
@@ -247,6 +249,7 @@ int pgwt_handle_init(struct pgwt_daemon *d, pid_t pid, uint64_t addr)
     be->wp_fd = pgwt_open_watchpoint(pid, addr, wp_prog_fd);
     if (be->wp_fd < 0) {
         /* Silently skip — process likely exited before attach */
+        d->counters.wp_attach_failures_total++;
         be->is_alive = false;
         be->pid = 0;
         return -1;

--- a/src/control.c
+++ b/src/control.c
@@ -1,0 +1,348 @@
+/* control.c — Daemon control socket: unix socket + JSON-line protocol */
+#define _GNU_SOURCE   /* accept4 */
+#include "control.h"
+#include "daemon.h"
+#include "event_writer.h"
+#include "cJSON.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <errno.h>
+#include <time.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <sys/stat.h>
+#include <sys/epoll.h>
+
+/* ── Helpers ──────────────────────────────────────────────── */
+
+static uint64_t now_mono_ns(void)
+{
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return (uint64_t)ts.tv_sec * 1000000000ULL + ts.tv_nsec;
+}
+
+/* Add uint64 as raw JSON number (avoids double precision loss) */
+static void cjson_add_uint64(cJSON *obj, const char *name, uint64_t val)
+{
+    char buf[32];
+    snprintf(buf, sizeof(buf), "%llu", (unsigned long long)val);
+    cJSON_AddRawToObject(obj, name, buf);
+}
+
+/* Count live tracked backends */
+static int count_backends(const struct pgwt_daemon *d)
+{
+    int n = 0;
+    for (int i = 0; i < d->backends.count; i++)
+        if (d->backends.entries[i].is_alive)
+            n++;
+    return n;
+}
+
+/* ── Response builders ────────────────────────────────────── */
+
+static cJSON *build_status(const struct pgwt_daemon *d)
+{
+    cJSON *root = cJSON_CreateObject();
+    cJSON_AddBoolToObject(root, "ok", 1);
+    /* Capture tier: "full" today; A2/A4 add sampled/tiered modes.
+     * --lightweight is reported as its own mode so the answer is
+     * never a lie about what is being captured. */
+    cJSON_AddStringToObject(root, "mode",
+                            d->lightweight_mode ? "lightweight" : "full");
+    cJSON_AddNumberToObject(root, "uptime_s",
+                            (double)(now_mono_ns() - d->start_ts) / 1e9);
+    cJSON_AddNumberToObject(root, "backends", count_backends(d));
+    cJSON_AddNumberToObject(root, "pg_pid", d->postmaster_pid);
+    cJSON_AddStringToObject(root, "version", PGWT_VERSION);
+    return root;
+}
+
+static cJSON *build_metrics(const struct pgwt_daemon *d)
+{
+    const struct pgwt_counters *ctr = &d->counters;
+
+    cJSON *root = cJSON_CreateObject();
+    cJSON_AddBoolToObject(root, "ok", 1);
+    cJSON_AddNumberToObject(root, "uptime_s",
+                            (double)(now_mono_ns() - d->start_ts) / 1e9);
+
+    /* Event path counters (incremented in event_stream.c / daemon.c) */
+    cjson_add_uint64(root, "events_total", ctr->events_total);
+    cJSON_AddNumberToObject(root, "events_per_sec", ctr->events_per_sec);
+    cjson_add_uint64(root, "lifecycle_events_total",
+                     ctr->lifecycle_events_total);
+
+    /* Watchpoint attach failures (incremented in backend.c) */
+    cjson_add_uint64(root, "wp_attach_failures_total",
+                     ctr->wp_attach_failures_total);
+
+    cJSON_AddNumberToObject(root, "backends_tracked", count_backends(d));
+
+    /* Trace writer stats (0 when recording is disabled) */
+    cjson_add_uint64(root, "trace_events_written_total",
+                     d->event_writer ? d->event_writer->total_events_written : 0);
+    cjson_add_uint64(root, "trace_bytes_written_total",
+                     d->event_writer ? d->event_writer->total_bytes_written : 0);
+
+    return root;
+}
+
+static cJSON *build_error(const char *msg)
+{
+    cJSON *root = cJSON_CreateObject();
+    cJSON_AddBoolToObject(root, "ok", 0);
+    cJSON_AddStringToObject(root, "error", msg);
+    return root;
+}
+
+/* ── Client handling ──────────────────────────────────────── */
+
+static void client_drop(struct pgwt_control *c, struct pgwt_control_client *cl)
+{
+    if (cl->fd < 0)
+        return;
+    epoll_ctl(c->epoll_fd, EPOLL_CTL_DEL, cl->fd, NULL);
+    close(cl->fd);
+    cl->fd = -1;
+    cl->len = 0;
+}
+
+/* Send one JSON object + '\n'. Returns 0 on success, -1 on failure
+ * (caller drops the client). MSG_NOSIGNAL: a client that disconnects
+ * mid-response must not SIGPIPE the daemon. */
+static int client_send_json(struct pgwt_control_client *cl, cJSON *root)
+{
+    char *str = cJSON_PrintUnformatted(root);
+    cJSON_Delete(root);
+    if (!str)
+        return -1;
+
+    size_t len = strlen(str);
+    str[len] = '\n';  /* overwrite NUL — cJSON allocates len+1 */
+    size_t off = 0;
+    int rc = 0;
+    while (off < len + 1) {
+        ssize_t w = send(cl->fd, str + off, len + 1 - off, MSG_NOSIGNAL);
+        if (w < 0) {
+            if (errno == EINTR)
+                continue;
+            /* EAGAIN on a <4KB response means the client stopped
+             * reading — drop it rather than block the daemon. */
+            rc = -1;
+            break;
+        }
+        off += (size_t)w;
+    }
+    free(str);
+    return rc;
+}
+
+/* Handle one complete request line. Returns 0 on success, -1 if the
+ * client should be dropped (send failure). */
+static int handle_request(struct pgwt_control *c,
+                          struct pgwt_control_client *cl, const char *line)
+{
+    cJSON *req = cJSON_Parse(line);
+    if (!req)
+        return client_send_json(cl, build_error("invalid json"));
+
+    cJSON *cmd = cJSON_GetObjectItem(req, "cmd");
+    cJSON *resp;
+    if (!cJSON_IsString(cmd) || !cmd->valuestring)
+        resp = build_error("missing cmd");
+    else if (strcmp(cmd->valuestring, "status") == 0)
+        resp = build_status(c->d);
+    else if (strcmp(cmd->valuestring, "metrics") == 0)
+        resp = build_metrics(c->d);
+    else
+        resp = build_error("unknown command");
+
+    cJSON_Delete(req);
+    return client_send_json(cl, resp);
+}
+
+static void handle_client_readable(struct pgwt_control *c,
+                                   struct pgwt_control_client *cl)
+{
+    for (;;) {
+        if (cl->len >= sizeof(cl->buf) - 1) {
+            /* No newline within buffer — protocol violation */
+            client_send_json(cl, build_error("request too long"));
+            client_drop(c, cl);
+            return;
+        }
+
+        ssize_t r = read(cl->fd, cl->buf + cl->len,
+                         sizeof(cl->buf) - 1 - cl->len);
+        if (r == 0) {
+            /* Client disconnected (possibly mid-request) — discard */
+            client_drop(c, cl);
+            return;
+        }
+        if (r < 0) {
+            if (errno == EINTR)
+                continue;
+            if (errno == EAGAIN || errno == EWOULDBLOCK)
+                break;  /* drained */
+            client_drop(c, cl);
+            return;
+        }
+        cl->len += (size_t)r;
+
+        /* Process complete lines */
+        char *nl;
+        while ((nl = memchr(cl->buf, '\n', cl->len)) != NULL) {
+            *nl = '\0';
+            size_t line_len = (size_t)(nl - cl->buf) + 1;
+
+            if (cl->buf[0] != '\0' &&
+                handle_request(c, cl, cl->buf) != 0) {
+                client_drop(c, cl);
+                return;
+            }
+
+            memmove(cl->buf, cl->buf + line_len, cl->len - line_len);
+            cl->len -= line_len;
+        }
+    }
+}
+
+static void handle_accept(struct pgwt_control *c)
+{
+    for (;;) {
+        int fd = accept4(c->listen_fd, NULL, NULL,
+                         SOCK_NONBLOCK | SOCK_CLOEXEC);
+        if (fd < 0) {
+            if (errno == EINTR)
+                continue;
+            return;  /* EAGAIN: done; other errors: nothing to do */
+        }
+
+        struct pgwt_control_client *cl = NULL;
+        for (int i = 0; i < PGWT_CTRL_MAX_CLIENTS; i++) {
+            if (c->clients[i].fd < 0) {
+                cl = &c->clients[i];
+                break;
+            }
+        }
+        if (!cl) {
+            /* All slots busy — refuse politely */
+            const char *msg = "{\"ok\":false,\"error\":\"too many clients\"}\n";
+            send(fd, msg, strlen(msg), MSG_NOSIGNAL);
+            close(fd);
+            continue;
+        }
+
+        cl->fd = fd;
+        cl->len = 0;
+
+        struct epoll_event ev;
+        ev.events = EPOLLIN;
+        ev.data.fd = fd;
+        if (epoll_ctl(c->epoll_fd, EPOLL_CTL_ADD, fd, &ev) != 0) {
+            close(fd);
+            cl->fd = -1;
+        }
+    }
+}
+
+/* ── Public API ───────────────────────────────────────────── */
+
+int pgwt_control_init(struct pgwt_control *c, struct pgwt_daemon *d,
+                      int epoll_fd)
+{
+    memset(c, 0, sizeof(*c));
+    c->listen_fd = -1;
+    c->epoll_fd = epoll_fd;
+    c->d = d;
+    for (int i = 0; i < PGWT_CTRL_MAX_CLIENTS; i++)
+        c->clients[i].fd = -1;
+
+    int n = snprintf(c->sock_path, sizeof(c->sock_path), "%s/pgwt.sock",
+                     d->trace_dir);
+    struct sockaddr_un addr;
+    if (n < 0 || (size_t)n >= sizeof(addr.sun_path)) {
+        fprintf(stderr, "WARN: control socket path too long: %s/pgwt.sock\n",
+                d->trace_dir);
+        return -1;
+    }
+
+    /* Unlink stale socket from a previous (crashed) daemon */
+    unlink(c->sock_path);
+
+    int fd = socket(AF_UNIX, SOCK_STREAM | SOCK_NONBLOCK | SOCK_CLOEXEC, 0);
+    if (fd < 0) {
+        fprintf(stderr, "WARN: control socket: socket(): %s\n",
+                strerror(errno));
+        return -1;
+    }
+
+    memset(&addr, 0, sizeof(addr));
+    addr.sun_family = AF_UNIX;
+    memcpy(addr.sun_path, c->sock_path, (size_t)n + 1);
+
+    /* Mode 0600 from the moment of creation (no chmod window) */
+    mode_t old_umask = umask(0177);
+    int bind_rc = bind(fd, (struct sockaddr *)&addr, sizeof(addr));
+    umask(old_umask);
+    if (bind_rc != 0) {
+        fprintf(stderr, "WARN: control socket: bind(%s): %s\n",
+                c->sock_path, strerror(errno));
+        close(fd);
+        return -1;
+    }
+
+    if (listen(fd, 8) != 0) {
+        fprintf(stderr, "WARN: control socket: listen(%s): %s\n",
+                c->sock_path, strerror(errno));
+        close(fd);
+        unlink(c->sock_path);
+        return -1;
+    }
+
+    struct epoll_event ev;
+    ev.events = EPOLLIN;
+    ev.data.fd = fd;
+    if (epoll_ctl(epoll_fd, EPOLL_CTL_ADD, fd, &ev) != 0) {
+        fprintf(stderr, "WARN: control socket: epoll_ctl: %s\n",
+                strerror(errno));
+        close(fd);
+        unlink(c->sock_path);
+        return -1;
+    }
+
+    c->listen_fd = fd;
+    return 0;
+}
+
+int pgwt_control_handle_fd(struct pgwt_control *c, int fd)
+{
+    if (fd == c->listen_fd) {
+        handle_accept(c);
+        return 1;
+    }
+    for (int i = 0; i < PGWT_CTRL_MAX_CLIENTS; i++) {
+        if (c->clients[i].fd == fd) {
+            handle_client_readable(c, &c->clients[i]);
+            return 1;
+        }
+    }
+    return 0;
+}
+
+void pgwt_control_cleanup(struct pgwt_control *c)
+{
+    for (int i = 0; i < PGWT_CTRL_MAX_CLIENTS; i++)
+        client_drop(c, &c->clients[i]);
+    if (c->listen_fd >= 0) {
+        epoll_ctl(c->epoll_fd, EPOLL_CTL_DEL, c->listen_fd, NULL);
+        close(c->listen_fd);
+        c->listen_fd = -1;
+        unlink(c->sock_path);
+    }
+}

--- a/src/control.h
+++ b/src/control.h
@@ -1,0 +1,53 @@
+/* control.h — Daemon control socket: unix socket + JSON-line protocol
+ *
+ * Listens on {trace_dir}/pgwt.sock (mode 0600). One JSON object per
+ * line, request/response. Commands (Phase A0):
+ *   {"cmd":"status"}  → mode, uptime, backends tracked, pg_pid, version
+ *   {"cmd":"metrics"} → self-observability counters (stable snake_case
+ *                       names with units: *_total, *_per_sec, *_bytes —
+ *                       a future Prometheus exporter consumes these)
+ *
+ * Note on ringbuf drops: the BPF ringbuf does not expose a drop
+ * counter to userspace, and A0 makes no BPF changes. A2 (provider
+ * split) should add a BPF-side drop counter map; until then drop
+ * counts are not reported rather than reported as a misleading 0.
+ */
+#ifndef PGWT_CONTROL_H
+#define PGWT_CONTROL_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+struct pgwt_daemon;
+
+#define PGWT_CTRL_MAX_CLIENTS 16
+#define PGWT_CTRL_BUF_SIZE    4096
+
+/* Per-client connection state (line-buffered request parsing) */
+struct pgwt_control_client {
+    int    fd;                       /* -1 = free slot */
+    size_t len;                      /* bytes buffered (no '\n' yet) */
+    char   buf[PGWT_CTRL_BUF_SIZE];
+};
+
+struct pgwt_control {
+    int    listen_fd;
+    int    epoll_fd;                 /* daemon's epoll (not owned) */
+    char   sock_path[520];
+    struct pgwt_control_client clients[PGWT_CTRL_MAX_CLIENTS];
+    struct pgwt_daemon *d;           /* back-pointer for status/metrics */
+};
+
+/* Create {trace_dir}/pgwt.sock (mode 0600, stale socket unlinked) and
+ * register the listening fd with epoll_fd. Returns 0 on success. */
+int pgwt_control_init(struct pgwt_control *c, struct pgwt_daemon *d,
+                      int epoll_fd);
+
+/* Dispatch an epoll-ready fd. Returns 1 if the fd belongs to the
+ * control socket (listener or client) and was handled, 0 otherwise. */
+int pgwt_control_handle_fd(struct pgwt_control *c, int fd);
+
+/* Close all clients and the listener, unlink the socket. */
+void pgwt_control_cleanup(struct pgwt_control *c);
+
+#endif /* PGWT_CONTROL_H */

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -1,6 +1,7 @@
 /* daemon.c — Main event loop: epoll on ring buffer, timer, signals */
 #include "daemon.h"
 #include "backend.h"
+#include "control.h"
 #include "discovery.h"
 #include "event_stream.h"
 #include "event_writer.h"
@@ -30,6 +31,8 @@ static int handle_lifecycle_event(void *ctx, void *data, size_t data_sz)
     struct pgwt_lifecycle_event *ev = data;
 
     (void)data_sz;
+
+    d->counters.lifecycle_events_total++;
 
     switch (ev->type) {
     case PGWT_LIFECYCLE_FORK:
@@ -135,6 +138,14 @@ static void handle_timer(struct pgwt_daemon *d)
         pgwt_summary_check_rotation(d->summary_writer);
         if (d->tick > 0 && d->tick % 60 == 0)
             pgwt_summary_cleanup_old_files(d->summary_writer);
+    }
+
+    /* Refresh recent event rate for control-socket metrics */
+    if (d->interval > 0) {
+        d->counters.events_per_sec =
+            (double)(d->counters.events_total - d->counters.prev_events_total)
+            / d->interval;
+        d->counters.prev_events_total = d->counters.events_total;
     }
 
     d->tick++;
@@ -428,6 +439,21 @@ int pgwt_daemon_init(struct pgwt_daemon *d)
     d->start_ts = (uint64_t)ts.tv_sec * 1000000000ULL + ts.tv_nsec;
     d->running = true;
 
+    /* Control socket at {trace_dir}/pgwt.sock (D4).
+     * Failure is non-fatal: tracing must not depend on the control plane. */
+    if (d->trace_dir) {
+        d->control = calloc(1, sizeof(*d->control));
+        if (d->control) {
+            if (pgwt_control_init(d->control, d, d->epoll_fd) != 0) {
+                free(d->control);
+                d->control = NULL;
+            } else if (d->verbose) {
+                fprintf(stderr, "INFO: control socket: %s/pgwt.sock\n",
+                        d->trace_dir);
+            }
+        }
+    }
+
     if (!d->quiet)
         pgwt_print_header(d);
     return 0;
@@ -481,6 +507,8 @@ int pgwt_daemon_run(struct pgwt_daemon *d)
                 ring_buffer__consume(d->event_rb);
             } else if (events[i].data.fd == d->signal_fd) {
                 handle_signal(d);
+            } else if (d->control) {
+                pgwt_control_handle_fd(d->control, events[i].data.fd);
             }
         }
 
@@ -501,6 +529,11 @@ int pgwt_daemon_run(struct pgwt_daemon *d)
 
 void pgwt_daemon_cleanup(struct pgwt_daemon *d)
 {
+    if (d->control) {
+        pgwt_control_cleanup(d->control);
+        free(d->control);
+        d->control = NULL;
+    }
     if (d->backend_meta) {
         pgwt_bm_close(d->backend_meta);
         free(d->backend_meta);

--- a/src/daemon.h
+++ b/src/daemon.h
@@ -18,6 +18,18 @@
 /* Forward declaration for skeleton */
 struct pg_wait_tracer_bpf;
 struct ring_buffer;
+struct pgwt_control;
+
+/* Self-observability counters (D6). Plain uint64 increments on the
+ * single-threaded event path — exposed via the control socket
+ * (src/control.c) with stable snake_case metric names. */
+struct pgwt_counters {
+    uint64_t events_total;             /* trace events consumed from event_ringbuf */
+    uint64_t lifecycle_events_total;   /* fork/init/exit/query_text events */
+    uint64_t wp_attach_failures_total; /* watchpoint attach failures (incl. bootstrap) */
+    uint64_t prev_events_total;        /* events_total at previous timer tick */
+    double   events_per_sec;           /* recent rate, refreshed each tick */
+};
 
 /* View modes */
 enum pgwt_view {
@@ -106,6 +118,10 @@ struct pgwt_daemon {
 
     /* Event stream */
     struct pgwt_accumulator *event_accum;   /* heap-allocated, cumulative from events */
+
+    /* Control socket (D4) — created when trace_dir is set */
+    struct pgwt_control *control;           /* NULL if disabled/unavailable */
+    struct pgwt_counters counters;          /* self-observability (D6) */
 
     /* State */
     struct pgwt_backend_table backends;

--- a/src/event_stream.c
+++ b/src/event_stream.c
@@ -24,6 +24,8 @@ int pgwt_handle_trace_event(void *ctx, void *data, size_t data_sz)
 
     (void)data_sz;
 
+    d->counters.events_total++;
+
     /* Write to trace file if recording is enabled (including markers) */
     if (d->event_writer)
         pgwt_writer_push_event(d->event_writer, evt);

--- a/src/pg_wait_tracer.h
+++ b/src/pg_wait_tracer.h
@@ -12,6 +12,9 @@ typedef uint32_t u32;
 typedef uint64_t u64;
 #endif
 
+/* ── Version ──────────────────────────────────────────────── */
+#define PGWT_VERSION         "0.8.0"
+
 /* ── Histogram ────────────────────────────────────────────── */
 #define HISTOGRAM_BUCKETS    16
 /* Bucket boundaries in microseconds:

--- a/src/server.c
+++ b/src/server.c
@@ -17,7 +17,10 @@
 #include <unistd.h>
 #include <ctype.h>
 #include <time.h>
+#include <errno.h>
 #include <sys/stat.h>
+#include <sys/socket.h>
+#include <sys/un.h>
 
 /* ── Utility ──────────────────────────────────────────────── */
 
@@ -1818,7 +1821,127 @@ static void handle_variants(struct pgwt_server *srv, struct pgwt_request *req)
     emit_json(root);
 }
 
-static void dispatch(struct pgwt_server *srv, struct pgwt_request *req)
+/* ── Daemon control proxy ─────────────────────────────────── */
+
+/* Round-trip one JSON line to the daemon control socket at
+ * {trace_dir}/pgwt.sock. Returns 0 on success (resp filled, newline
+ * stripped), -1 if the socket does not exist (daemon not running),
+ * -2 on connect/IO errors. */
+static int control_roundtrip(const char *trace_dir, const char *req_line,
+                             char *resp, size_t resp_size)
+{
+    char sock_path[600];
+    snprintf(sock_path, sizeof(sock_path), "%s/pgwt.sock", trace_dir);
+
+    struct sockaddr_un addr;
+    memset(&addr, 0, sizeof(addr));
+    addr.sun_family = AF_UNIX;
+    if (strlen(sock_path) >= sizeof(addr.sun_path))
+        return -2;
+    strcpy(addr.sun_path, sock_path);
+
+    struct stat st;
+    if (stat(sock_path, &st) != 0)
+        return -1;  /* no socket — daemon not running */
+
+    int fd = socket(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0);
+    if (fd < 0)
+        return -2;
+
+    /* Bounded waits — a stuck daemon must not hang the server */
+    struct timeval tv = { .tv_sec = 3 };
+    setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+    setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(tv));
+
+    if (connect(fd, (struct sockaddr *)&addr, sizeof(addr)) != 0) {
+        close(fd);
+        /* Stale socket file with no listener == daemon not running */
+        return (errno == ECONNREFUSED) ? -1 : -2;
+    }
+
+    /* Send request + newline (MSG_NOSIGNAL: no SIGPIPE if daemon dies) */
+    size_t req_len = strlen(req_line);
+    if (send(fd, req_line, req_len, MSG_NOSIGNAL) != (ssize_t)req_len ||
+        send(fd, "\n", 1, MSG_NOSIGNAL) != 1) {
+        close(fd);
+        return -2;
+    }
+
+    /* Read one response line */
+    size_t off = 0;
+    while (off < resp_size - 1) {
+        ssize_t r = read(fd, resp + off, resp_size - 1 - off);
+        if (r <= 0)
+            break;
+        off += (size_t)r;
+        if (memchr(resp, '\n', off))
+            break;
+    }
+    close(fd);
+
+    resp[off] = '\0';
+    char *nl = strchr(resp, '\n');
+    if (!nl)
+        return -2;  /* truncated/empty response */
+    *nl = '\0';
+    return 0;
+}
+
+/* Proxy a control command to the daemon:
+ *   {"id":N,"cmd":"control","request":{"cmd":"status"}}
+ * → {"id":N,"response":<daemon reply>}
+ * or {"id":N,"error":"daemon not running"} when the socket is absent. */
+static void handle_control(struct pgwt_server *srv, struct pgwt_request *req,
+                           const char *line)
+{
+    cJSON *root = cJSON_CreateObject();
+    cJSON_AddNumberToObject(root, "id", (double)req->id);
+
+    cJSON *outer = cJSON_Parse(line);
+    cJSON *inner = outer ? cJSON_GetObjectItem(outer, "request") : NULL;
+    if (!cJSON_IsObject(inner)) {
+        cJSON_AddStringToObject(root, "error", "missing request object");
+        cJSON_Delete(outer);
+        emit_json(root);
+        return;
+    }
+
+    char *inner_str = cJSON_PrintUnformatted(inner);
+    cJSON_Delete(outer);
+    if (!inner_str) {
+        cJSON_AddStringToObject(root, "error", "cannot serialize request");
+        emit_json(root);
+        return;
+    }
+
+    char resp[8192];
+    int rc = control_roundtrip(srv->trace_dir, inner_str, resp, sizeof(resp));
+    cJSON_free(inner_str);
+
+    if (rc == -1) {
+        cJSON_AddStringToObject(root, "error", "daemon not running");
+        emit_json(root);
+        return;
+    }
+    if (rc != 0) {
+        cJSON_AddStringToObject(root, "error", "control socket error");
+        emit_json(root);
+        return;
+    }
+
+    cJSON *daemon_resp = cJSON_Parse(resp);
+    if (!daemon_resp) {
+        cJSON_AddStringToObject(root, "error", "invalid daemon response");
+        emit_json(root);
+        return;
+    }
+
+    cJSON_AddItemToObject(root, "response", daemon_resp);
+    emit_json(root);
+}
+
+static void dispatch(struct pgwt_server *srv, struct pgwt_request *req,
+                     const char *line)
 {
     if (strcmp(req->cmd, "info") == 0)
         handle_info(srv, req);
@@ -1848,6 +1971,8 @@ static void dispatch(struct pgwt_server *srv, struct pgwt_request *req)
         handle_variants(srv, req);
     else if (strcmp(req->cmd, "interference") == 0)
         handle_interference(srv, req);
+    else if (strcmp(req->cmd, "control") == 0)
+        handle_control(srv, req, line);
     else {
         cJSON *root = cJSON_CreateObject();
         cJSON_AddNumberToObject(root, "id", (double)req->id);
@@ -1861,6 +1986,53 @@ static void dispatch(struct pgwt_server *srv, struct pgwt_request *req)
 /* ── Main ─────────────────────────────────────────────────── */
 
 /* ── Dump mode: text summary to stdout ──────────────────── */
+
+/* If a daemon control socket is present in the trace dir, print a short
+ * status block at the top of the dump. Silent when no daemon runs. */
+static void dump_daemon_status(const char *trace_dir)
+{
+    char resp[8192];
+
+    if (control_roundtrip(trace_dir, "{\"cmd\":\"status\"}",
+                          resp, sizeof(resp)) != 0)
+        return;
+
+    cJSON *status = cJSON_Parse(resp);
+    if (!status)
+        return;
+
+    const char *mode = "?";
+    double uptime_s = 0;
+    int backends = 0, pg_pid = 0;
+
+    cJSON *it;
+    if (cJSON_IsString((it = cJSON_GetObjectItem(status, "mode"))))
+        mode = it->valuestring;
+    if (cJSON_IsNumber((it = cJSON_GetObjectItem(status, "uptime_s"))))
+        uptime_s = it->valuedouble;
+    if (cJSON_IsNumber((it = cJSON_GetObjectItem(status, "backends"))))
+        backends = (int)it->valuedouble;
+    if (cJSON_IsNumber((it = cJSON_GetObjectItem(status, "pg_pid"))))
+        pg_pid = (int)it->valuedouble;
+
+    double events_per_sec = 0;
+    if (control_roundtrip(trace_dir, "{\"cmd\":\"metrics\"}",
+                          resp, sizeof(resp)) == 0) {
+        cJSON *metrics = cJSON_Parse(resp);
+        if (metrics) {
+            if (cJSON_IsNumber((it = cJSON_GetObjectItem(metrics,
+                                                         "events_per_sec"))))
+                events_per_sec = it->valuedouble;
+            cJSON_Delete(metrics);
+        }
+    }
+
+    printf("Daemon: running    mode: %s    uptime: %.0fs    "
+           "events/s: %.0f    backends: %d    pg_pid: %d\n\n",
+           mode, uptime_s, events_per_sec, backends, pg_pid);
+
+    cJSON_Delete(status);
+}
 
 static void dump_summary(struct pgwt_server *srv)
 {
@@ -1976,6 +2148,7 @@ int main(int argc, char **argv)
         return 1;
 
     if (dump_mode) {
+        dump_daemon_status(srv.trace_dir);
         dump_summary(&srv);
         return 0;
     }
@@ -1993,7 +2166,7 @@ int main(int argc, char **argv)
             continue;
         }
 
-        dispatch(&srv, &req);
+        dispatch(&srv, &req, line);
     }
 
     return 0;

--- a/tests/test_control.sh
+++ b/tests/test_control.sh
@@ -1,0 +1,282 @@
+#!/bin/bash
+# test_control.sh — Integration test for the daemon control socket (Phase A0)
+#
+# Starts the daemon against a real PostgreSQL with trace recording,
+# then exercises {trace_dir}/pgwt.sock:
+#   - status / metrics JSON shape
+#   - unknown command + invalid JSON errors
+#   - concurrent clients
+#   - client disconnect mid-request (daemon must survive)
+#   - pgwt-server "control" proxy command
+#   - pgwt-server --dump daemon status block
+#   - clean shutdown (socket unlinked)
+#
+# Requires: root, running PostgreSQL, python3.
+# Usage: sudo tests/test_control.sh [--pid POSTMASTER_PID]
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+TRACER="$SCRIPT_DIR/../pg_wait_tracer"
+SERVER="$SCRIPT_DIR/../pgwt-server"
+source "$SCRIPT_DIR/testutil.sh"
+
+PM_PID=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --pid) PM_PID="$2"; shift 2 ;;
+        *) echo "Usage: $0 [--pid POSTMASTER_PID]"; exit 1 ;;
+    esac
+done
+
+if [[ -z "$PM_PID" ]]; then
+    PM_PID=$(find_postmaster)
+    if [[ -z "$PM_PID" ]]; then
+        echo "ERROR: cannot find postmaster PID"
+        exit 1
+    fi
+fi
+
+echo "=== test_control ==="
+echo "Postmaster PID: $PM_PID"
+
+TRACE_DIR=$(mktemp -d /tmp/pgwt_control_XXXXXX)
+DAEMON_LOG=$(mktemp /tmp/pgwt_control_daemon_XXXXXX.log)
+SOCK="$TRACE_DIR/pgwt.sock"
+TRACER_PID=""
+
+passed=0
+failed=0
+
+check() {
+    if [[ "$1" -eq 0 ]]; then
+        echo "  PASS: $2"
+        passed=$((passed + 1))
+    else
+        echo "  FAIL: $2"
+        failed=$((failed + 1))
+    fi
+}
+
+cleanup() {
+    if [[ -n "$TRACER_PID" ]] && kill -0 "$TRACER_PID" 2>/dev/null; then
+        kill -TERM "$TRACER_PID" 2>/dev/null
+        wait "$TRACER_PID" 2>/dev/null
+    fi
+    rm -rf "$TRACE_DIR" "$DAEMON_LOG"
+}
+trap cleanup EXIT
+
+# Send one JSON line to the socket, print the one-line response.
+ctl() {
+    python3 - "$SOCK" "$1" <<'PYEOF'
+import socket, sys
+s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+s.settimeout(5)
+s.connect(sys.argv[1])
+s.sendall((sys.argv[2] + "\n").encode())
+buf = b""
+while b"\n" not in buf:
+    chunk = s.recv(4096)
+    if not chunk:
+        break
+    buf += chunk
+sys.stdout.write(buf.decode().split("\n")[0])
+PYEOF
+}
+
+# ── Start daemon ──────────────────────────────────────────────
+"$TRACER" --daemon --pid "$PM_PID" -i 1 -T "$TRACE_DIR" -v \
+    >/dev/null 2>"$DAEMON_LOG" &
+TRACER_PID=$!
+
+for _ in $(seq 1 30); do
+    [[ -S "$SOCK" ]] && break
+    if ! kill -0 "$TRACER_PID" 2>/dev/null; then
+        echo "ERROR: daemon exited during startup:"
+        tail -20 "$DAEMON_LOG"
+        exit 1
+    fi
+    sleep 0.5
+done
+
+[[ -S "$SOCK" ]]
+check $? "control socket created at \$TRACE_DIR/pgwt.sock"
+if [[ ! -S "$SOCK" ]]; then
+    tail -20 "$DAEMON_LOG"
+    exit 1
+fi
+
+MODE=$(stat -c %a "$SOCK")
+[[ "$MODE" == "600" ]]
+check $? "socket mode is 0600 (got $MODE)"
+
+# ── status ────────────────────────────────────────────────────
+STATUS=$(ctl '{"cmd":"status"}')
+echo "  status: $STATUS"
+echo "$STATUS" | python3 -c "
+import json, sys
+r = json.load(sys.stdin)
+assert r['ok'] is True, r
+assert r['mode'] == 'full', r
+assert isinstance(r['uptime_s'], (int, float)) and r['uptime_s'] >= 0, r
+assert isinstance(r['backends'], int) and r['backends'] >= 0, r
+assert r['pg_pid'] == $PM_PID, r
+assert isinstance(r['version'], str) and r['version'], r
+"
+check $? "status: ok/mode/uptime_s/backends/pg_pid/version"
+
+# ── metrics (initial) ─────────────────────────────────────────
+METRICS=$(ctl '{"cmd":"metrics"}')
+echo "  metrics: $METRICS"
+echo "$METRICS" | python3 -c "
+import json, sys
+r = json.load(sys.stdin)
+assert r['ok'] is True, r
+for k in ('events_total', 'events_per_sec', 'lifecycle_events_total',
+          'wp_attach_failures_total', 'backends_tracked',
+          'trace_events_written_total', 'trace_bytes_written_total',
+          'uptime_s'):
+    assert k in r, 'missing ' + k
+    assert isinstance(r[k], (int, float)), k
+"
+check $? "metrics: all counters present and numeric"
+
+EVENTS_BEFORE=$(echo "$METRICS" | python3 -c \
+    "import json,sys; print(json.load(sys.stdin)['events_total'])")
+
+# ── generate load, counters must move ─────────────────────────
+for i in 1 2 3; do
+    psql -U postgres -d postgres -tAc \
+        "SELECT count(*) FROM generate_series(1,200000); SELECT pg_sleep(0.2);" \
+        >/dev/null 2>&1
+done
+sleep 2   # let a timer tick refresh events_per_sec
+
+METRICS2=$(ctl '{"cmd":"metrics"}')
+EVENTS_AFTER=$(echo "$METRICS2" | python3 -c \
+    "import json,sys; print(json.load(sys.stdin)['events_total'])")
+[[ "$EVENTS_AFTER" -gt "$EVENTS_BEFORE" ]]
+check $? "events_total increased under load ($EVENTS_BEFORE -> $EVENTS_AFTER)"
+
+BYTES=$(echo "$METRICS2" | python3 -c \
+    "import json,sys; print(json.load(sys.stdin)['trace_bytes_written_total'])")
+[[ "$BYTES" -gt 0 ]]
+check $? "trace_bytes_written_total > 0 ($BYTES)"
+
+# ── unknown command ───────────────────────────────────────────
+RESP=$(ctl '{"cmd":"bogus"}')
+[[ "$RESP" == '{"ok":false,"error":"unknown command"}' ]]
+check $? "unknown command rejected (got: $RESP)"
+
+# ── invalid JSON ──────────────────────────────────────────────
+RESP=$(ctl 'this is not json')
+echo "$RESP" | python3 -c "
+import json, sys
+r = json.load(sys.stdin)
+assert r['ok'] is False and 'error' in r, r
+"
+check $? "invalid JSON rejected (got: $RESP)"
+
+# ── concurrent clients + disconnect mid-request ───────────────
+python3 - "$SOCK" <<'PYEOF'
+import json, socket, sys
+
+path = sys.argv[1]
+
+def conn():
+    s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    s.settimeout(5)
+    s.connect(path)
+    return s
+
+def ask(s, req):
+    s.sendall((json.dumps(req) + "\n").encode())
+    buf = b""
+    while b"\n" not in buf:
+        chunk = s.recv(4096)
+        if not chunk:
+            raise RuntimeError("daemon closed connection")
+        buf += chunk
+    return json.loads(buf.decode().split("\n")[0])
+
+# Two clients interleaved on open connections
+a, b = conn(), conn()
+ra = ask(a, {"cmd": "status"})
+rb = ask(b, {"cmd": "metrics"})
+ra2 = ask(a, {"cmd": "metrics"})   # second request on same connection
+assert ra["ok"] and rb["ok"] and ra2["ok"]
+b.close()
+
+# Disconnect mid-request: partial line, no newline, then close
+c = conn()
+c.sendall(b'{"cmd":"sta')
+c.close()
+
+# Daemon must still answer on the surviving and on a fresh connection
+ra3 = ask(a, {"cmd": "status"})
+assert ra3["ok"]
+a.close()
+d = conn()
+rd = ask(d, {"cmd": "status"})
+assert rd["ok"]
+d.close()
+PYEOF
+check $? "concurrent clients + disconnect mid-request survived"
+
+kill -0 "$TRACER_PID" 2>/dev/null
+check $? "daemon still alive after client abuse"
+
+# ── pgwt-server control proxy ─────────────────────────────────
+RESP=$(echo '{"id":7,"cmd":"control","request":{"cmd":"status"}}' | \
+       "$SERVER" "$TRACE_DIR" 2>/dev/null)
+echo "  proxy: $RESP"
+echo "$RESP" | python3 -c "
+import json, sys
+r = json.load(sys.stdin)
+assert r['id'] == 7, r
+assert r['response']['ok'] is True, r
+assert r['response']['mode'] == 'full', r
+"
+check $? "pgwt-server control proxy forwards status"
+
+RESP=$(echo '{"id":8,"cmd":"control"}' | "$SERVER" "$TRACE_DIR" 2>/dev/null)
+echo "$RESP" | python3 -c "
+import json, sys
+r = json.load(sys.stdin)
+assert r['id'] == 8 and 'error' in r, r
+"
+check $? "control proxy rejects missing request object"
+
+# ── pgwt-server --dump status block ───────────────────────────
+DUMP=$("$SERVER" --dump "$TRACE_DIR" 2>/dev/null | head -3)
+echo "$DUMP" | grep -q "Daemon: running.*mode: full.*uptime"
+check $? "--dump prints daemon status block"
+
+# ── clean shutdown ────────────────────────────────────────────
+kill -TERM "$TRACER_PID"
+SHUT_OK=1
+for _ in $(seq 1 20); do
+    if ! kill -0 "$TRACER_PID" 2>/dev/null; then SHUT_OK=0; break; fi
+    sleep 0.5
+done
+wait "$TRACER_PID" 2>/dev/null
+check $SHUT_OK "daemon exits on SIGTERM"
+TRACER_PID=""
+
+[[ ! -e "$SOCK" ]]
+check $? "socket unlinked on shutdown"
+
+# ── proxy with daemon stopped → clean error ───────────────────
+RESP=$(echo '{"id":9,"cmd":"control","request":{"cmd":"status"}}' | \
+       "$SERVER" "$TRACE_DIR" 2>/dev/null)
+echo "$RESP" | python3 -c "
+import json, sys
+r = json.load(sys.stdin)
+assert r['id'] == 9, r
+assert r.get('error') == 'daemon not running', r
+"
+check $? "proxy reports 'daemon not running' when socket absent (got: $RESP)"
+
+echo ""
+echo "$passed/$((passed + failed)) tests passed"
+[[ $failed -eq 0 ]]

--- a/tests/test_wait_event.c
+++ b/tests/test_wait_event.c
@@ -131,6 +131,7 @@ static void test_client_events(void)
      * Client class — see pgwt_is_idle_event() in src/wait_event.c. */
     CHECK(pgwt_is_idle_event(WEI(PG_WAIT_CLIENT, 0)) == 0,
           "Client:ClientRead should NOT be idle");
+    /* Other Client events are NOT idle */
     CHECK(pgwt_is_idle_event(WEI(PG_WAIT_CLIENT, 1)) == 0,
           "Client:ClientWrite should NOT be idle");
 }


### PR DESCRIPTION
Implements **Phase A0** of `docs/REWORK_PLAN.md` — the daemon grows a runtime control plane and self-observability, with **zero capture-behavior changes** (design decisions D4 + D6).

## What changed
- **`src/control.c` / `src/control.h`** — unix domain socket at `{trace_dir}/pgwt.sock` (mode 0600, stale socket unlinked on start, removed on shutdown). JSON-line protocol, registered on the daemon's existing epoll loop; up to 16 concurrent clients, line-buffered, disconnect-safe. Unknown command → `{"ok":false,"error":"unknown command"}`.
  - `{"cmd":"status"}` → `mode` (full/lightweight), `uptime_s`, `backends`, `pg_pid`, `version`
  - `{"cmd":"metrics"}` → `events_total`, `events_per_sec`, `lifecycle_events_total`, `wp_attach_failures_total`, `trace_events_written_total`, `trace_bytes_written_total`, `backends_tracked`
- **Self-observability counters** (`struct pgwt_counters` in `daemon.h`) — plain `uint64` increments on the single-threaded event path (`events_total` in `event_stream.c`; `wp_attach_failures_total` at the three watchpoint-attach sites in `backend.c`). `events_per_sec` refreshed each timer tick.
- **`pgwt-server` control proxy** (`src/server.c`) — new `control` protocol command connects to the daemon socket (path derived from the trace dir), forwards the inner request, returns a clean error if the daemon isn't running.
- **`pgwt-server --dump`** — prints a daemon status block (mode, uptime, events/s) when the socket is present.
- **`tests/test_control.sh`** — standalone integration test: status + metrics shape, unknown command, mid-request client disconnect, clean shutdown.

## Metric naming
Stable snake_case with units (`*_total`, `*_per_sec`, `*_bytes`) so the planned **Prometheus exporter** can consume them directly.

## Deliberate non-scope
- **Ringbuf drop counter** is *not* reported — the BPF ringbuf exposes no drop count to userspace and A0 makes no BPF changes. Reported as absent rather than a misleading `0`; A2 (provider split) should add a BPF-side drop map. (Documented in `control.h`.)

## Acceptance ("daemon answers status/metrics over the socket with zero change to capture behavior")
- ✅ No BPF / event-path semantic changes — only `uint64` counter increments added.
- ✅ `pgwt-server` (incl. the control proxy) builds clean locally.
- ⏳ Full BPF daemon build + live `test_control.sh` re-verification pending: the local machine has no `bpftool` for its kernel, and the shared test server's SSH access changed. Recommend validating via CI after the rebase below.

## Dependencies / sequencing
- **Depends on #6 (B1).** Branched before B1, so it does **not** include the CI workflow. After #6 merges, this branch should be **rebased onto master** — that brings CI (which does the full BPF build the local box can't) and resolves the overlap where both PRs edited `tests/test_wait_event.c` and `tests/Makefile`.
- Wiring `tests/test_control.sh` into `tests/run_all.sh` is **intentionally deferred** to avoid colliding with #6's changes to that file.