### PR TITLE
Fix Lock-class wait-event name mislabeling on PG17+

### DIFF
--- a/src/wait_event.c
+++ b/src/wait_event.c
@@ -602,12 +602,93 @@ static void dyn_add(int class_byte, int event_id, const char *name)
         dyn_max[class_byte] = event_id;
 }
 
+/* Return the hardcoded id→name table + max index for a wait-event class
+ * byte. Returns 1 if the class has a known table, 0 otherwise. */
+static int hardcoded_class_table(int cb, const char ***tbl, int *max)
+{
+    switch (cb) {
+    case PG_WAIT_IO:       *tbl = io_events;       *max = io_events_max;       return 1;
+    case PG_WAIT_LOCK:     *tbl = lock_events;     *max = LOCK_EVENTS_MAX;     return 1;
+    case PG_WAIT_TIMEOUT:  *tbl = timeout_events;  *max = TIMEOUT_EVENTS_MAX;  return 1;
+    case PG_WAIT_ACTIVITY: *tbl = activity_events; *max = ACTIVITY_EVENTS_MAX; return 1;
+    case PG_WAIT_CLIENT:   *tbl = client_events;   *max = CLIENT_EVENTS_MAX;   return 1;
+    case PG_WAIT_IPC:      *tbl = ipc_events;      *max = IPC_EVENTS_MAX;      return 1;
+    case PG_WAIT_LWLOCK:   *tbl = lwlock_tranches; *max = LWLOCK_TRANCHES_MAX; return 1;
+    default:               return 0;
+    }
+}
+
+/* Reverse lookup: event name → numeric event_id within a class's
+ * hardcoded table. Returns -1 if the name is not known. This is how we
+ * recover the correct enum id for a dynamically-discovered name —
+ * pg_wait_events exposes no id column, and its rows are NOT in enum
+ * order for every class (e.g. the Lock class follows LockTagType, which
+ * is not alphabetical), so positional id assignment is wrong. */
+static int hardcoded_event_id(int cb, const char *name)
+{
+    const char **tbl;
+    int max;
+    if (!hardcoded_class_table(cb, &tbl, &max))
+        return -1;
+    for (int i = 0; i <= max; i++)
+        if (tbl[i] && strcmp(tbl[i], name) == 0)
+            return i;
+    return -1;
+}
+
+/* Parse "Type|Name" lines from fp into the dynamic name table, assigning
+ * each name its CORRECT enum id by reverse-lookup against the hardcoded
+ * tables. We cannot derive the id from pg_wait_events: it has no id
+ * column, and `ORDER BY name` is not enum order for every class (the
+ * Lock class follows LockTagType — relation=0 … advisory=10 — which is
+ * not alphabetical), so positional id assignment mislabelled Lock
+ * subtypes (relation shown as advisory). Names unknown to this build (a
+ * newer PG version) are appended after the class's known maximum —
+ * best-effort forward-compat, since their true id is not available.
+ * Caller is responsible for dyn_clear() before and dyn_loaded after.
+ * Returns the number of names parsed. */
+static int load_names_from_fp(FILE *fp)
+{
+    char line[256];
+    int count = 0;
+    int cur_class = -1;
+    int next_unknown_id = 0;
+
+    while (fgets(line, sizeof(line), fp)) {
+        char *nl = strchr(line, '\n');
+        if (nl) *nl = '\0';
+        if (line[0] == '\0') continue;
+
+        char *sep = strchr(line, '|');
+        if (!sep) continue;
+        *sep = '\0';
+
+        const char *type = line;
+        const char *name = sep + 1;
+        int cb = class_name_to_byte(type);
+        if (cb < 0) continue;
+
+        if (cb != cur_class) {
+            const char **tbl;
+            int max;
+            cur_class = cb;
+            next_unknown_id = hardcoded_class_table(cb, &tbl, &max) ? max + 1 : 0;
+        }
+
+        int id = hardcoded_event_id(cb, name);
+        if (id < 0)
+            id = next_unknown_id++;
+
+        dyn_add(cb, id, name);
+        count++;
+    }
+    return count;
+}
+
 int pgwt_load_event_names_from_pg(const char *pg_bindir, int pg_port,
                                   const char *pg_user)
 {
     char cmd[512];
-    char line[256];
-    int  count = 0;
 
     /* pg_wait_events view exists since PG17 */
     snprintf(cmd, sizeof(cmd),
@@ -620,39 +701,7 @@ int pgwt_load_event_names_from_pg(const char *pg_bindir, int pg_port,
         return -1;
 
     dyn_clear();
-
-    /* Track sequential event_id per class.
-     * pg_wait_events returns events in enum order within each class,
-     * so the nth event within a class has event_id = n. */
-    int cur_class = -1;
-    int cur_id = -1;
-
-    while (fgets(line, sizeof(line), fp)) {
-        /* Remove trailing newline */
-        char *nl = strchr(line, '\n');
-        if (nl) *nl = '\0';
-        if (line[0] == '\0') continue;
-
-        /* Parse "Type|Name" */
-        char *sep = strchr(line, '|');
-        if (!sep) continue;
-        *sep = '\0';
-
-        const char *type = line;
-        const char *name = sep + 1;
-        int cb = class_name_to_byte(type);
-        if (cb < 0) continue;
-
-        if (cb != cur_class) {
-            cur_class = cb;
-            cur_id = 0;
-        } else {
-            cur_id++;
-        }
-
-        dyn_add(cb, cur_id, name);
-        count++;
-    }
+    int count = load_names_from_fp(fp);
 
     int status = pclose(fp);
     if (status != 0 || count == 0) {
@@ -660,6 +709,29 @@ int pgwt_load_event_names_from_pg(const char *pg_bindir, int pg_port,
         return -1;
     }
 
+    dyn_loaded = 1;
+    return 0;
+}
+
+/* Test/forward-compat entry point: load names from an in-memory buffer
+ * of "Type|Name\n" lines (same format as the pg_wait_events query
+ * output). Lets the id-mapping logic be unit-tested without a live PG. */
+int pgwt_load_event_names_from_buffer(const char *data)
+{
+    if (!data)
+        return -1;
+    FILE *fp = fmemopen((void *)data, strlen(data), "r");
+    if (!fp)
+        return -1;
+
+    dyn_clear();
+    int count = load_names_from_fp(fp);
+    fclose(fp);
+
+    if (count == 0) {
+        dyn_clear();
+        return -1;
+    }
     dyn_loaded = 1;
     return 0;
 }

--- a/src/wait_event.h
+++ b/src/wait_event.h
@@ -17,6 +17,12 @@ void pgwt_init_event_names(int pg_major);
 int pgwt_load_event_names_from_pg(const char *pg_bindir, int pg_port,
                                   const char *pg_user);
 
+/* Load dynamic event names from an in-memory buffer of "Type|Name\n"
+ * lines (the pg_wait_events query output format). Same id-mapping logic
+ * as pgwt_load_event_names_from_pg, but without a live PG — used by unit
+ * tests. Returns 0 on success, -1 on failure. */
+int pgwt_load_event_names_from_buffer(const char *data);
+
 /* Write current event name mapping to a JSON sidecar file.
  * Path: <trace_dir>/wait_event_names.json
  * Returns 0 on success, -1 on failure. */

--- a/tests/test_wait_event.c
+++ b/tests/test_wait_event.c
@@ -198,6 +198,47 @@ static void test_unknown_fallbacks(void)
           "class 0xFF should be unknown or numeric, got \"%s\"", buf);
 }
 
+/* Regression: dynamic names loaded from pg_wait_events arrive ordered by
+ * NAME (alphabetical), which is NOT enum order for the Lock class
+ * (LockTagType: relation=0 … advisory=10). The loader must map each name
+ * to its correct enum id, not its row position. Before the fix,
+ * Lock:relation (id 0) was mislabelled "advisory". */
+static void test_dynamic_name_mapping(void)
+{
+    printf("--- Dynamic Name Mapping (pg_wait_events order) ---\n");
+
+    /* Lock rows exactly as `SELECT type,name ... ORDER BY type,name`
+     * returns them: alphabetical by name. Includes a fabricated future
+     * event ("zzznewlock") to exercise the unknown-name fallback. */
+    const char *buf =
+        "Lock|advisory\n"
+        "Lock|applytransaction\n"
+        "Lock|extend\n"
+        "Lock|frozenid\n"
+        "Lock|object\n"
+        "Lock|page\n"
+        "Lock|relation\n"
+        "Lock|spectoken\n"
+        "Lock|transactionid\n"
+        "Lock|tuple\n"
+        "Lock|userlock\n"
+        "Lock|virtualxid\n"
+        "Lock|zzznewlock\n";
+
+    CHECK(pgwt_load_event_names_from_buffer(buf) == 0,
+          "load dynamic names from buffer");
+
+    /* Correct enum ids despite alphabetical input order */
+    CHECK_NAME(WEI(PG_WAIT_LOCK, 0),  "Lock:relation");
+    CHECK_NAME(WEI(PG_WAIT_LOCK, 1),  "Lock:extend");
+    CHECK_NAME(WEI(PG_WAIT_LOCK, 5),  "Lock:transactionid");
+    CHECK_NAME(WEI(PG_WAIT_LOCK, 6),  "Lock:virtualxid");
+    CHECK_NAME(WEI(PG_WAIT_LOCK, 10), "Lock:advisory");
+    CHECK_NAME(WEI(PG_WAIT_LOCK, 11), "Lock:applytransaction");
+    /* Unknown future name appended after the class max (11) */
+    CHECK_NAME(WEI(PG_WAIT_LOCK, 12), "Lock:zzznewlock");
+}
+
 int main(void)
 {
     printf("=== test_wait_event ===\n");
@@ -213,6 +254,7 @@ int main(void)
     test_bufferpin();
     test_extension();
     test_unknown_fallbacks();
+    test_dynamic_name_mapping();  /* must run last: sets dyn_loaded */
 
     printf("\n%d/%d tests passed\n", tests_passed, tests_run);
     return (tests_passed == tests_run) ? 0 : 1;


### PR DESCRIPTION
## The bug
Live `Lock`-class wait events were mislabeled on PG 17/18: a backend waiting on `Lock:relation` was reported as `Lock:advisory`. Confirmed on a real box three ways — `pg_stat_activity` says `relation`, a raw `/proc` read of `wait_event_info` is `0x03000000` (subtype 0 = relation), and instrumenting the tracer showed it *reads* `0x03000000` correctly but still names it `advisory`.

## Root cause
`pgwt_load_event_names_from_pg()` queried `pg_wait_events` with `ORDER BY type, name` and assigned `event_id = 0,1,2…` by **row position**, assuming alphabetical order equals enum order. That holds for the classes PG17 alphabetized, but **not the Lock class**, whose events come from the `LockTagType` enum (`relation`=0 … `advisory`=10) — not alphabetical. So "advisory" (alphabetically first) took id 0, and every live `Lock:relation` wait rendered as `Lock:advisory`. Because these dynamic names are *preferred over* the hardcoded table, this corrupted **all** live Lock output on PG17+ (drill-downs, lock-chain views), not just one test.

It was never caught because no watchpoint-path test checked Lock *subtype* names, and synthetic tests use the hardcoded table directly (dynamic names not loaded).

## Fix
- Assign each dynamic name its **correct enum id by reverse-lookup against the hardcoded tables** (`hardcoded_event_id()`), instead of by row position. Names unknown to this build (a future PG) are appended after the class's known max — best-effort forward-compat, since `pg_wait_events` exposes no id.
- Extract the parser into `load_names_from_fp()` and add `pgwt_load_event_names_from_buffer()` so the id mapping is **unit-testable without a live PG**.
- New regression in `test_wait_event.c` feeds alphabetical Lock rows (exactly as `pg_wait_events` returns them) and asserts correct ids.

## Validation (on dmitry-micro-test, PG 18.4)
- C unit test: **83/83** (incl. new `test_dynamic_name_mapping`).
- Live: the exact scenario that produced `Lock:advisory` now reports `Lock:relation`, matching `pg_stat_activity`.
- `test_deterministic`: **7/8 → 11/11** (Test 2 Lock now passes).

Part of the Track E live-suite cleanup; this is the one genuine product bug among the failures investigated (pre-existing, not introduced by B1/A0).