### PR TITLE
Track E: skip pg_wait_sampling tests cleanly; wire test_control into run_all

### DIFF
--- a/tests/run_all.sh
+++ b/tests/run_all.sh
@@ -126,6 +126,7 @@ if [[ $(id -u) -eq 0 ]] && pgrep -x postgres > /dev/null 2>&1; then
     run_test "test_partition" python3 "$SCRIPT_DIR/test_partition.py" $PID_ARG
     run_test "test_idle_exclusion" python3 "$SCRIPT_DIR/test_idle_exclusion.py" $PID_ARG
     run_test "test_daemon_server" python3 "$SCRIPT_DIR/test_daemon_server.py" $PID_ARG
+    run_test "test_control" bash "$SCRIPT_DIR/test_control.sh" $PID_ARG
 else
     if [[ $(id -u) -ne 0 ]]; then
         skip_test "test_lifecycle" "requires root"
@@ -148,6 +149,7 @@ else
         skip_test "test_partition" "requires root"
         skip_test "test_idle_exclusion" "requires root"
         skip_test "test_daemon_server" "requires root"
+        skip_test "test_control" "requires root"
     else
         skip_test "test_lifecycle" "PostgreSQL not running"
         skip_test "test_cross_validate" "PostgreSQL not running"
@@ -169,6 +171,7 @@ else
         skip_test "test_partition" "PostgreSQL not running"
         skip_test "test_idle_exclusion" "PostgreSQL not running"
         skip_test "test_daemon_server" "PostgreSQL not running"
+        skip_test "test_control" "PostgreSQL not running"
     fi
 fi
 

--- a/tests/test_cross_pg_wait_sampling.py
+++ b/tests/test_cross_pg_wait_sampling.py
@@ -21,7 +21,7 @@ import time
 import argparse
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-from testutil import find_postmaster
+from testutil import find_postmaster, pg_wait_sampling_available
 
 TRACER = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
                       "pg_wait_tracer")
@@ -282,10 +282,10 @@ def main():
         print("ERROR: cannot find PostgreSQL postmaster PID")
         sys.exit(1)
 
-    # Check pg_wait_sampling is available
-    try:
-        psql("SELECT 1 FROM pg_wait_sampling_profile LIMIT 1")
-    except Exception:
+    # Check pg_wait_sampling is available. The local psql() returns "" on
+    # error instead of raising, so a try/except here never fires — probe
+    # via the process return code instead (see testutil).
+    if not pg_wait_sampling_available():
         print("SKIP: pg_wait_sampling not available")
         sys.exit(0)
 

--- a/tests/test_event_classes.py
+++ b/tests/test_event_classes.py
@@ -18,7 +18,7 @@ import time
 import argparse
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-from testutil import find_postmaster
+from testutil import find_postmaster, pg_wait_sampling_available
 
 TRACER = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
                       "pg_wait_tracer")
@@ -239,10 +239,10 @@ def test_extension(pm_pid):
     """Verify Extension events are detected (pg_wait_sampling generates them)."""
     print("--- Test 3: Extension Events ---")
 
-    # Check pg_wait_sampling is loaded
-    try:
-        psql("SELECT 1 FROM pg_wait_sampling_profile LIMIT 1")
-    except Exception:
+    # Check pg_wait_sampling is loaded. The local psql() returns "" on
+    # error instead of raising, so a try/except here never fires — probe
+    # via the process return code instead (see testutil).
+    if not pg_wait_sampling_available():
         print("  SKIP: pg_wait_sampling not loaded")
         return
 

--- a/tests/testutil.py
+++ b/tests/testutil.py
@@ -10,6 +10,22 @@ import re
 import subprocess
 
 
+def pg_wait_sampling_available():
+    """Return True if the pg_wait_sampling extension is loaded and queryable.
+
+    Tests that cross-check against pg_wait_sampling (Extension-class waits,
+    sample-count cross-validation) must skip cleanly when it is absent —
+    e.g. on a stock PostgreSQL or in CI. Note: a per-test psql() helper
+    that returns "" on error cannot be used to detect this, since the
+    failure is silent; we must inspect the process return code here.
+    """
+    r = subprocess.run(
+        ["psql", "-U", "postgres", "-d", "postgres", "-tAc",
+         "SELECT 1 FROM pg_wait_sampling_profile LIMIT 1"],
+        capture_output=True, text=True)
+    return r.returncode == 0
+
+
 def find_postmaster(pg_version=None):
     """Find the PostgreSQL postmaster PID.
 


### PR DESCRIPTION
Finishes the Track E live-suite cleanup (after the Lock-naming fix in #8).

## Problem
Two tests cross-check against the **pg_wait_sampling** extension —
`test_cross_pg_wait_sampling` and the Extension-class subtest of
`test_event_classes`. Their skip guards wrapped a `psql()` helper in
`try/except`, but that helper returns `""` on error instead of raising,
so the `except` never fired. On a stock PostgreSQL (no pg_wait_sampling)
they **failed** (0/3 and 5/7) instead of skipping.

## Fix
- Add `testutil.pg_wait_sampling_available()` which probes via the psql
  **process return code** (the silent-empty helper can't detect the
  failure), and use it in both tests so they skip cleanly when the
  extension is absent (stock PG / CI).
- `test_cpu_time` needs no change — it only tolerates pg_wait_sampling
  dilution, it doesn't require the extension (verified 6/6 on stock PG).
- Wire `tests/test_control.sh` (the A0 control-socket integration test,
  deferred at A0 merge to avoid colliding with B1's run_all.sh edits)
  into the live section of `run_all.sh`, with matching `skip_test`
  entries for the no-root / no-PG branches.

## Scope correction
Drops the earlier "de-flake test_cross_validate" Track E item — that was
a misdiagnosis. `test_cross_validate` passes 77/77 consistently and does
not use pg_wait_sampling; the "sampling empty" failures were
`test_cross_pg_wait_sampling`.

## Validation (dmitry-micro-test, stock PG 18.4, no pg_wait_sampling)
- `test_cross_pg_wait_sampling`: **SKIP, exit 0** (was 0/3 fail).
- `test_event_classes`: Extension **SKIP**, others **5/5 pass**, exit 0
  (was 5/7 fail).
- `test_control`: **16/16** via the suite.