### PR TITLE
Classify Client:ClientRead as idle (excluded from DB Time) but keep it visible

### DIFF
--- a/src/compute.c
+++ b/src/compute.c
@@ -568,10 +568,13 @@ void pgwt_compute_top_events(const struct pgwt_trace_event *events, int count,
 
     for (int i = 0; i < count; i++) {
         const struct pgwt_trace_event *ev = &events[i];
-        if (!pgwt_filter_matches(f, ev) || pgwt_is_idle_event(ev->old_event))
+        if (!pgwt_filter_matches(f, ev) || pgwt_is_hidden_event(ev->old_event))
             continue;
 
-        db_time_ns += ev->duration_ns;
+        /* Idle-but-visible events (Client:ClientRead) appear in the list
+         * but are excluded from DB Time, so their %DB stays meaningful. */
+        if (!pgwt_is_idle_event(ev->old_event))
+            db_time_ns += ev->duration_ns;
 
         /* Hash by event_id */
         uint32_t h = ev->old_event & EVENT_HT_MASK;
@@ -914,7 +917,8 @@ void pgwt_compute_heatmap(const struct pgwt_trace_event *events, int count,
 
     for (int i = 0; i < count; i++) {
         const struct pgwt_trace_event *ev = &events[i];
-        if (!pgwt_filter_matches(f, ev) || pgwt_is_idle_event(ev->old_event))
+        /* Visibility filter: keep Client:ClientRead in the latency heatmap. */
+        if (!pgwt_filter_matches(f, ev) || pgwt_is_hidden_event(ev->old_event))
             continue;
 
         uint64_t ev_ts = ev->timestamp_ns;
@@ -979,6 +983,30 @@ struct aas_summary_ctx {
     int has_query_filter;
 };
 
+/* Client:ClientRead time recorded for a query in this summary record
+ * (from its top_events). Used to subtract the idle-but-visible ClientRead
+ * portion out of the lumped Client class_ns so it is not counted as DB
+ * Time / AAS (load), while ClientRead still shows in event lists. */
+static double summary_query_clientread_ns(const struct pgwt_summary_query *sq)
+{
+    for (int j = 0; j < sq->num_top_events; j++)
+        if (sq->top_events[j].event_id == WEI(PG_WAIT_CLIENT, 0))
+            return (double)sq->top_events[j].total_ns;
+    return 0.0;
+}
+
+/* System-wide Client:ClientRead time recorded in this summary record
+ * (from the per-event table). Same purpose as above for the no-filter path. */
+static double summary_clientread_ns(const struct pgwt_summary_accum *rec)
+{
+    for (int e = 0; e < SUMMARY_MAX_EVENTS; e++) {
+        const struct pgwt_summary_event *se = &rec->events[e];
+        if (se->event_id == WEI(PG_WAIT_CLIENT, 0))
+            return (double)se->total_ns;
+    }
+    return 0.0;
+}
+
 static int aas_summary_visitor(const struct pgwt_summary_accum *rec, void *arg)
 {
     struct aas_summary_ctx *ctx = arg;
@@ -998,9 +1026,14 @@ static int aas_summary_visitor(const struct pgwt_summary_accum *rec, void *arg)
             const struct pgwt_summary_query *sq = &rec->queries[q];
             if (sq->query_id == 0 && sq->count == 0) continue;
             if (sq->query_id != ctx->f->query_id) continue;
+            /* AAS is active load: exclude idle Client:ClientRead from the
+             * lumped Client class_ns. */
+            double cr_ns = summary_query_clientread_ns(sq);
             for (int c = 0; c < PGWT_NUM_CLASSES; c++) {
                 if (c == PGWT_CLASS_ACTIVITY) continue;
-                ctx->buckets[bi].class_aas[c] += (double)sq->class_ns[c];
+                double cls_ns = (double)sq->class_ns[c];
+                if (c == PGWT_CLASS_CLIENT) cls_ns -= cr_ns;
+                ctx->buckets[bi].class_aas[c] += cls_ns;
             }
             break;
         }
@@ -1008,9 +1041,13 @@ static int aas_summary_visitor(const struct pgwt_summary_accum *rec, void *arg)
     }
 
     if (!ctx->has_class_filter && !ctx->has_event_filter) {
+        /* AAS is active load: exclude idle Client:ClientRead. */
+        double cr_ns = summary_clientread_ns(rec);
         for (int c = 0; c < PGWT_NUM_CLASSES; c++) {
             if (c == PGWT_CLASS_ACTIVITY) continue;
-            ctx->buckets[bi].class_aas[c] += (double)rec->class_ns[c];
+            double cls_ns = (double)rec->class_ns[c];
+            if (c == PGWT_CLASS_CLIENT) cls_ns -= cr_ns;
+            ctx->buckets[bi].class_aas[c] += cls_ns;
         }
     } else {
         for (int e = 0; e < SUMMARY_MAX_EVENTS; e++) {
@@ -1103,14 +1140,21 @@ static int tm_summary_visitor(const struct pgwt_summary_accum *rec, void *arg)
             if (sq->query_id == 0 && sq->count == 0) continue;
             if (sq->query_id != f->query_id) continue;
 
+            /* Client:ClientRead is idle: route it to the idle bucket, not
+             * DB Time, even though it is lumped into the Client class_ns. */
+            double cr_ns = summary_query_clientread_ns(sq);
             for (int c = 0; c < PGWT_NUM_CLASSES; c++) {
-                if (c == PGWT_CLASS_ACTIVITY)
+                double cls_ns = (double)sq->class_ns[c];
+                if (c == PGWT_CLASS_CLIENT)
+                    cls_ns -= cr_ns;
+                if (c == PGWT_CLASS_ACTIVITY) {
                     ctx->idle_time_ns += (double)sq->class_ns[c];
-                else {
-                    ctx->classes[c].total_ns += (double)sq->class_ns[c];
-                    ctx->db_time_ns += (double)sq->class_ns[c];
+                } else {
+                    ctx->classes[c].total_ns += cls_ns;
+                    ctx->db_time_ns += cls_ns;
                 }
             }
+            ctx->idle_time_ns += cr_ns;
             for (int j = 0; j < sq->num_top_events; j++) {
                 uint32_t eid = sq->top_events[j].event_id;
                 if (pgwt_is_idle_event(eid)) continue;
@@ -1138,14 +1182,21 @@ static int tm_summary_visitor(const struct pgwt_summary_accum *rec, void *arg)
 
     /* If no class/event filter: use class_ns directly */
     if (f->class_name[0] == '\0' && f->event_id == 0) {
+        /* Client:ClientRead is idle: subtract it out of the lumped Client
+         * class_ns so it counts toward idle time, not DB Time. */
+        double cr_ns = summary_clientread_ns(rec);
         for (int c = 0; c < PGWT_NUM_CLASSES; c++) {
-            if (c == PGWT_CLASS_ACTIVITY)
+            double cls_ns = (double)rec->class_ns[c];
+            if (c == PGWT_CLASS_CLIENT)
+                cls_ns -= cr_ns;
+            if (c == PGWT_CLASS_ACTIVITY) {
                 ctx->idle_time_ns += (double)rec->class_ns[c];
-            else {
-                ctx->classes[c].total_ns += (double)rec->class_ns[c];
-                ctx->db_time_ns += (double)rec->class_ns[c];
+            } else {
+                ctx->classes[c].total_ns += cls_ns;
+                ctx->db_time_ns += cls_ns;
             }
         }
+        ctx->idle_time_ns += cr_ns;
     }
 
     /* Per-event stats: iterate event entries */
@@ -1295,10 +1346,12 @@ static int te_summary_visitor(const struct pgwt_summary_accum *rec, void *arg)
 
             for (int j = 0; j < sq->num_top_events; j++) {
                 uint32_t eid = sq->top_events[j].event_id;
-                if (pgwt_is_idle_event(eid)) continue;
+                if (pgwt_is_hidden_event(eid)) continue;
                 if (!summary_event_matches_filter(ctx->f, eid)) continue;
 
-                ctx->db_time_ns += sq->top_events[j].total_ns;
+                /* Idle-but-visible (ClientRead): list it, exclude from DB Time. */
+                if (!pgwt_is_idle_event(eid))
+                    ctx->db_time_ns += sq->top_events[j].total_ns;
 
                 uint32_t h = eid & EVENT_HT_MASK;
                 while (ctx->ht[h].count > 0 && ctx->ht[h].event_id != eid)
@@ -1319,10 +1372,12 @@ static int te_summary_visitor(const struct pgwt_summary_accum *rec, void *arg)
     for (int e = 0; e < SUMMARY_MAX_EVENTS; e++) {
         const struct pgwt_summary_event *se = &rec->events[e];
         if (se->event_id == 0 && se->count == 0) continue;
-        if (pgwt_is_idle_event(se->event_id)) continue;
+        if (pgwt_is_hidden_event(se->event_id)) continue;
         if (!summary_event_matches_filter(ctx->f, se->event_id)) continue;
 
-        ctx->db_time_ns += se->total_ns;
+        /* Idle-but-visible (ClientRead): list it, exclude from DB Time. */
+        if (!pgwt_is_idle_event(se->event_id))
+            ctx->db_time_ns += se->total_ns;
 
         uint32_t h = se->event_id & EVENT_HT_MASK;
         while (ctx->ht[h].count > 0 && ctx->ht[h].event_id != se->event_id)
@@ -1676,7 +1731,8 @@ static int hm_summary_visitor(const struct pgwt_summary_accum *rec, void *arg)
     for (int e = 0; e < SUMMARY_MAX_EVENTS; e++) {
         const struct pgwt_summary_event *se = &rec->events[e];
         if (se->event_id == 0 && se->count == 0) continue;
-        if (pgwt_is_idle_event(se->event_id)) continue;
+        /* Visibility filter: keep Client:ClientRead in the latency heatmap. */
+        if (pgwt_is_hidden_event(se->event_id)) continue;
         if (!summary_event_matches_filter(ctx->f, se->event_id)) continue;
 
         for (int b = 0; b < HISTOGRAM_BUCKETS; b++) {
@@ -1771,7 +1827,8 @@ void pgwt_compute_transitions(const struct pgwt_trace_event *events, int count,
         const struct pgwt_trace_event *ev = &events[i];
         if (!pgwt_filter_matches(f, ev))
             continue;
-        if (pgwt_is_idle_event(ev->old_event) || pgwt_is_idle_event(ev->new_event))
+        /* Visibility filter: Client:ClientRead transitions stay in the graph. */
+        if (pgwt_is_hidden_event(ev->old_event) || pgwt_is_hidden_event(ev->new_event))
             continue;
         if (ev->new_event == PGWT_EVENT_EXIT)
             continue;

--- a/src/output.c
+++ b/src/output.c
@@ -423,7 +423,8 @@ static void print_system_event_multi(struct pgwt_daemon *d)
         for (int i = 0; i < deltas[w].num_events && shown < 20; i++) {
             struct pgwt_snap_event *ev = &deltas[w].events[i];
             if (ev->count == 0) continue;
-            if (pgwt_is_idle_event(ev->wait_event)) continue;
+            /* System events list (visibility): keep Client:ClientRead. */
+            if (pgwt_is_hidden_event(ev->wait_event)) continue;
 
             char name[64];
             pgwt_event_full_name(ev->wait_event, name, sizeof(name));
@@ -480,7 +481,8 @@ void pgwt_print_system_event(struct pgwt_daemon *d)
     int shown = 0;
     for (int i = 0; i < n && shown < 20; i++) {
         if (sorted[i].count == 0) continue;
-        if (pgwt_is_idle_event(sorted[i].wait_event)) continue;
+        /* System events list (visibility): keep Client:ClientRead. */
+        if (pgwt_is_hidden_event(sorted[i].wait_event)) continue;
 
         char name[64];
         pgwt_event_full_name(sorted[i].wait_event, name, sizeof(name));

--- a/src/pg_wait_tracer.h
+++ b/src/pg_wait_tracer.h
@@ -102,6 +102,8 @@ struct pgwt_query_text_event {
 
 #define WE_CLASS(x)  (((x) >> 24) & 0xFF)
 #define WE_EVENT(x)  ((x) & 0x00FFFFFF)
+/* Compose a wait_event_info from class byte + event id. */
+#define WEI(cls, id) (((uint32_t)(cls) << 24) | (uint32_t)(id))
 
 /* Client:ClientRead — idle between queries (like Oracle's SQL*Net message from client) */
 #define PG_WAIT_CLIENT_READ  ((PG_WAIT_CLIENT << 24) | 0x000000)

--- a/src/server.c
+++ b/src/server.c
@@ -1332,7 +1332,8 @@ static void handle_session_timeline(struct pgwt_server *srv, struct pgwt_request
         const struct pgwt_trace_event *ev = &events[i];
         if (!pgwt_filter_matches(&req->filter, ev))
             continue;
-        if (pgwt_is_idle_event(ev->old_event))
+        /* Timeline is a visibility view: keep Client:ClientRead bars. */
+        if (pgwt_is_hidden_event(ev->old_event))
             continue;
         total_matching++;
 
@@ -1426,7 +1427,8 @@ static void handle_session_timeline(struct pgwt_server *srv, struct pgwt_request
         const struct pgwt_trace_event *ev = &events[i];
         if (!pgwt_filter_matches(&req->filter, ev))
             continue;
-        if (pgwt_is_idle_event(ev->old_event))
+        /* Timeline is a visibility view: keep Client:ClientRead bars. */
+        if (pgwt_is_hidden_event(ev->old_event))
             continue;
 
         /* O(1) PID index lookup */
@@ -1511,7 +1513,8 @@ static void handle_transitions(struct pgwt_server *srv, struct pgwt_request *req
     for (int i = 0; i < count; i++) {
         const struct pgwt_trace_event *ev = &events[i];
         uint32_t eid = ev->old_event;
-        if (pgwt_is_idle_event(eid) || PGWT_IS_MARKER(eid))
+        /* Transition-graph node totals: visibility view, keep ClientRead. */
+        if (pgwt_is_hidden_event(eid) || PGWT_IS_MARKER(eid))
             continue;
         double ms = ev->duration_ns / 1e6;
         uint32_t h = (eid * 0x9e3779b9) & NODE_HT_MASK;

--- a/src/wait_event.c
+++ b/src/wait_event.c
@@ -549,13 +549,34 @@ void pgwt_event_full_name(uint32_t wei, char *buf, size_t bufsz)
         snprintf(buf, bufsz, "%s:id=%d", cls, WE_EVENT(wei));
 }
 
+/* LOAD vs VISIBILITY — two distinct concepts, intentionally split:
+ *
+ *  - pgwt_is_idle_event(): "excluded from DB Time / AAS / active load."
+ *    True for Activity-class AND Client:ClientRead. Client:ClientRead is
+ *    idle time spent waiting for the next command from the client (the
+ *    direct analogue of Oracle's "SQL*Net message from client"); counting
+ *    it as DB Time wrongly inflates load when connections sit idle (e.g.
+ *    idle-in-transaction). So it is excluded from load accounting here.
+ *
+ *  - pgwt_is_hidden_event(): "do not display in lists/graphs/breakdowns."
+ *    True for Activity-class ONLY. Client:ClientRead must stay VISIBLE in
+ *    event lists, timelines, transition graphs, histograms and class
+ *    drill-downs, so it is NOT hidden — only excluded from load.
+ *
+ * Conflating these two is what previously forced ClientRead to be marked
+ * non-idle (otherwise the visibility filters deleted it from every view,
+ * producing an empty Client class breakdown). Keeping them separate lets
+ * ClientRead be both excluded-from-load and still-visible.
+ */
 int pgwt_is_idle_event(uint32_t wei)
 {
-    /* Only Activity-class events are idle (AutoVacuumMain, idle, etc.).
-     * Client:ClientRead is NOT idle — it's a real wait event showing
-     * time spent waiting for the client to send the next command.
-     * Filtering it caused inconsistent behavior between zoom levels
-     * and empty Client class breakdown. */
+    return WE_CLASS(wei) == PG_WAIT_ACTIVITY ||
+           wei == WEI(PG_WAIT_CLIENT, 0);   /* Client:ClientRead */
+}
+
+int pgwt_is_hidden_event(uint32_t wei)
+{
+    /* Activity-class only — never hides Client:ClientRead. */
     return WE_CLASS(wei) == PG_WAIT_ACTIVITY;
 }
 

--- a/src/wait_event.h
+++ b/src/wait_event.h
@@ -44,8 +44,21 @@ const char *pgwt_event_name(uint32_t wait_event_info);
  * For event=0, writes "CPU*" (asterisk: not all CPU time is instrumented). */
 void pgwt_event_full_name(uint32_t wait_event_info, char *buf, size_t bufsz);
 
-/* Returns true if this event class represents idle waits
- * (Activity class — should be excluded from DB Time). */
+/* LOAD accounting: returns true if this event must be EXCLUDED from
+ * DB Time / AAS / active load. True for Activity-class events AND for
+ * Client:ClientRead (idle between commands — like Oracle's "SQL*Net
+ * message from client"). Use this anywhere you are deciding how much
+ * LOAD an event represents (DB Time, idle bucket, AAS, active sessions,
+ * % of DB Time, interference, etc.). */
 int pgwt_is_idle_event(uint32_t wait_event_info);
+
+/* VISIBILITY: returns true if this event must NOT be displayed in event
+ * lists / graphs / breakdowns. True for Activity-class events ONLY.
+ * Note: this deliberately does NOT include Client:ClientRead — that
+ * event is excluded from load (pgwt_is_idle_event) but must remain
+ * VISIBLE in event lists, timelines, transition graphs, histograms,
+ * and class drill-downs. Use this anywhere you are deciding whether an
+ * event ROW/series/marker should APPEAR to the user. */
+int pgwt_is_hidden_event(uint32_t wait_event_info);
 
 #endif /* PGWT_WAIT_EVENT_H */

--- a/tests/test_client_wait.py
+++ b/tests/test_client_wait.py
@@ -1,12 +1,16 @@
 #!/usr/bin/env python3
-"""test_client_wait.py — Verify Client:ClientRead idle classification.
+"""test_client_wait.py — Verify Client:ClientRead idle-but-visible contract.
 
-Client:ClientRead is an idle wait event (like Oracle's SQL*Net message from
-client).  When a backend is idle-in-transaction, it enters Client:ClientRead.
+Client:ClientRead is an idle wait event (like Oracle's "SQL*Net message from
+client").  When a backend is idle-in-transaction, it enters Client:ClientRead.
 
-This test verifies:
-  1. Client:ClientRead is excluded from system_event (idle, like Activity events)
-  2. An idle-in-transaction backend does not inflate DB Time
+The contract (load-vs-visibility split, see src/wait_event.c):
+  - Client:ClientRead is EXCLUDED from DB Time / AAS (it is idle load), so an
+    idle-in-transaction backend must NOT inflate DB Time.
+  - Client:ClientRead is NOT hidden: it must still APPEAR in the system_event
+    list (unlike Activity events, which are hidden).
+  - The idle time is still accounted — it shows up in the Activity/idle bucket
+    of the time model, not in DB Time.
 
 Requires: root, running PostgreSQL 18, pg_wait_tracer built.
 Usage: sudo python3 tests/test_client_wait.py [--pid POSTMASTER_PID]
@@ -78,15 +82,22 @@ def parse_time_model(output):
     model = {}
     for line in output.split('\n'):
         line = line.strip()
+        # Normal rows: "Name   <ms>   <pct>%"
         m = re.match(r'^(.+?)\s{2,}([\d.]+)\s+[\d.]+%', line)
         if m:
             model[m.group(1).strip()] = float(m.group(2))
+            continue
+        # Idle bucket row: "(Activity/Idle — excluded from DB Time)  <ms>  —"
+        m = re.match(r'^(\(Activity/Idle.*?\))\s{2,}([\d.]+)\s', line)
+        if m:
+            model['Idle'] = float(m.group(2))
     return model
 
 
-def test_client_read_excluded(pm_pid):
-    """Start an idle-in-transaction backend, verify Client:ClientRead is excluded."""
-    print("--- Test 1: Client:ClientRead Excluded from system_event ---")
+def test_client_read_visible_but_idle(pm_pid):
+    """Idle-in-transaction backend: ClientRead is VISIBLE in system_event
+    but does NOT inflate DB Time (idle for load accounting)."""
+    print("--- Test 1: Client:ClientRead visible but excluded from DB Time ---")
 
     # Start psql idle-in-transaction FIRST — before tracer
     psql_proc = subprocess.Popen(
@@ -153,26 +164,34 @@ def test_client_read_excluded(pm_pid):
     events = parse_system_events(output_se)
     model = parse_time_model(output_tm)
 
-    # Client:ClientRead should NOT appear in system_event (it's idle)
+    # Client:ClientRead MUST appear in system_event (idle but visible).
     client_read = [e for e in events if e['name'] == 'Client:ClientRead']
-    check(len(client_read) == 0,
-          f"Client:ClientRead excluded from system_event "
+    check(len(client_read) >= 1,
+          f"Client:ClientRead visible in system_event "
           f"(found {len(client_read)}, events: {[e['name'] for e in events]})")
 
-    # No Activity events should appear either (confirms idle exclusion works)
+    # Activity events stay hidden (they are idle AND hidden).
     activity = [e for e in events if 'Activity' in e['name']]
     check(len(activity) == 0,
-          f"Activity events excluded from system_event (found {len(activity)})")
+          f"Activity events hidden from system_event (found {len(activity)})")
 
-    # Activity time should capture the idle backend's Client:ClientRead time
-    # (routed to activity_time_ns alongside Activity class events)
-    if 'Activity' in model:
-        activity_time = model['Activity']
-        # The idle-in-transaction backend alone adds ~INTERVAL*1000ms
-        check(activity_time >= INTERVAL * 1000 * 0.8,
-              f"Activity time = {activity_time:.0f}ms >= "
+    # DB Time must NOT be inflated by the idle backend.  The idle backend
+    # contributes ~INTERVAL*1000ms of ClientRead; if that leaked into DB
+    # Time it would dominate.  DB Time should stay well below that.
+    if 'DB Time' in model:
+        db_time = model['DB Time']
+        idle_floor = INTERVAL * 1000 * 0.8
+        check(db_time < idle_floor,
+              f"DB Time = {db_time:.0f}ms < {idle_floor:.0f}ms "
+              f"(idle ClientRead NOT counted as DB Time)")
+
+    # The idle time is still accounted — routed to the Activity/idle bucket.
+    if 'Idle' in model:
+        idle_time = model['Idle']
+        check(idle_time >= INTERVAL * 1000 * 0.8,
+              f"Activity/idle time = {idle_time:.0f}ms >= "
               f"{INTERVAL * 1000 * 0.8:.0f}ms "
-              f"(includes Client:ClientRead idle time)")
+              f"(captures Client:ClientRead idle time)")
 
 
 def main():
@@ -197,7 +216,7 @@ def main():
 
     print(f"=== test_client_wait (postmaster PID {pm_pid}) ===")
 
-    test_client_read_excluded(pm_pid)
+    test_client_read_visible_but_idle(pm_pid)
 
     print(f"\n{tests_passed}/{tests_run} tests passed")
     sys.exit(0 if tests_failed == 0 else 1)

--- a/tests/test_data_idle.py
+++ b/tests/test_data_idle.py
@@ -4,10 +4,10 @@
 Verifies that Activity (idle) events are excluded from DB Time, AAS,
 top_events, top_sessions, and top_queries.
 
-Client:ClientRead is deliberately NOT idle (see pgwt_is_idle_event in
-src/wait_event.c): it is a real wait event — time spent waiting for the
-client to send the next command — and counts toward DB Time under the
-Client class.
+Client:ClientRead is treated as IDLE for load accounting (see the
+load-vs-visibility split in src/wait_event.c): like Oracle's "SQL*Net
+message from client", it is EXCLUDED from DB Time / AAS. But it is NOT
+hidden — it must still appear in top_events and the timeline.
 """
 import os
 import sys
@@ -25,11 +25,12 @@ def build_scenario():
     """Mix of active and idle events.
 
     PID 1000: IO:Read 5ms (active)
-    PID 1001: Activity:Idle 50ms (should be excluded)
+    PID 1001: Activity:Idle 50ms (idle + hidden — excluded everywhere)
     PID 1002: CPU 3ms (active)
-    PID 1003: Client:ClientRead 20ms (NOT idle — counts toward DB Time)
+    PID 1003: Client:ClientRead 20ms (idle — excluded from DB Time,
+              but still VISIBLE in top_events/timeline)
 
-    Expected DB Time = 5 + 3 + 20 = 28ms (not 78ms)
+    Expected DB Time = 5 + 3 = 8ms (Activity AND ClientRead excluded)
     """
     events = [
         {"pid": 1000, "ts": BASE_TS + 5_000_000, "dur": 5_000_000,
@@ -71,12 +72,12 @@ def main():
             rows = {r["name"]: r for r in resp["rows"]}
 
             print("--- DB Time excludes idle ---")
-            t.check_approx(rows["DB Time"]["ms"], 28.0, 0.001,
-                           "DB Time = 28ms (Activity excluded, ClientRead counted)")
+            t.check_approx(rows["DB Time"]["ms"], 8.0, 0.001,
+                           "DB Time = 8ms (Activity AND ClientRead excluded)")
 
-            # top_events should not contain Activity events, but
-            # Client:ClientRead is a real wait and must be present
-            print("--- top_events excludes idle ---")
+            # top_events must hide Activity events, but Client:ClientRead
+            # stays VISIBLE (idle for load, not hidden from views)
+            print("--- top_events hides Activity, keeps ClientRead ---")
             resp_ev = srv.query("top_events")
             idle_rows = [r for r in resp_ev.get("rows", [])
                          if "Activity" in r.get("name", "")
@@ -86,16 +87,22 @@ def main():
             client_rows = [r for r in resp_ev.get("rows", [])
                            if r.get("name", "") == "Client:ClientRead"]
             t.check(len(client_rows) == 1,
-                    "Client:ClientRead present in top_events (not idle)")
+                    "Client:ClientRead present in top_events (visible)")
 
-            # session_timeline should not show Activity bars
-            print("--- timeline excludes idle ---")
+            # session_timeline must hide Activity bars but KEEP ClientRead
+            print("--- timeline hides Activity, keeps ClientRead ---")
             resp_tl = srv.query("session_timeline")
-            idle_bars = [e for e in resp_tl.get("events", [])
+            tl_events = resp_tl.get("events", [])
+            idle_bars = [e for e in tl_events
                          if "Activity" in e.get("n", "")
                          or "Idle" in e.get("n", "")]
             t.check(len(idle_bars) == 0,
                     f"No Activity bars in timeline (found {len(idle_bars)})")
+            client_bars = [e for e in tl_events
+                           if "ClientRead" in e.get("n", "")]
+            t.check(len(client_bars) >= 1,
+                    f"Client:ClientRead bar present in timeline "
+                    f"(found {len(client_bars)})")
 
     finally:
         cleanup_traces(trace_dir)

--- a/tests/test_wait_event.c
+++ b/tests/test_wait_event.c
@@ -10,7 +10,7 @@
 static int tests_run = 0;
 static int tests_passed = 0;
 
-#define WEI(cls, id) (((uint32_t)(cls) << 24) | (id))
+/* WEI is provided by pg_wait_tracer.h */
 
 #define CHECK(cond, fmt, ...) do { \
     tests_run++; \
@@ -34,6 +34,7 @@ static void test_cpu(void)
     CHECK(strcmp(pgwt_event_name(0), "CPU") == 0,
           "event_name(0) expected CPU");
     CHECK(pgwt_is_idle_event(0) == 0, "CPU should not be idle");
+    CHECK(pgwt_is_hidden_event(0) == 0, "CPU should not be hidden");
 }
 
 static void test_io_events(void)
@@ -52,9 +53,11 @@ static void test_io_events(void)
     /* Class name */
     CHECK(strcmp(pgwt_class_name(WEI(PG_WAIT_IO, 0)), "IO") == 0,
           "class_name for IO");
-    /* Not idle */
+    /* Not idle, not hidden */
     CHECK(pgwt_is_idle_event(WEI(PG_WAIT_IO, 21)) == 0,
           "IO events should not be idle");
+    CHECK(pgwt_is_hidden_event(WEI(PG_WAIT_IO, 21)) == 0,
+          "IO events should not be hidden");
 }
 
 static void test_lock_events(void)
@@ -126,14 +129,19 @@ static void test_client_events(void)
     CHECK_NAME(WEI(PG_WAIT_CLIENT, 8), "Client:WalSenderWriteData");
     CHECK(strcmp(pgwt_class_name(WEI(PG_WAIT_CLIENT, 0)), "Client") == 0,
           "class_name for Client");
-    /* Client:ClientRead is deliberately NOT idle: it is a real wait event
-     * (time waiting for the client's next command) counted under the
-     * Client class — see pgwt_is_idle_event() in src/wait_event.c. */
-    CHECK(pgwt_is_idle_event(WEI(PG_WAIT_CLIENT, 0)) == 0,
-          "Client:ClientRead should NOT be idle");
-    /* Other Client events are NOT idle */
+    /* Client:ClientRead is IDLE for LOAD accounting — excluded from DB
+     * Time / AAS, like Oracle's "SQL*Net message from client" — but it is
+     * NOT hidden: it must remain visible in event lists/graphs. See the
+     * load-vs-visibility split in src/wait_event.c. */
+    CHECK(pgwt_is_idle_event(WEI(PG_WAIT_CLIENT, 0)) == 1,
+          "Client:ClientRead should be idle (excluded from DB Time)");
+    CHECK(pgwt_is_hidden_event(WEI(PG_WAIT_CLIENT, 0)) == 0,
+          "Client:ClientRead should NOT be hidden (stays visible)");
+    /* Other Client events are NOT idle and NOT hidden */
     CHECK(pgwt_is_idle_event(WEI(PG_WAIT_CLIENT, 1)) == 0,
           "Client:ClientWrite should NOT be idle");
+    CHECK(pgwt_is_hidden_event(WEI(PG_WAIT_CLIENT, 1)) == 0,
+          "Client:ClientWrite should NOT be hidden");
 }
 
 static void test_activity_events(void)
@@ -143,11 +151,15 @@ static void test_activity_events(void)
     CHECK_NAME(WEI(PG_WAIT_ACTIVITY, 4),  "Activity:CheckpointerMain");
     CHECK_NAME(WEI(PG_WAIT_ACTIVITY, 6),  "Activity:IoWorkerMain");
     CHECK_NAME(WEI(PG_WAIT_ACTIVITY, 17), "Activity:WalWriterMain");
-    /* Activity events ARE idle */
+    /* Activity events ARE idle AND hidden */
     CHECK(pgwt_is_idle_event(WEI(PG_WAIT_ACTIVITY, 0)) != 0,
           "Activity events should be idle");
     CHECK(pgwt_is_idle_event(WEI(PG_WAIT_ACTIVITY, 4)) != 0,
           "Activity:CheckpointerMain should be idle");
+    CHECK(pgwt_is_hidden_event(WEI(PG_WAIT_ACTIVITY, 0)) != 0,
+          "Activity events should be hidden");
+    CHECK(pgwt_is_hidden_event(WEI(PG_WAIT_ACTIVITY, 4)) != 0,
+          "Activity:CheckpointerMain should be hidden");
     CHECK(strcmp(pgwt_class_name(WEI(PG_WAIT_ACTIVITY, 0)), "Activity") == 0,
           "class_name for Activity");
 }


### PR DESCRIPTION
## What

`Client:ClientRead` is now treated like Oracle's "SQL*Net message from client": it is an **IDLE** wait, **excluded from DB Time / AAS / active load**, but it remains **recorded and VISIBLE** in event lists, graphs, timelines, transitions, and class drill-downs.

Previously ClientRead was counted as real DB Time, which wrongly inflated load whenever a connection sat idle (e.g. idle-in-transaction).

## Why this needed a load-vs-visibility split

`pgwt_is_idle_event()` conflated two different ideas: "excluded from DB Time" AND "hidden from views" (the many `... || pgwt_is_idle_event(...) continue;` filters). Simply marking ClientRead idle would have deleted it from every view — the "empty Client class breakdown" bug that previously forced ClientRead back to not-idle.

So the concept is now split into two predicates:

- `pgwt_is_idle_event(wei)` — **excluded from DB Time / AAS / active load.** Now true for Activity-class **and** `Client:ClientRead` (`WE_CLASS==PG_WAIT_ACTIVITY || wei==WEI(PG_WAIT_CLIENT,0)`).
- `pgwt_is_hidden_event(wei)` — **do not display.** Activity-class **only** (never hides ClientRead).

## Classification approach

Every `pgwt_is_idle_event` call site was read in context and classified:

- **LOAD** (keep `is_idle`, ClientRead excluded): time model / DB Time / idle bucket, AAS (raw + summary), top sessions, top queries, per-query denominators & breakdowns, fingerprints, concurrency, interference, variants, per-PID db_time/wait_time, and the active-session IDLE state.
- **VISIBILITY** (switch to `is_hidden`, ClientRead stays): top_events list (raw + summary), latency heatmap (raw + summary), transition graph + its node totals, session timeline, and the system_event lists.

`top_events` now lists ClientRead but excludes it from the DB Time denominator so `%DB` stays meaningful. The summary fast paths lump ClientRead into the `Client` `class_ns` aggregate, so its per-event/per-query total is subtracted back out and routed to idle in the time-model and AAS summary paths. CPU (`wei==0`) and `PGWT_IS_MARKER` handling are unchanged.

## Tests

- `tests/test_wait_event.c`: `is_idle(ClientRead)==1`, `is_hidden(ClientRead)==0`; Activity idle==1 & hidden==1; CPU/IO neither. (89/89 pass.)
- `tests/test_data_idle.py`: DB Time = 8ms (ClientRead excluded); ClientRead still present in top_events and the timeline. (5/5 pass.)
- `tests/test_client_wait.py`: rewritten to the new contract — ClientRead visible in `system_event`, idle-in-transaction backend does not inflate DB Time, idle time still accounted in the Activity/idle bucket.
- `tests/test_idle_exclusion.py`: unchanged — it only asserted Activity exclusion and a DB Time reconstruction that stays consistent (both sides exclude ClientRead).

All local synthetic data tests and the C unit test pass.

## Live validation

Controlled idle-in-transaction proof on the remote box (Rocky 9 / PG 18) — evidence pasted in a PR comment: `Client:ClientRead` appears in `--view system_event` and in the timeline, while DB Time / AAS are not inflated by the idle backend (the idle time shows in the Activity/idle bucket, excluded from DB Time).

## Follow-up for the UI track

Graphs/timelines should consider visually marking idle ClientRead bars/series distinctly (e.g. muted color or an "idle" legend) so users can tell idle-but-shown waits apart from active load. Not implemented here — flagged as a UI follow-up.
