### PR TITLE
B2: adversarial chaos mode in mock server + race-exposing UI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,13 @@ jobs:
       - name: Run web UI tests (mock server)
         run: python3 tests/test_web_ui.py
 
+      - name: Run web UI chaos tests (adversarial mock — Phase B2)
+        # Drives the UI against mock_server.py in chaos mode (latency jitter,
+        # out-of-order + late responses). Race-exposing tests are classified
+        # gating vs xfail inside the suite, so this stays green; an xfail that
+        # starts passing is reported (XPASS) for promotion, never fatal.
+        run: python3 tests/test_web_ui_chaos.py
+
   protocol-drift:
     name: protocol-drift
     runs-on: ubuntu-latest

--- a/tests/mock_server.py
+++ b/tests/mock_server.py
@@ -12,6 +12,41 @@ The test_web_ui.py injects a script to point the WS at the correct port.
 Usage:
     python3 tests/mock_server.py              # HTTP :18765, WS :18766
     python3 tests/mock_server.py --port 9000  # HTTP :9000,  WS :9001
+
+Chaos mode (Phase B2)
+─────────────────────
+By default the mock answers every request synchronously with zero latency,
+in arrival order.  That is friendly to deterministic assertions but it never
+fires the async races the real network does — which is exactly why CI stays
+green while manual testing keeps finding bugs.
+
+Chaos mode reproduces real network conditions so the race-exposing tests in
+tests/test_web_ui_chaos.py can drive them.  It is OFF unless explicitly
+enabled (so existing tests are unaffected) and DETERMINISTIC: every chaos
+decision is derived from the request's monotonically-increasing index, never
+from wall-clock RNG, so a given action sequence always produces the same
+interleaving.
+
+Enable + tune via env vars (or --chaos on the CLI):
+    PGWT_CHAOS=1            enable chaos (default off)
+    PGWT_CHAOS_MIN_MS=50    min per-response latency  (default 50)
+    PGWT_CHAOS_MAX_MS=300   max per-response latency  (default 300)
+    PGWT_CHAOS_REORDER=1    deliver concurrent in-flight responses shuffled
+                            (default on when chaos is on)
+    PGWT_CHAOS_LATE_EVERY=7 every Nth request is a "late" response that is
+                            delayed far beyond the others, so it lands after
+                            the client has navigated away (0 = never;
+                            default 7)
+    PGWT_CHAOS_LATE_MS=900  extra delay added to a "late" response (default
+                            900, i.e. ~1s after a normal one)
+    PGWT_CHAOS_LATE_CMDS=   comma-separated command names whose responses are
+                            ALWAYS late (e.g. "transitions,heatmap"). Lets a
+                            test deterministically force one view's response
+                            to land after the user has moved on, without
+                            depending on request-index arithmetic. (default:
+                            empty)
+    PGWT_CHAOS_SEED=1337    seed mixed into the deterministic hash (default
+                            1337) — vary only to explore other interleavings
 """
 import asyncio
 import json
@@ -335,7 +370,16 @@ def handle_request(msg):
     if cmd == "session_timeline":
         filters = msg.get("filters", {})
         if "pid" in filters or "query_id" in filters:
-            return {"id": req_id, **_CANNED["session_timeline"]}
+            resp = {"id": req_id, **_CANNED["session_timeline"]}
+            # Protocol-faithful: the real server returns the timeline for the
+            # filtered pid. Reflecting the requested pid into the response also
+            # makes responses request-distinguishable, so a chaos test can
+            # detect a stale (wrong-pid) render overwriting a fresh one.
+            if "pid" in filters:
+                pid = filters["pid"]
+                resp["pids"] = [pid]
+                resp["events"] = [{**e, "p": pid} for e in resp["events"]]
+            return resp
         return {"id": req_id, "events": [], "pids": [], "truncated": False, "total_count": 0}
 
     if cmd == "transitions":
@@ -391,17 +435,133 @@ def handle_request(msg):
     return {"id": req_id, "error": f"unknown command: {cmd}"}
 
 
+# ── Chaos layer ──────────────────────────────────────────────────────────────
+# Reproduces real network conditions (jitter, out-of-order, late responses)
+# without any wall-clock RNG: every decision is a pure function of the
+# request's index, so chaos tests are reproducible.
+
+
+def _env_int(name, default):
+    try:
+        return int(os.environ.get(name, default))
+    except (TypeError, ValueError):
+        return default
+
+
+class ChaosConfig:
+    """Deterministic chaos parameters, read once from env or kwargs."""
+
+    def __init__(self, enabled=None, min_ms=None, max_ms=None, reorder=None,
+                 late_every=None, late_ms=None, seed=None, late_cmds=None):
+        if enabled is None:
+            enabled = os.environ.get("PGWT_CHAOS", "0") not in ("0", "", "false")
+        self.enabled = enabled
+        self.min_ms = min_ms if min_ms is not None else _env_int("PGWT_CHAOS_MIN_MS", 50)
+        self.max_ms = max_ms if max_ms is not None else _env_int("PGWT_CHAOS_MAX_MS", 300)
+        if reorder is None:
+            reorder = os.environ.get("PGWT_CHAOS_REORDER", "1") not in ("0", "", "false")
+        self.reorder = reorder
+        self.late_every = late_every if late_every is not None else _env_int("PGWT_CHAOS_LATE_EVERY", 7)
+        self.late_ms = late_ms if late_ms is not None else _env_int("PGWT_CHAOS_LATE_MS", 900)
+        self.seed = seed if seed is not None else _env_int("PGWT_CHAOS_SEED", 1337)
+        if late_cmds is None:
+            raw = os.environ.get("PGWT_CHAOS_LATE_CMDS", "")
+            late_cmds = [c.strip() for c in raw.split(",") if c.strip()]
+        self.late_cmds = set(late_cmds)
+        if self.max_ms < self.min_ms:
+            self.max_ms = self.min_ms
+
+    def delay_ms(self, index, cmd=None):
+        """Deterministic per-request latency in ms.
+
+        Spreads jitter across [min_ms, max_ms] using a cheap integer hash of
+        the request index — so two requests in flight at once almost always
+        get different delays, producing out-of-order completion. A request is
+        additionally "late" (gets `late_ms` tacked on, so it lands long after
+        the client has moved on — the stale-overwrite race) when either its
+        index hits the late_every cadence or its command is in late_cmds.
+        """
+        if not self.enabled:
+            return 0
+        h = (index * 2654435761 + self.seed * 40503) & 0xFFFFFFFF
+        span = self.max_ms - self.min_ms + 1
+        base = self.min_ms + (h % span)
+        if self.is_late(index, cmd):
+            base += self.late_ms
+        return base
+
+    def is_late(self, index, cmd=None):
+        if not self.enabled:
+            return False
+        if cmd is not None and cmd in self.late_cmds:
+            return True
+        if self.late_every <= 0:
+            return False
+        # index is 1-based per connection; fire on the Nth, 2Nth, ...
+        return index % self.late_every == 0
+
+
 # ── WebSocket server ─────────────────────────────────────────────────────────
 
-async def ws_handler(websocket):
-    async for raw in websocket:
+async def ws_handler(websocket, chaos=None):
+    """Serve one WebSocket connection.
+
+    With chaos disabled this is the original synchronous request/response
+    loop. With chaos enabled, each request is answered by an independent
+    asyncio task whose send is delayed by ChaosConfig.delay_ms() — so
+    responses to concurrent in-flight requests naturally complete out of
+    order, and "late" requests land well after newer ones (and after the
+    client has navigated away). A per-connection asyncio.Lock keeps the
+    actual websocket.send() calls from interleaving on the wire.
+    """
+    if chaos is None:
+        chaos = ChaosConfig()
+
+    if not chaos.enabled:
+        async for raw in websocket:
+            try:
+                msg = json.loads(raw)
+                resp = handle_request(msg)
+                await websocket.send(json.dumps(resp))
+            except Exception as e:
+                err = {"id": 0, "error": str(e)}
+                await websocket.send(json.dumps(err))
+        return
+
+    send_lock = asyncio.Lock()
+    tasks = set()
+    req_index = 0
+
+    async def respond(raw, index):
         try:
-            msg = json.loads(raw)
-            resp = handle_request(msg)
-            await websocket.send(json.dumps(resp))
-        except Exception as e:
-            err = {"id": 0, "error": str(e)}
-            await websocket.send(json.dumps(err))
+            cmd = None
+            try:
+                msg = json.loads(raw)
+                cmd = msg.get("cmd")
+                resp = handle_request(msg)
+            except Exception as e:
+                resp = {"id": 0, "error": str(e)}
+            delay = chaos.delay_ms(index, cmd)
+            if delay:
+                await asyncio.sleep(delay / 1000.0)
+            async with send_lock:
+                try:
+                    await websocket.send(json.dumps(resp))
+                except Exception:
+                    pass  # connection closed while a delayed response waited
+        except asyncio.CancelledError:
+            pass
+
+    try:
+        async for raw in websocket:
+            req_index += 1
+            t = asyncio.ensure_future(respond(raw, req_index))
+            tasks.add(t)
+            t.add_done_callback(tasks.discard)
+    finally:
+        # Connection closed: drop any responses still waiting out their delay.
+        for t in list(tasks):
+            t.cancel()
 
 
 # ── HTTP server ──────────────────────────────────────────────────────────────
@@ -421,9 +581,11 @@ def run_http(port):
 
 # ── Main ─────────────────────────────────────────────────────────────────────
 
-async def run_ws(port):
+async def run_ws(port, chaos):
+    async def handler(ws):
+        await ws_handler(ws, chaos)
     async with websockets.asyncio.server.serve(
-        ws_handler, "127.0.0.1", port,
+        handler, "127.0.0.1", port,
         origins=None,
     ):
         await asyncio.Future()
@@ -437,7 +599,12 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--port", type=int, default=18765,
                         help="HTTP port (WS = port+1)")
+    parser.add_argument("--chaos", action="store_true",
+                        help="enable chaos mode (jitter / out-of-order / "
+                             "late responses); also via PGWT_CHAOS=1")
     args = parser.parse_args()
+
+    chaos = ChaosConfig(enabled=True) if args.chaos else ChaosConfig()
 
     http_port = args.port
     ws_port = args.port + 1
@@ -446,12 +613,17 @@ def main():
     http_thread = threading.Thread(target=run_http, args=(http_port,), daemon=True)
     http_thread.start()
 
+    mode = "CHAOS" if chaos.enabled else "normal"
     print(f"mock_server: HTTP http://127.0.0.1:{http_port}, "
-          f"WS ws://127.0.0.1:{ws_port}", flush=True)
+          f"WS ws://127.0.0.1:{ws_port} [{mode}]", flush=True)
+    if chaos.enabled:
+        print(f"mock_server: chaos latency {chaos.min_ms}-{chaos.max_ms}ms, "
+              f"reorder={chaos.reorder}, late_every={chaos.late_every} "
+              f"(+{chaos.late_ms}ms), seed={chaos.seed}", flush=True)
 
     # WS in asyncio
     try:
-        asyncio.run(run_ws(ws_port))
+        asyncio.run(run_ws(ws_port, chaos))
     except KeyboardInterrupt:
         pass
 

--- a/tests/run_all.sh
+++ b/tests/run_all.sh
@@ -178,13 +178,20 @@ fi
 # Step 5: Web UI tests (needs playwright + websockets, no root needed)
 # Locally a missing dependency is a skip; in CI ($CI set) it is a FAILURE —
 # the UI suite silently not running is how regressions slip through.
+# test_web_ui_chaos runs the same UI against mock_server.py in CHAOS mode
+# (latency jitter / out-of-order / late responses) — its race-exposing tests
+# are classified gating vs xfail internally, so it stays CI-green either way.
 if python3 -c "import playwright, websockets" 2>/dev/null; then
     run_test "test_web_ui" python3 "$SCRIPT_DIR/test_web_ui.py"
+    run_test "test_web_ui_chaos" python3 "$SCRIPT_DIR/test_web_ui_chaos.py"
 elif [[ -n "${CI:-}" ]]; then
     run_test "test_web_ui" bash -c \
         'echo "ERROR: playwright/websockets not installed — required in CI"; exit 1'
+    run_test "test_web_ui_chaos" bash -c \
+        'echo "ERROR: playwright/websockets not installed — required in CI"; exit 1'
 else
     skip_test "test_web_ui" "playwright or websockets not installed"
+    skip_test "test_web_ui_chaos" "playwright or websockets not installed"
 fi
 
 # Summary

--- a/tests/test_web_ui_chaos.py
+++ b/tests/test_web_ui_chaos.py
@@ -1,0 +1,550 @@
+#!/usr/bin/env python3
+"""test_web_ui_chaos.py -- Adversarial / chaos UI tests (Phase B2).
+
+The web UI's instability is async races that NEVER fire against the
+zero-latency mock (tests/mock_server.py) — which is why CI is green while
+manual testing keeps finding bugs. This suite runs the mock in CHAOS mode
+(latency jitter, out-of-order delivery, late-after-navigation responses,
+see mock_server.py) and replicates the manual-testing actions that surface
+those races:
+
+  - rapid tab switching (switch faster than responses arrive)
+  - clicking a drill-down row before its data has loaded
+  - toggling Live mode on/off mid-refresh
+  - drag-zoom on the AAS chart during an in-flight refresh
+
+Every test asserts ZERO console errors / pageerrors / unhandled rejections
+(reusing B1's console guard) AND a correct, self-consistent FINAL state.
+
+══════════════════════════════════════════════════════════════════════════
+XFAIL infrastructure + the B3 acceptance list
+══════════════════════════════════════════════════════════════════════════
+Phase B2's premise is that these tests expose races that the Phase B3
+restructure (view-manager response chokepoint + transport single-flight)
+will fix. To keep CI green regardless of outcome, every chaos test is
+classified at registration time as either:
+
+  GATING  — must pass; a failure fails the suite (CI red).
+  XFAIL   — a known B3 target: expected to fail today; its failure is
+            reported as "XFAIL (B3 will fix)" and does NOT fail the suite.
+            An XFAIL test that unexpectedly PASSES is reported as XPASS
+            (surfaced loudly, non-fatal) so it can be promoted to GATING.
+
+The XFAIL machinery is retained as required B2 infrastructure so B3 (or any
+future view) can register a genuinely-failing race here without turning CI
+red. It also self-corrects: an XPASS print is the signal to promote.
+
+FINDING (2026-06-14, this PR): against the CURRENT app.js, all four
+race-exposing tests PASS under genuine chaos (verified out-of-order + late
+delivery + a 40-action soak — zero console errors). app.js's global
+generation counter (_refreshGen, bumped on every user-initiated view change
+and re-checked before every heavy renderer dispatches) correctly supersedes
+stale in-flight responses at the OBSERVABLE level. So these are registered
+as GATING: they lock in that behavior as a regression guard B3 must keep
+green while it replaces the ad-hoc generation counters with the structural
+view-manager/transport chokepoint. The B3 acceptance list is therefore
+"these four chaos tests stay green through the restructure."
+
+The documented races (symptom → root cause → what B3 changes) live next to
+each test below.
+
+Usage: python3 tests/test_web_ui_chaos.py
+  (No root, no PG, no SSH needed — uses mock_server.py with PGWT_CHAOS=1)
+"""
+import os
+import sys
+import subprocess
+import time
+import signal
+
+try:
+    from playwright.sync_api import sync_playwright
+except ImportError:
+    # Match test_web_ui.py: a skip locally, a hard failure in CI.
+    if os.environ.get("CI"):
+        print("ERROR: playwright not installed — required in CI", file=sys.stderr)
+        sys.exit(1)
+    print("SKIP: pip install playwright && playwright install chromium",
+          file=sys.stderr)
+    sys.exit(0)
+
+# Reuse a distinct port so this can run alongside test_web_ui.py.
+MOCK_PORT = int(os.environ.get("PGWT_TEST_PORT", "18811"))
+MOCK_URL = f"http://127.0.0.1:{MOCK_PORT}"
+MOCK_SCRIPT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "mock_server.py")
+
+# ── Result accounting ─────────────────────────────────────────────────────────
+# Gating tests fail the suite. XFAIL tests (the B3 targets) report their
+# status but never fail the suite, so CI stays green.
+
+gating_checks = []   # (ok, msg)
+xfail_results = {}    # test_name -> {"failed": bool, "msgs": [...]}
+
+_current_xfail = None  # set while an xfail test runs
+
+
+def check(cond, msg):
+    """Record a check. Inside an xfail test it feeds that test's tally;
+    otherwise it is a gating check that can fail the suite."""
+    if _current_xfail is not None:
+        rec = xfail_results[_current_xfail]
+        if not cond:
+            rec["failed"] = True
+            rec["msgs"].append(msg)
+            print(f"  xfail-check FAIL: {msg}")
+        else:
+            print(f"  xfail-check ok:   {msg}")
+    else:
+        gating_checks.append((cond, msg))
+        print(f"  {'PASS' if cond else 'FAIL'}: {msg}")
+
+
+# ── Console error guard (Phase B1, reused) ────────────────────────────────────
+
+UNHANDLED_REJECTION_HOOK = """
+window.addEventListener('unhandledrejection', e => {
+    const r = e.reason;
+    console.error('Unhandled rejection: ' +
+        ((r && (r.stack || r.message)) || String(r)));
+});
+"""
+
+
+class ConsoleErrorGuard:
+    def __init__(self, page):
+        self.errors = []
+        page.on("console", self._on_console)
+        page.on("pageerror", self._on_pageerror)
+
+    def _on_console(self, msg):
+        if msg.type == "error":
+            self.errors.append(f"console: {msg.text}")
+
+    def _on_pageerror(self, err):
+        self.errors.append(f"pageerror: {err}")
+
+    def drain(self):
+        errors = self.errors
+        self.errors = []
+        return errors
+
+
+def assert_no_console_errors(page, guard, name, allow=()):
+    page.wait_for_timeout(1200)  # chaos delays are long; let late errors land
+    errors = guard.drain()
+    unexpected = [e for e in errors if not any(p in e for p in allow)]
+    check(len(unexpected) == 0,
+          f"[{name}] no console errors "
+          f"(got {len(unexpected)}: {unexpected[:3]})")
+
+
+# ── Mock server (chaos mode) ──────────────────────────────────────────────────
+
+def start_mock_server():
+    env = dict(os.environ)
+    env["PGWT_CHAOS"] = "1"  # belt-and-suspenders alongside --chaos
+    proc = subprocess.Popen(
+        [sys.executable, MOCK_SCRIPT, "--port", str(MOCK_PORT), "--chaos"],
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env,
+    )
+    time.sleep(1.5)
+    if proc.poll() is not None:
+        out, err = proc.communicate()
+        print(f"mock_server failed to start:\n{out.decode()}\n{err.decode()}")
+        sys.exit(1)
+    return proc
+
+
+def stop_mock_server(proc):
+    proc.send_signal(signal.SIGTERM)
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait()
+
+
+def goto_ready(page):
+    """Load the page and wait until the first data is on screen."""
+    page.goto(MOCK_URL)
+    page.wait_for_selector("#status.connected", timeout=15000)
+    # Under chaos the first table/chart can take a while.
+    page.wait_for_selector("#table-container table tbody tr, .loading",
+                           timeout=15000)
+
+
+def active_tab(page):
+    el = page.query_selector(".tab.active")
+    return el.text_content() if el else None
+
+
+# ── Tests ─────────────────────────────────────────────────────────────────────
+# Each test fixes the FINAL action, lets chaos settle, then asserts the UI
+# reflects that final action — not a stale in-flight response.
+
+def test_rapid_tab_switching(page):
+    """RACE: stale tab response overwrites the current tab's content.
+
+    Symptom (manual): switch rapidly *through* the heavy analysis tabs
+    (Histogram / Timeline / Transitions) and land on Events faster than the
+    chaos-delayed responses arrive. A late response for an earlier tab paints
+    its own widget into #table-container while Events is the active tab — e.g.
+    a heatmap container or a "Select a session" timeline prompt shows up under
+    the Events tab header, or the Events table never appears.
+
+    Root cause: refreshTable()'s plain-table branch checks `_refreshGen`, but
+    the histogram/timeline/transitions/concurrency branches (refreshHistogram,
+    refreshTimeline, refreshTransitions, refreshConcurrency) write into
+    #table-container with NO generation re-check after their awaits — so a
+    superseded heavy-tab response still renders over the active tab. B3's
+    view-manager makes "drop any response addressed to a non-active view"
+    structural.
+    """
+    goto_ready(page)
+    # Stop live so auto-refresh ticks don't muddy the final-state assertion.
+    page.click("#live-btn")
+    page.wait_for_timeout(200)
+
+    # Go through the heavy tabs (each kicks an async render into the shared
+    # #table-container), then land on Events — all faster than chaos latency.
+    order = ["histogram", "timeline", "transitions", "events"]
+    for tab in order:
+        page.click(f".tab[data-tab='{tab}']")
+        page.wait_for_timeout(50)  # faster than the 50-300ms chaos latency
+
+    # Let every in-flight (and late) response drain.
+    page.wait_for_timeout(4000)
+
+    check(active_tab(page) == "Events",
+          f"final active tab is Events (got {active_tab(page)})")
+
+    # Under the race a stale heavy-tab renderer wins #table-container.
+    # The Events tab must own the container exclusively: its table present,
+    # and none of the other tabs' signature widgets leaking in.
+    headers = [th.text_content().strip() for th in
+               page.query_selector_all("#table-container table thead th")]
+    check("Wait Event" in headers,
+          f"final container holds the Events table (headers={headers[:4]})")
+
+    leaked = page.evaluate("""() => {
+        const c = document.getElementById('table-container');
+        const t = c ? c.textContent : '';
+        return {
+            heatmap: !!(c && c.querySelector('#heatmap-container')),
+            timelinePrompt: t.includes('Select a session'),
+            dfg: !!(c && c.querySelector('#dfg-container')),
+        };
+    }""")
+    check(not leaked["heatmap"],
+          "no stale heatmap container leaked under Events tab")
+    check(not leaked["timelinePrompt"],
+          "no stale timeline prompt leaked under Events tab")
+    check(not leaked["dfg"],
+          "no stale transitions DFG leaked under Events tab")
+
+
+def test_click_drilldown_before_load(page):
+    """RACE: a second drill-down click before the first one's data loaded.
+
+    Symptom (manual): in Sessions, click a row to drill into Timeline for PID
+    A; the chaos-delayed session_timeline response for A is still in flight.
+    Before it lands, drill back and click PID B. The late timeline render for
+    A then paints over PID B's timeline — the chart shows the wrong session,
+    while the breadcrumb says PID B.
+
+    Root cause: refreshTimeline() awaits session_timeline then calls
+    renderTimeline() with NO generation re-check, so a superseded drill's
+    response still renders. drillDown() bumps the generation for the table
+    path but the timeline branch ignores it. B3's single-flight transport +
+    view-manager supersede the pending request on the second drill.
+    """
+    goto_ready(page)
+    page.click("#live-btn")
+    page.wait_for_timeout(200)
+
+    page.click(".tab[data-tab='sessions']")
+    page.wait_for_selector("#table-container table tbody tr.clickable",
+                           timeout=15000)
+    page.wait_for_timeout(2500)  # let sessions settle so rows are stable
+
+    rows = page.query_selector_all("#table-container table tbody tr.clickable")
+    check(len(rows) >= 2, f"have >=2 session rows to drill ({len(rows)})")
+    pid_a = page.text_content(
+        "#table-container table tbody tr:nth-child(1) td:first-child").strip()
+    pid_b = page.text_content(
+        "#table-container table tbody tr:nth-child(2) td:first-child").strip()
+
+    # Drill into PID A, then — before its timeline can load — go back and
+    # drill into PID B.
+    rows[0].click()                       # -> Timeline, pid A in flight
+    page.wait_for_timeout(40)             # < chaos latency: A not back yet
+    page.click(".tab[data-tab='sessions']")
+    page.wait_for_selector("#table-container table tbody tr.clickable",
+                           timeout=15000)
+    rows = page.query_selector_all("#table-container table tbody tr.clickable")
+    rows[1].click()                       # -> Timeline, pid B
+
+    page.wait_for_timeout(4000)           # drain the late PID-A response
+
+    check(active_tab(page) == "Timeline",
+          f"drill lands on Timeline (got {active_tab(page)})")
+
+    breadcrumb = page.text_content("#breadcrumb") or ""
+    check(pid_b in breadcrumb,
+          f"breadcrumb shows the final drill (PID {pid_b}); got "
+          f"'{breadcrumb.strip()[:50]}'")
+
+    # The breadcrumb (final drill = PID B) must agree with the timeline the
+    # chart actually rendered. The mock reflects the requested pid into the
+    # response's `pids` (→ y-axis category), so a stale PID-A render is visible
+    # as a "PID A" axis label under a "PID B" breadcrumb. That is the race.
+    axis_pids = page.evaluate("""() => {
+        const el = document.getElementById('timeline-chart');
+        if (!el || typeof echarts === 'undefined') return null;
+        const c = echarts.getInstanceByDom(el);
+        if (!c) return null;
+        const opt = c.getOption();
+        const yAxis = opt && opt.yAxis && opt.yAxis[0];
+        return (yAxis && yAxis.data) ? yAxis.data : null;
+    }""")
+    check(axis_pids is not None and any(pid_b in s for s in axis_pids),
+          f"timeline chart renders the final drill PID {pid_b} "
+          f"(y-axis={axis_pids})")
+    check(axis_pids is not None and not any(pid_a in s for s in axis_pids),
+          f"timeline chart does NOT show the stale PID {pid_a} "
+          f"(y-axis={axis_pids})")
+
+
+def test_toggle_live_mid_refresh(page):
+    """RACE: Live toggled off mid-refresh, then a stale tick moves the window.
+
+    Symptom (manual): zoom into a specific historical window, toggle Live on
+    (auto-refresh starts) then immediately off, then zoom into another window.
+    A stale auto-refresh tick from the just-stopped loop — whose refresh() is
+    NOT user-initiated and whose response can still be in flight — repaints
+    the chart and, worse, the loop has already overwritten state.viewFrom/To
+    with the live "last N min" window, so the user's chosen window jumps.
+
+    Root cause: stopAutoRefresh() invalidates the loop by id, but a tick that
+    has already passed its id-check and is awaiting send('info')/refresh() will
+    still run to completion; refresh() inside the loop is not user-initiated so
+    it does not bump the generation and is not discarded. The final view
+    window must be the user's last explicit zoom, not the live window.
+    """
+    goto_ready(page)
+    # Start from a stopped, explicit custom window so "live" vs "frozen" is
+    # unambiguous.
+    page.click("#live-btn")          # stop the default live loop
+    page.wait_for_timeout(200)
+
+    # Pick a fixed historical window via the time picker "All" range.
+    page.click("#time-range")
+    page.wait_for_timeout(150)
+    page.click(".tp-quick button[data-range='0']")  # All -> frozen
+    page.wait_for_timeout(2500)
+
+    target = page.evaluate("() => [state.viewFrom, state.viewTo]")
+
+    # Toggle Live on then off rapidly so an auto-refresh tick is mid-flight
+    # when we stop, then re-assert the frozen window.
+    page.click("#live-btn")          # live ON  (loop starts, ticks every 5s
+                                     #           but its first refresh runs now)
+    page.wait_for_timeout(80)        # < chaos latency: refresh in flight
+    page.click("#live-btn")          # live OFF (mid-flight)
+    page.wait_for_timeout(150)
+    # Reassert the user's frozen window explicitly.
+    page.click("#time-range")
+    page.wait_for_timeout(150)
+    page.click(".tp-quick button[data-range='0']")
+    page.wait_for_timeout(4000)      # let any stale tick land
+
+    is_active = page.evaluate(
+        "document.getElementById('live-btn').classList.contains('active')")
+    check(is_active is False,
+          f"Live button is off after final toggle (active={is_active})")
+
+    label = page.text_content("#live-btn") or ""
+    check(("●" in label) == bool(is_active),
+          f"Live label/class consistent (label='{label}', active={is_active})")
+
+    final = page.evaluate("() => [state.viewFrom, state.viewTo]")
+    # A stale live tick would shove the window to (serverNow - N, serverNow).
+    # The frozen "All" window must survive.
+    check(final == target,
+          f"view window stayed frozen (target={target}, final={final})")
+
+
+def test_dragzoom_during_refresh(page):
+    """RACE: drag-zoom on the AAS chart while a refresh is in flight.
+
+    Symptom (manual): start a drag-select zoom on the ApexCharts AAS chart
+    while a chaos-delayed aas response is still pending. The pending response
+    repaints the chart out from under the active selection, the zoom maps to
+    the wrong time range, or the chart instance is mutated mid-render.
+
+    Root cause: renderApexChart() reuses a module-level chart instance with no
+    coordination against beforeZoom -> zoomTo -> refresh(true); responses are
+    gen-guarded but the chart object itself is shared mutable state. B3 moves
+    drag-select to a custom overlay owned by the view's enter/leave.
+    """
+    goto_ready(page)
+    page.click("#live-btn")
+    page.wait_for_timeout(200)
+
+    # Kick a refresh (zoom out) so an aas request is in flight, then
+    # immediately drag-select across the chart.
+    box = page.query_selector("#apex-chart-container").bounding_box()
+    page.click("#zoom-out-btn")
+    page.wait_for_timeout(40)  # response not back yet (chaos >= 50ms)
+
+    y = box["y"] + box["height"] / 2
+    x1 = box["x"] + box["width"] * 0.30
+    x2 = box["x"] + box["width"] * 0.70
+    page.mouse.move(x1, y)
+    page.mouse.down()
+    page.mouse.move(x1 + 20, y)
+    page.mouse.move(x2, y)
+    page.mouse.up()
+
+    page.wait_for_timeout(3500)  # let zoom + late responses settle
+
+    # The chart must still be a live, rendered ApexCharts SVG with series.
+    svg = page.query_selector("#apex-chart-container svg")
+    check(svg is not None, "AAS chart SVG still present after drag-zoom")
+    series_paths = page.query_selector_all(
+        "#apex-chart-container .apexcharts-series path")
+    check(len(series_paths) > 0,
+          f"AAS chart still has series paths ({len(series_paths)})")
+
+    # Time range and view window must be self-consistent (from < to).
+    consistent = page.evaluate(
+        "() => (typeof state !== 'undefined') && state.viewFrom < state.viewTo")
+    check(consistent is True,
+          "view window self-consistent (viewFrom < viewTo) after drag-zoom")
+
+
+# ── Registry ──────────────────────────────────────────────────────────────────
+# Tests are registered as either gating (must pass) or xfail (B3 targets:
+# expected to fail today, reported but non-fatal). If an xfail test starts
+# passing, it is reported as XPASS so it can be promoted to gating.
+
+# All four pass against current app.js (see FINDING in the module docstring),
+# so they are GATING regression guards. If B3's restructure regresses any,
+# move it to XFAIL_TESTS with a note rather than weakening the assertion.
+GATING_TESTS = [
+    test_rapid_tab_switching,
+    test_click_drilldown_before_load,
+    test_toggle_live_mid_refresh,
+    test_dragzoom_during_refresh,
+]
+
+# B3 acceptance list: race-exposing tests that fail against current code.
+# Currently empty — every chaos test above passes today. Retained (with the
+# XFAIL machinery in main()) so a genuinely-failing race can be registered
+# here without turning CI red.
+XFAIL_TESTS = [
+    # (test_fn, "symptom — root cause (B3 will fix)"),
+]
+
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+
+def main():
+    global _current_xfail
+    print("=== test_web_ui_chaos (Phase B2 — chaos mode) ===")
+
+    mock_proc = start_mock_server()
+    xpass = []  # xfail tests that unexpectedly passed (promote to gating)
+
+    try:
+        with sync_playwright() as p:
+            browser = p.chromium.launch(headless=True)
+            context = browser.new_context(
+                viewport={"width": 1280, "height": 900})
+
+            ws_port = MOCK_PORT + 1
+            context.add_init_script(f"""(function() {{
+                const _WS = window.WebSocket;
+                window.WebSocket = function(url, protocols) {{
+                    url = url.replace(':{MOCK_PORT}/', ':{ws_port}/');
+                    if (protocols !== undefined) return new _WS(url, protocols);
+                    return new _WS(url);
+                }};
+                window.WebSocket.prototype = _WS.prototype;
+                window.WebSocket.CONNECTING = _WS.CONNECTING;
+                window.WebSocket.OPEN = _WS.OPEN;
+                window.WebSocket.CLOSING = _WS.CLOSING;
+                window.WebSocket.CLOSED = _WS.CLOSED;
+            }})();""")
+            context.add_init_script(UNHANDLED_REJECTION_HOOK)
+
+            page = context.new_page()
+            guard = ConsoleErrorGuard(page)
+
+            # Gating chaos tests (none yet — kept for promoted xpasses).
+            for fn in GATING_TESTS:
+                print(f"\n--- [gating] {fn.__name__} ---")
+                fn(page)
+                assert_no_console_errors(page, guard, fn.__name__)
+
+            # XFAIL chaos tests (the B3 acceptance list).
+            for fn, desc in XFAIL_TESTS:
+                name = fn.__name__
+                print(f"\n--- [xfail] {name} — {desc} ---")
+                xfail_results[name] = {"failed": False, "msgs": []}
+                _current_xfail = name
+                try:
+                    fn(page)
+                    assert_no_console_errors(page, guard, name)
+                except Exception as e:
+                    xfail_results[name]["failed"] = True
+                    xfail_results[name]["msgs"].append(f"exception: {e}")
+                    print(f"  xfail-check FAIL: exception: {e}")
+                finally:
+                    _current_xfail = None
+                rec = xfail_results[name]
+                if rec["failed"]:
+                    print(f"  -> XFAIL (expected, B3 will fix): {desc}")
+                else:
+                    print(f"  -> XPASS (unexpected pass — promote to gating!)")
+                    xpass.append(name)
+
+            browser.close()
+    finally:
+        stop_mock_server(mock_proc)
+
+    # ── Summary ──────────────────────────────────────────────────────────────
+    print("\n" + "=" * 60)
+    print("  CHAOS SUITE SUMMARY")
+    print("=" * 60)
+
+    gating_failed = [m for ok, m in gating_checks if not ok]
+    gating_passed = len(gating_checks) - len(gating_failed)
+    print(f"  Gating checks: {gating_passed}/{len(gating_checks)} passed")
+    for m in gating_failed:
+        print(f"    GATING FAIL: {m}")
+
+    xfailed = [n for n, r in xfail_results.items() if r["failed"]]
+    print(f"\n  XFAIL (B3 acceptance list) — {len(xfailed)} failing as expected:")
+    for fn, desc in XFAIL_TESTS:
+        n = fn.__name__
+        status = "XFAIL" if xfail_results[n]["failed"] else "XPASS"
+        print(f"    [{status}] {n}: {desc}")
+
+    if xpass:
+        print(f"\n  NOTE: {len(xpass)} xfail test(s) PASSED unexpectedly "
+              f"(XPASS) — promote to gating:")
+        for n in xpass:
+            print(f"    {n}")
+
+    # CI stays green: only GATING failures are fatal. XFAIL/XPASS are not.
+    print("")
+    if gating_failed:
+        print("RESULT: FAIL (gating checks failed)")
+        sys.exit(1)
+    print("RESULT: PASS (xfail races documented for B3; CI green)")
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Phase B2 — adversarial / chaos mock + race-exposing UI tests

The web UI's instability is async races that never fire against the
zero-latency mock, which is why CI is green while manual testing keeps
finding bugs. B2 makes the mock adversarial and adds tests that replicate
the manual-testing actions which expose those races — all under chaos mode,
all asserting zero console errors and a correct final state.

### Chaos mechanisms added (`tests/mock_server.py`)

Off by default (existing tests unaffected); enabled with `--chaos` or
`PGWT_CHAOS=1`. Fully **deterministic** — every chaos decision is a pure
function of the request's per-connection index plus a fixed seed, no
wall-clock RNG, so a given action sequence always produces the same
interleaving.

- **Latency jitter** — each response delayed `PGWT_CHAOS_MIN_MS`..`MAX_MS`
  (default 50–300 ms), spread by an integer hash of the request index so two
  in-flight requests almost always get different delays.
- **Out-of-order delivery** — responses are sent from independent asyncio
  tasks, so concurrent in-flight requests complete in delay order, not
  arrival order (verified: e.g. ids arrive `9,2,4,6,8,1,3,...`).
- **Late-after-navigation** — every Nth request (`PGWT_CHAOS_LATE_EVERY`,
  default 7), or any command in `PGWT_CHAOS_LATE_CMDS`, gets
  `PGWT_CHAOS_LATE_MS` (default 900 ms) tacked on, so it lands long after the
  client has moved on — the classic stale-response-overwrites-fresh-data
  race. Responses still pending when the socket closes are cancelled.

Also: `session_timeline` now reflects the requested pid into its response
(protocol-faithful, schema-compatible — protocol-drift stays green), so a
stale wrong-pid render is actually detectable by a test.

### Race-exposing tests (`tests/test_web_ui_chaos.py`, Playwright)

All under chaos mode, all reuse B1's console-error guard (zero console
errors / pageerrors / unhandled rejections), all assert a correct,
request-distinguishable FINAL state:

1. **Rapid tab switching** through the heavy analysis tabs, landing on
   Events faster than responses arrive — asserts no stale heatmap / timeline
   prompt / DFG leaks under the Events tab.
2. **Drill-down click before load** — drill PID A, then PID B before A's
   timeline loads — asserts the chart renders the final drill (PID B axis),
   not the stale PID A.
3. **Toggle Live mid-refresh** — freeze a window, toggle Live on/off with a
   refresh in flight, re-freeze — asserts the window stays frozen (no stale
   live tick shoves it to "last N min") and the button label/class agree.
4. **Drag-zoom during in-flight refresh** — kick a refresh, drag-select on
   the AAS chart before it returns — asserts the chart stays rendered and the
   view window stays self-consistent.

### XFAIL machinery + the B3 acceptance list

Every chaos test is classified at registration as **gating** (failure fails
CI) or **xfail** (a known B3 target: failure reported but non-fatal; an
xfail that starts passing is flagged **XPASS** for promotion). The xfail
infrastructure is retained as required B2 scaffolding so B3 (or any future
view) can register a genuinely-failing race without turning CI red.

**Finding:** against the current `app.js`, all four race-exposing tests
**PASS** under genuine chaos (verified out-of-order + late delivery, plus a
40-action soak — zero console errors). `app.js`'s global generation counter
(`_refreshGen`, bumped on every user-initiated view change and re-checked
before every heavy renderer dispatches) correctly supersedes stale in-flight
responses at the observable level. Per the phase instructions ("if any chaos
test passes against current code, leave it as a gating test"), all four are
registered **gating**.

So the B3 acceptance list inverts: **these four chaos tests must stay green
through the B3 restructure** as it replaces the ad-hoc generation counters
with the structural view-manager response chokepoint + transport
single-flight. `XFAIL_TESTS` is currently empty; the machinery stands ready
if B3 surfaces a regression mid-migration.

| chaos test | classification today |
| --- | --- |
| `test_rapid_tab_switching` | gating (passes) |
| `test_click_drilldown_before_load` | gating (passes) |
| `test_toggle_live_mid_refresh` | gating (passes) |
| `test_dragzoom_during_refresh` | gating (passes) |

### CI / run_all wiring

Added `test_web_ui_chaos` to the web-ui CI job and `run_all.sh` alongside
`test_web_ui`, with the same CI-fails-on-missing-playwright behavior. No
root/PG/BPF needed — mock + Playwright only.

### Local validation

- `test_web_ui_chaos.py` — 20/20 gating checks pass.
- `test_web_ui.py` — 146/146 (unchanged; chaos off by default).
- `test_protocol_drift.py` — 48/48 (session_timeline change is
  schema-compatible).

### Notes for B3

- The races are real in production (different windows/filters → different
  data); the mock now makes at least the pid case observable. When B3 lands,
  watch that these four stay green as the generation counters are removed.
- If B3 needs to register a temporarily-failing race during the per-view
  migration, move the test into `XFAIL_TESTS` with a one-line symptom →
  root-cause note rather than weakening the assertion.
- `PGWT_CHAOS_LATE_CMDS` is the knob to deterministically force a specific
  view's response to arrive stale — useful for targeting a single view's
  migration.
