### PR TITLE
A1: trace format v2 — typed transition/sample blocks (v2-only)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,7 @@ jobs:
           tests/test_bucket
           tests/test_event_writer
           tests/test_event_reader
+          tests/test_trace_v2
 
       - name: Run synthetic data tests
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ tests/test_cmdline
 tests/test_bucket
 tests/test_event_writer
 tests/test_event_reader
+tests/test_trace_v2
 tests/gen_test_traces
 tests/gen_bench_traces
 tests/__pycache__/

--- a/src/event_reader.c
+++ b/src/event_reader.c
@@ -38,8 +38,13 @@ int pgwt_reader_open(struct pgwt_event_reader *r, const char *path)
         return -1;
     }
     if (r->header.version != PGWT_TRACE_VERSION) {
-        fprintf(stderr, "WARN: unsupported version %d in %s\n",
-                r->header.version, path);
+        /* v2-only: no v1 compatibility (no deployed installs existed).
+         * A version mismatch is a clear, non-fatal-to-the-process error —
+         * the file is simply skipped — never a crash on a stale layout. */
+        fprintf(stderr,
+                "ERROR: unsupported trace version %u in %s "
+                "(this build reads version %u only; regenerate with this build)\n",
+                r->header.version, path, PGWT_TRACE_VERSION);
         fclose(r->fp); r->fp = NULL;
         return -1;
     }
@@ -187,8 +192,33 @@ void pgwt_reader_close(struct pgwt_event_reader *r)
     free(r->decode_buf); r->decode_buf = NULL;
 }
 
+int pgwt_reader_block_info(struct pgwt_event_reader *r, int block_idx,
+                           struct pgwt_block_info *info)
+{
+    if (block_idx < 0 || block_idx >= r->num_blocks || !r->fp || !info)
+        return -1;
+
+    fseek(r->fp, (long)r->block_index[block_idx].file_offset, SEEK_SET);
+    struct pgwt_trace_block_header bh;
+    if (fread(&bh, sizeof(bh), 1, r->fp) != 1)
+        return -1;
+
+    info->block_type        = (enum pgwt_block_type)bh.block_type;
+    info->sample_period_ns  = bh.sample_period_ns;
+    info->first_timestamp_ns = bh.first_timestamp_ns;
+    info->last_timestamp_ns  = bh.last_timestamp_ns;
+    return 0;
+}
+
 int pgwt_reader_decode_block(struct pgwt_event_reader *r, int block_idx,
                               struct pgwt_trace_event *out, int max_events)
+{
+    return pgwt_reader_decode_block_info(r, block_idx, out, max_events, NULL);
+}
+
+int pgwt_reader_decode_block_info(struct pgwt_event_reader *r, int block_idx,
+                                   struct pgwt_trace_event *out, int max_events,
+                                   struct pgwt_block_info *info)
 {
     if (block_idx < 0 || block_idx >= r->num_blocks || !r->fp)
         return -1;
@@ -199,6 +229,14 @@ int pgwt_reader_decode_block(struct pgwt_event_reader *r, int block_idx,
     struct pgwt_trace_block_header bh;
     if (fread(&bh, sizeof(bh), 1, r->fp) != 1)
         return -1;
+
+    enum pgwt_block_type block_type = (enum pgwt_block_type)bh.block_type;
+    if (info) {
+        info->block_type        = block_type;
+        info->sample_period_ns  = bh.sample_period_ns;
+        info->first_timestamp_ns = bh.first_timestamp_ns;
+        info->last_timestamp_ns  = bh.last_timestamp_ns;
+    }
 
     int count = (int)bh.num_events;
     if (count > max_events) count = max_events;
@@ -228,11 +266,11 @@ int pgwt_reader_decode_block(struct pgwt_event_reader *r, int block_idx,
     if (decompressed < 0)
         return -1;
 
-    /* Columnar decode — inverse of pgwt_encode_block() */
+    /* Columnar decode */
     const uint8_t *p = r->decode_buf;
     size_t avail = (size_t)decompressed;
 
-    /* Column 1: timestamps (delta varint) */
+    /* Column 1: timestamps (delta varint) — common to both block types */
     uint64_t prev_ts = 0;
     for (int i = 0; i < count; i++) {
         uint64_t delta;
@@ -243,11 +281,33 @@ int pgwt_reader_decode_block(struct pgwt_event_reader *r, int block_idx,
         out[i].timestamp_ns = prev_ts;
     }
 
-    /* Column 2: PIDs (raw uint32) */
+    /* Column 2: PIDs (raw uint32) — common to both block types */
     for (int i = 0; i < count; i++) {
         if (avail < 4) return -1;
         memcpy(&out[i].pid, p, 4); p += 4; avail -= 4;
     }
+
+    if (block_type == PGWT_BLOCK_SAMPLES) {
+        /* SAMPLES layout: event (u32), query_id (u64). No old_event,
+         * no duration. Surface as a point observation: sampled event in
+         * new_event, old_event/duration cleared, FLAG_SAMPLE set. */
+        for (int i = 0; i < count; i++) {
+            if (avail < 4) return -1;
+            memcpy(&out[i].new_event, p, 4); p += 4; avail -= 4;
+        }
+        for (int i = 0; i < count; i++) {
+            if (avail < 8) return -1;
+            memcpy(&out[i].query_id, p, 8); p += 8; avail -= 8;
+        }
+        for (int i = 0; i < count; i++) {
+            out[i].old_event = 0;
+            out[i].duration_ns = 0;
+            out[i].flags = PGWT_EVENT_FLAG_SAMPLE;
+        }
+        return count;
+    }
+
+    /* TRANSITIONS layout — inverse of pgwt_encode_block() */
 
     /* Column 3: old_events (raw uint32) */
     for (int i = 0; i < count; i++) {
@@ -274,9 +334,9 @@ int pgwt_reader_decode_block(struct pgwt_event_reader *r, int block_idx,
         memcpy(&out[i].query_id, p, 8); p += 8; avail -= 8;
     }
 
-    /* Clear padding */
+    /* Clear flags (transition records carry no per-record flag) */
     for (int i = 0; i < count; i++)
-        out[i]._pad = 0;
+        out[i].flags = 0;
 
     return count;
 }

--- a/src/event_reader.h
+++ b/src/event_reader.h
@@ -36,10 +36,36 @@ int pgwt_reader_open(struct pgwt_event_reader *r, const char *path);
 /* Close file and free internal buffers. */
 void pgwt_reader_close(struct pgwt_event_reader *r);
 
+/* Per-block metadata surfaced to consumers (trace format v2). */
+struct pgwt_block_info {
+    enum pgwt_block_type block_type;   /* TRANSITIONS or SAMPLES */
+    uint64_t sample_period_ns;         /* SAMPLES: nominal interval; else 0 */
+    uint64_t first_timestamp_ns;       /* monotonic */
+    uint64_t last_timestamp_ns;        /* monotonic */
+};
+
 /* Decode a single block by index into out[].
- * Returns number of events decoded, or -1 on error. */
+ * Returns number of events decoded, or -1 on error.
+ *
+ * Both block types decode into pgwt_trace_event. For a SAMPLES block, each
+ * record is a point observation: new_event = sampled event id, old_event = 0,
+ * duration_ns = 0, and flags has PGWT_EVENT_FLAG_SAMPLE set so consumers can
+ * distinguish samples from transition intervals per-record. For a TRANSITIONS
+ * block, flags is 0 and all columns are populated as before. */
 int pgwt_reader_decode_block(struct pgwt_event_reader *r, int block_idx,
                               struct pgwt_trace_event *out, int max_events);
+
+/* Like pgwt_reader_decode_block(), but also fills *info with the block's
+ * type and sample_period_ns (NULL allowed). Use this when block-level
+ * fidelity matters (e.g. A3's exact-wins merge needs the block time range
+ * and sample period). */
+int pgwt_reader_decode_block_info(struct pgwt_event_reader *r, int block_idx,
+                                   struct pgwt_trace_event *out, int max_events,
+                                   struct pgwt_block_info *info);
+
+/* Read just a block's header metadata (no decode). Returns 0 / -1. */
+int pgwt_reader_block_info(struct pgwt_event_reader *r, int block_idx,
+                           struct pgwt_block_info *info);
 
 /* Find the first block that could contain events at or after mono_ns.
  * Returns block index (0-based). */

--- a/src/event_writer.c
+++ b/src/event_writer.c
@@ -92,6 +92,45 @@ size_t pgwt_encode_block(const struct pgwt_trace_event *events, int count,
     return (size_t)(p - out);
 }
 
+/* ── Columnar SAMPLE block encoder ────────────────────────── */
+/* Samples are point observations: no old_event, no duration. The sampled
+ * event id lives in new_event (the field the daemon's sampler populates).
+ * Layout: ts (delta varint), pid (u32), event (u32), query_id (u64). */
+size_t pgwt_encode_sample_block(const struct pgwt_trace_event *events, int count,
+                                uint8_t *out, size_t out_size)
+{
+    uint8_t *p = out;
+    (void)out_size;  /* caller guarantees sufficient space */
+
+    /* Column 1: timestamps, delta-encoded as varint */
+    uint64_t prev_ts = 0;
+    for (int i = 0; i < count; i++) {
+        uint64_t delta = events[i].timestamp_ns - prev_ts;
+        p += pgwt_encode_varint(delta, p);
+        prev_ts = events[i].timestamp_ns;
+    }
+
+    /* Column 2: PIDs as raw uint32 */
+    for (int i = 0; i < count; i++) {
+        uint32_t pid = events[i].pid;
+        memcpy(p, &pid, 4); p += 4;
+    }
+
+    /* Column 3: events as raw uint32 (the sampled event id, from new_event) */
+    for (int i = 0; i < count; i++) {
+        uint32_t ev = events[i].new_event;
+        memcpy(p, &ev, 4); p += 4;
+    }
+
+    /* Column 4: query_ids as raw uint64 */
+    for (int i = 0; i < count; i++) {
+        uint64_t qid = events[i].query_id;
+        memcpy(p, &qid, 8); p += 8;
+    }
+
+    return (size_t)(p - out);
+}
+
 /* ── File operations (static) ─────────────────────────────── */
 
 static int write_footer(struct pgwt_event_writer *w)
@@ -159,13 +198,21 @@ static int open_trace_file(struct pgwt_event_writer *w, uint64_t first_mono_ns)
     return 0;
 }
 
-static int flush_block(struct pgwt_event_writer *w)
+/* Encode, compress, and write one typed block (TRANSITIONS or SAMPLES).
+ * `events`/`count` are the records; block_type selects the columnar layout;
+ * sample_period_ns is recorded in the header (0 for TRANSITIONS). Updates
+ * the block index, stats, and the committed-block meta file. */
+static int write_typed_block(struct pgwt_event_writer *w,
+                             const struct pgwt_trace_event *events, int count,
+                             enum pgwt_block_type block_type,
+                             uint64_t sample_period_ns)
 {
-    if (w->num_events == 0 || !w->fp) return 0;
+    if (count <= 0 || !w->fp) return 0;
 
-    /* Columnar encode */
-    size_t encoded_size = pgwt_encode_block(
-        w->events, w->num_events, w->encode_buf, w->encode_buf_size);
+    /* Columnar encode (layout depends on block type) */
+    size_t encoded_size = (block_type == PGWT_BLOCK_SAMPLES)
+        ? pgwt_encode_sample_block(events, count, w->encode_buf, w->encode_buf_size)
+        : pgwt_encode_block(events, count, w->encode_buf, w->encode_buf_size);
 
     /* LZ4 compress */
     int compressed_size = LZ4_compress_default(
@@ -173,7 +220,6 @@ static int flush_block(struct pgwt_event_writer *w)
         (int)encoded_size, (int)w->compress_buf_size);
     if (compressed_size <= 0) {
         fprintf(stderr, "WARN: LZ4 compression failed\n");
-        w->num_events = 0;
         return -1;
     }
 
@@ -194,17 +240,20 @@ static int flush_block(struct pgwt_event_writer *w)
     /* Record block index entry */
     long file_offset = ftell(w->fp);
     w->block_index[w->num_blocks++] = (struct pgwt_block_index_entry){
-        .timestamp_ns = w->events[0].timestamp_ns,
+        .timestamp_ns = events[0].timestamp_ns,
         .file_offset = (uint64_t)file_offset,
     };
 
     /* Write block header + compressed data */
     struct pgwt_trace_block_header bh = {
-        .first_timestamp_ns = w->events[0].timestamp_ns,
-        .last_timestamp_ns = w->events[w->num_events - 1].timestamp_ns,
-        .num_events = (uint32_t)w->num_events,
+        .first_timestamp_ns = events[0].timestamp_ns,
+        .last_timestamp_ns = events[count - 1].timestamp_ns,
+        .num_events = (uint32_t)count,
         .compressed_size = (uint32_t)compressed_size,
         .uncompressed_size = (uint32_t)encoded_size,
+        .block_type = (uint16_t)block_type,
+        .reserved = 0,
+        .sample_period_ns = sample_period_ns,
     };
     if (fwrite(&bh, sizeof(bh), 1, w->fp) != 1 ||
         fwrite(w->compress_buf, 1, compressed_size, w->fp) != (size_t)compressed_size) {
@@ -213,9 +262,8 @@ static int flush_block(struct pgwt_event_writer *w)
         return -1;
     }
 
-    w->total_events_written += w->num_events;
+    w->total_events_written += count;
     w->total_bytes_written += sizeof(bh) + compressed_size;
-    w->num_events = 0;
 
     /* Flush to OS page cache so concurrent readers can see this block */
     fflush(w->fp);
@@ -237,6 +285,16 @@ static int flush_block(struct pgwt_event_writer *w)
     }
 
     return 0;
+}
+
+static int flush_block(struct pgwt_event_writer *w)
+{
+    if (w->num_events == 0 || !w->fp) return 0;
+
+    int rc = write_typed_block(w, w->events, w->num_events,
+                               PGWT_BLOCK_TRANSITIONS, 0);
+    w->num_events = 0;
+    return rc;
 }
 
 /* ── Public API ───────────────────────────────────────────── */
@@ -306,6 +364,43 @@ int pgwt_writer_push_event(struct pgwt_event_writer *w,
 
     if (w->num_events >= PGWT_BLOCK_EVENTS)
         return flush_block(w);
+
+    return 0;
+}
+
+int pgwt_writer_push_samples(struct pgwt_event_writer *w,
+                             const struct pgwt_trace_event *samples,
+                             int count, uint64_t sample_period_ns)
+{
+    if (!w->enabled) return 0;
+    if (count <= 0) return 0;
+
+    /* Lazy file open on first write */
+    if (!w->fp) {
+        if (open_trace_file(w, samples[0].timestamp_ns) != 0) {
+            w->enabled = false;
+            return -1;
+        }
+    }
+
+    /* Flush any pending buffered TRANSITIONS block first so block
+     * boundaries stay clean (one block is either all transitions or all
+     * samples — never mixed). */
+    if (w->num_events > 0) {
+        if (flush_block(w) != 0)
+            return -1;
+    }
+
+    /* Samples can exceed one block; split into PGWT_BLOCK_EVENTS chunks. */
+    int off = 0;
+    while (off < count) {
+        int chunk = count - off;
+        if (chunk > PGWT_BLOCK_EVENTS) chunk = PGWT_BLOCK_EVENTS;
+        if (write_typed_block(w, samples + off, chunk,
+                              PGWT_BLOCK_SAMPLES, sample_period_ns) != 0)
+            return -1;
+        off += chunk;
+    }
 
     return 0;
 }

--- a/src/event_writer.h
+++ b/src/event_writer.h
@@ -13,10 +13,27 @@
 /* ── On-disk format constants ─────────────────────────────── */
 
 #define PGWT_TRACE_MAGIC      0x54574750   /* "PGWT" little-endian */
-#define PGWT_TRACE_VERSION    1
+#define PGWT_TRACE_VERSION    2
 #define PGWT_FLAG_LZ4         0x0001
 
 #define PGWT_BLOCK_EVENTS     4096         /* events per block */
+
+/* Block type (trace format v2). Identifies what a block's columns mean.
+ *   TRANSITIONS — wait-event transition intervals (exact fidelity): the
+ *                 full columnar layout (ts, pid, old_event, new_event,
+ *                 duration_ns, query_id). This is what the watchpoint
+ *                 ("full") provider writes.
+ *   SAMPLES     — point observations of a backend's current wait event
+ *                 (sampled fidelity): a reduced columnar layout
+ *                 (ts, pid, event, query_id) — no old_event, no duration.
+ *                 This is what the A2 sampler writes. Each sample means
+ *                 "at timestamp T, pid P was in event E"; A3 treats it as
+ *                 a point observation worth `sample_period_ns`, never an
+ *                 interval. */
+enum pgwt_block_type {
+    PGWT_BLOCK_TRANSITIONS = 0,
+    PGWT_BLOCK_SAMPLES     = 1,
+};
 
 /* File header (28 bytes) */
 struct pgwt_trace_file_header {
@@ -28,13 +45,20 @@ struct pgwt_trace_file_header {
     uint64_t clock_offset_ns;    /* CLOCK_MONOTONIC at file creation */
 } __attribute__((packed));
 
-/* Block header (28 bytes) */
+/* Block header (v2: 40 bytes).
+ * block_type/sample_period_ns are new in v2. sample_period_ns is the
+ * nominal interval between samples in a SAMPLES block (0 for TRANSITIONS).
+ * reserved keeps the 8-byte fields naturally aligned and leaves room for
+ * a future v3 without another size bump. */
 struct pgwt_trace_block_header {
     uint64_t first_timestamp_ns;
     uint64_t last_timestamp_ns;
     uint32_t num_events;
     uint32_t compressed_size;
     uint32_t uncompressed_size;
+    uint16_t block_type;         /* enum pgwt_block_type */
+    uint16_t reserved;           /* 0; reserved for future use */
+    uint64_t sample_period_ns;   /* SAMPLES: nominal sample interval; TRANSITIONS: 0 */
 } __attribute__((packed));
 
 /* Block index entry (16 bytes) */
@@ -88,6 +112,20 @@ int  pgwt_writer_init(struct pgwt_event_writer *w, const char *trace_dir,
                       const char *group_name);
 int  pgwt_writer_push_event(struct pgwt_event_writer *w,
                             const struct pgwt_trace_event *evt);
+
+/* Write a SAMPLES block (trace format v2). The A2 sampler calls this once
+ * per drain with the samples it collected this tick-batch. Only the pid,
+ * new_event (= sampled event), query_id, and timestamp_ns fields of each
+ * struct are used; old_event/duration_ns are ignored (samples carry
+ * neither). `sample_period_ns` is recorded in the block header so the
+ * compute layer (A3) can weight each sample. Samples must be sorted by
+ * timestamp ascending (delta-varint encoding requires it). A pending
+ * TRANSITIONS block, if any, is flushed first so block boundaries stay
+ * clean. Returns 0 on success, -1 on error. */
+int  pgwt_writer_push_samples(struct pgwt_event_writer *w,
+                              const struct pgwt_trace_event *samples,
+                              int count, uint64_t sample_period_ns);
+
 int  pgwt_writer_check_rotation(struct pgwt_event_writer *w);
 int  pgwt_writer_close(struct pgwt_event_writer *w);
 int  pgwt_writer_cleanup_old_files(struct pgwt_event_writer *w);
@@ -95,8 +133,13 @@ void pgwt_writer_destroy(struct pgwt_event_writer *w);
 
 /* ── Exposed for unit testing ─────────────────────────────── */
 
+/* Encode a TRANSITIONS block (full columnar layout). */
 size_t pgwt_encode_block(const struct pgwt_trace_event *events, int count,
                          uint8_t *out, size_t out_size);
+/* Encode a SAMPLES block (reduced layout: ts, pid, event, query_id).
+ * Reads each event's new_event field as the sampled event id. */
+size_t pgwt_encode_sample_block(const struct pgwt_trace_event *events, int count,
+                                uint8_t *out, size_t out_size);
 int pgwt_encode_varint(uint64_t val, uint8_t *out);
 int pgwt_decode_varint(const uint8_t *in, size_t avail, uint64_t *val);
 

--- a/src/pg_wait_tracer.h
+++ b/src/pg_wait_tracer.h
@@ -62,10 +62,17 @@ struct pgwt_trace_event {
     u32 pid;            /* backend PID */
     u32 old_event;      /* previous wait_event_info */
     u32 new_event;      /* new wait_event_info (0xFFFFFFFF = exit) */
-    u32 _pad;           /* alignment */
+    u32 flags;          /* reader-side annotation (PGWT_EVENT_FLAG_*); 0 on the wire */
     u64 duration_ns;    /* time spent in old_event */
     u64 query_id;       /* active query during old_event */
 };
+
+/* flags bits — set by the trace reader, never on the wire/ringbuf.
+ * SAMPLE marks a record decoded from a SAMPLES block: it is a point
+ * observation (new_event = sampled event; old_event = 0; duration_ns = 0),
+ * not a transition interval. A3's compute must treat it as worth one
+ * sample_period_ns, not as an interval duration. */
+#define PGWT_EVENT_FLAG_SAMPLE  0x1U
 
 #define PGWT_EVENT_EXIT  0xFFFFFFFFU  /* sentinel new_event for process exit */
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -6,7 +6,8 @@ CFLAGS    = -g -O2 -Wall -I../src -I../include
 BUILD     = ../build
 
 TESTS     = test_wait_event test_cmdline test_event_writer test_event_reader \
-            test_bucket gen_test_traces gen_bench_traces test_concurrent_rw
+            test_trace_v2 test_bucket gen_test_traces gen_bench_traces \
+            test_concurrent_rw
 
 .PHONY: all clean
 
@@ -27,6 +28,13 @@ test_event_reader: test_event_reader.c $(BUILD)/event_reader.o $(BUILD)/event_wr
 
 test_bucket: test_bucket.c
 	$(CC) $(CFLAGS) -o $@ $^
+
+# test_trace_v2: format round-trip (v2 typed blocks). Built against the
+# server objects (-DPGWT_SERVER) so it needs no BPF skeleton — buildable on
+# a box without bpftool and in CI's server-only jobs.
+test_trace_v2: test_trace_v2.c $(BUILD)/server_event_writer.o \
+               $(BUILD)/server_event_reader.o
+	$(CC) $(CFLAGS) -DPGWT_SERVER -o $@ $^ -llz4
 
 # Server-build objects for gen_test_traces
 SERVER_OBJS = $(BUILD)/server_event_writer.o $(BUILD)/server_summary_writer.o \

--- a/tests/gen_test_traces.c
+++ b/tests/gen_test_traces.c
@@ -13,10 +13,23 @@
  *   "queries":  [{"id": 12345, "text": "SELECT pg_sleep(1)"}],
  *   "events": [
  *     {"pid": 1000, "ts": 1000000000, "dur": 500000, "old": 167772181, "new": 0, "qid": 12345}
+ *   ],
+ *   "sample_period_ns": 100000000,
+ *   "samples": [
+ *     {"pid": 1000, "ts": 1000000000, "event": 167772181, "qid": 12345}
  *   ]
  * }
  *
- * Event IDs: old_event/new_event are uint32 wait_event_info values.
+ * "events"  → written as a TRANSITIONS block (trace format v2). The existing
+ *             columnar layout: ts, pid, old, new, dur, qid.
+ * "samples" → written as a SAMPLES block (trace format v2). Reduced layout:
+ *             ts, pid, event, qid — no old/new/dur. "event" is the single
+ *             sampled wait_event_info; "sample_period_ns" (top-level, default
+ *             100000000 = 10 Hz) is stored in the block header. Samples must
+ *             be sorted by ts ascending. A scenario may have events, samples,
+ *             or both. Both arrays produce A3 fixtures.
+ *
+ * Event IDs: old_event/new_event/event are uint32 wait_event_info values.
  *   CPU = 0, IO:DataFileRead = 0x0A000001, Lock:relation = 0x03000001, etc.
  *   Class byte << 24 | event_number.
  *
@@ -55,6 +68,12 @@ struct test_query {
 struct scenario {
     struct pgwt_trace_event events[MAX_EVENTS];
     int num_events;
+
+    /* SAMPLES block (trace format v2). The sampled event id is stored in
+     * each record's new_event field (what the writer's sample encoder reads). */
+    struct pgwt_trace_event samples[MAX_EVENTS];
+    int num_samples;
+    uint64_t sample_period_ns;
 
     struct test_backend backends[MAX_TEST_BACKENDS];
     int num_backends;
@@ -204,9 +223,42 @@ static int parse_events(const char *arr, struct scenario *sc)
     return 0;
 }
 
+static int parse_samples(const char *arr, struct scenario *sc)
+{
+    const char *p = skip_ws(arr);
+    if (*p != '[') return -1;
+    p++;
+
+    while (*p && sc->num_samples < MAX_EVENTS) {
+        p = skip_ws(p);
+        if (*p == ']') break;
+        if (*p == ',') { p++; continue; }
+        if (*p != '{') break;
+
+        const char *end = find_matching(p, '{', '}');
+        if (!end) break;
+
+        struct pgwt_trace_event *ev = &sc->samples[sc->num_samples];
+        memset(ev, 0, sizeof(*ev));
+
+        const char *v;
+        if ((v = find_key(p, "pid")))   ev->pid = (uint32_t)strtoull(v, NULL, 10);
+        if ((v = find_key(p, "ts")))    ev->timestamp_ns = strtoull(v, NULL, 10);
+        /* sampled event id → new_event (the field the sample encoder reads) */
+        if ((v = find_key(p, "event"))) ev->new_event = (uint32_t)strtoull(v, NULL, 10);
+        if ((v = find_key(p, "qid")))   ev->query_id = strtoull(v, NULL, 10);
+
+        sc->num_samples++;
+        p = end + 1;
+    }
+    return 0;
+}
+
 static int parse_scenario(const char *json, struct scenario *sc)
 {
     const char *v;
+
+    sc->sample_period_ns = 100000000ULL;  /* default 10 Hz */
 
     if ((v = find_key(json, "backends")))
         parse_backends(v, sc);
@@ -214,6 +266,10 @@ static int parse_scenario(const char *json, struct scenario *sc)
         parse_queries(v, sc);
     if ((v = find_key(json, "events")))
         parse_events(v, sc);
+    if ((v = find_key(json, "sample_period_ns")))
+        sc->sample_period_ns = strtoull(v, NULL, 10);
+    if ((v = find_key(json, "samples")))
+        parse_samples(v, sc);
 
     return 0;
 }
@@ -290,12 +346,23 @@ static int write_traces(const char *dir, struct scenario *sc)
         return -1;
     }
 
+    /* TRANSITIONS block(s): the "events" array. Also feeds the summary
+     * writer (summaries are transition-based; sampled summaries are A3). */
     for (int i = 0; i < sc->num_events; i++) {
         if (pgwt_writer_push_event(&ew, &sc->events[i]) != 0) {
             fprintf(stderr, "Failed to write event %d\n", i);
             break;
         }
         pgwt_summary_push_event(&sw, &sc->events[i]);
+    }
+
+    /* SAMPLES block: the "samples" array (trace format v2). Written after
+     * the transitions so a scenario with both produces a transition block
+     * followed by a sample block. */
+    if (sc->num_samples > 0) {
+        if (pgwt_writer_push_samples(&ew, sc->samples, sc->num_samples,
+                                     sc->sample_period_ns) != 0)
+            fprintf(stderr, "Failed to write %d samples\n", sc->num_samples);
     }
 
     /* Flush summary */
@@ -306,7 +373,8 @@ static int write_traces(const char *dir, struct scenario *sc)
     pgwt_writer_destroy(&ew);
     pgwt_summary_destroy(&sw);
 
-    fprintf(stderr, "Wrote %d events to %s\n", sc->num_events, dir);
+    fprintf(stderr, "Wrote %d events + %d samples to %s\n",
+            sc->num_events, sc->num_samples, dir);
     return 0;
 }
 
@@ -418,8 +486,8 @@ int main(int argc, char **argv)
     }
     free(json);
 
-    fprintf(stderr, "Scenario: %d events, %d backends, %d queries\n",
-            sc->num_events, sc->num_backends, sc->num_queries);
+    fprintf(stderr, "Scenario: %d events, %d samples, %d backends, %d queries\n",
+            sc->num_events, sc->num_samples, sc->num_backends, sc->num_queries);
 
     /* Write output files */
     int rc = 0;

--- a/tests/run_all.sh
+++ b/tests/run_all.sh
@@ -75,6 +75,7 @@ make -C "$SCRIPT_DIR"
 run_test "test_wait_event" "$SCRIPT_DIR/test_wait_event"
 run_test "test_cmdline" "$SCRIPT_DIR/test_cmdline"
 run_test "test_bucket" "$SCRIPT_DIR/test_bucket"
+run_test "test_trace_v2" "$SCRIPT_DIR/test_trace_v2"
 
 # Step 2.5: Synthetic data correctness tests (no root needed, needs pgwt-server)
 if [[ -x "$PROJECT_DIR/pgwt-server" ]] && [[ -x "$SCRIPT_DIR/gen_test_traces" ]]; then

--- a/tests/test_trace_v2.c
+++ b/tests/test_trace_v2.c
@@ -1,0 +1,267 @@
+/* test_trace_v2.c — Unit tests for trace format v2 (Phase A1)
+ *
+ * Round-trips a v2 file containing BOTH a TRANSITIONS block and a SAMPLES
+ * block, asserting every column survives and that block_type /
+ * sample_period_ns are preserved. Also asserts the v1-rejection behavior:
+ * a file with an old version byte must fail to open with a clear error,
+ * not crash.
+ *
+ * Built with -DPGWT_SERVER against the server objects so it needs no BPF
+ * skeleton (compiles on a box without bpftool, and in CI). */
+#include "event_writer.h"
+#include "event_reader.h"
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <sys/stat.h>
+
+static int tests_run = 0;
+static int tests_passed = 0;
+
+#define CHECK(cond, fmt, ...) do { \
+    tests_run++; \
+    if (cond) { tests_passed++; } \
+    else { printf("  FAIL: " fmt "\n", ##__VA_ARGS__); } \
+} while(0)
+
+static const char *TEST_DIR = "/tmp/test_trace_v2";
+
+static void cleanup_test_dir(void)
+{
+    char cmd[512];
+    snprintf(cmd, sizeof(cmd), "rm -rf %s", TEST_DIR);
+    if (system(cmd) != 0) { /* ignore */ }
+}
+
+/* ── Test 1: mixed TRANSITIONS + SAMPLES round-trip ───────── */
+
+static void test_mixed_roundtrip(void)
+{
+    printf("--- v2 mixed (TRANSITIONS + SAMPLES) round-trip ---\n");
+    cleanup_test_dir();
+    mkdir(TEST_DIR, 0755);
+
+    const int NT = 64;   /* transitions */
+    const int NS = 40;   /* samples */
+    const uint64_t SAMPLE_PERIOD = 100000000ULL;  /* 100 ms = 10 Hz */
+
+    struct pgwt_trace_event trans[64];
+    for (int i = 0; i < NT; i++) {
+        trans[i].timestamp_ns = 1000000ULL + (uint64_t)i * 1000ULL;
+        trans[i].pid = 1000 + (i % 8);
+        trans[i].old_event = 0x0A000000U + (uint32_t)i;
+        trans[i].new_event = 0x03000000U + (uint32_t)i;
+        trans[i].flags = 0;
+        trans[i].duration_ns = 500 + (uint64_t)i * 13;
+        trans[i].query_id = (i % 4 == 0) ? 0 : (uint64_t)(9000 + i);
+    }
+
+    struct pgwt_trace_event samp[40];
+    for (int i = 0; i < NS; i++) {
+        /* Samples come after the transitions, sorted ascending. */
+        samp[i].timestamp_ns = 2000000ULL + (uint64_t)i * SAMPLE_PERIOD;
+        samp[i].pid = 2000 + (i % 5);
+        samp[i].new_event = 0x01000000U + (uint32_t)i;  /* sampled event */
+        /* old_event/duration deliberately set to nonzero garbage to prove
+         * the writer ignores them and the reader returns them zeroed. */
+        samp[i].old_event = 0xDEADBEEFU;
+        samp[i].duration_ns = 0xCAFEull;
+        samp[i].flags = 0;
+        samp[i].query_id = (i % 3 == 0) ? 0 : (uint64_t)(7000 + i);
+    }
+
+    /* Write: a transition block, then a sample block. */
+    struct pgwt_event_writer w;
+    CHECK(pgwt_writer_init(&w, TEST_DIR, 18, 24, NULL) == 0, "writer_init");
+    for (int i = 0; i < NT; i++)
+        CHECK(pgwt_writer_push_event(&w, &trans[i]) == 0, "push_event %d", i);
+    CHECK(pgwt_writer_push_samples(&w, samp, NS, SAMPLE_PERIOD) == 0,
+          "push_samples");
+    pgwt_writer_close(&w);
+    pgwt_writer_destroy(&w);
+
+    /* Read back. */
+    char path[512];
+    snprintf(path, sizeof(path), "%s/current.trace", TEST_DIR);
+
+    struct pgwt_event_reader r;
+    CHECK(pgwt_reader_open(&r, path) == 0, "reader_open");
+    CHECK(r.header.version == PGWT_TRACE_VERSION, "version=%u", r.header.version);
+    CHECK(r.header.version == 2, "version is 2");
+    CHECK(r.num_blocks == 2, "num_blocks=%d (expected 2)", r.num_blocks);
+
+    struct pgwt_trace_event out[PGWT_BLOCK_EVENTS];
+    struct pgwt_block_info info;
+
+    /* Block 0: TRANSITIONS */
+    int n0 = pgwt_reader_decode_block_info(&r, 0, out, PGWT_BLOCK_EVENTS, &info);
+    CHECK(n0 == NT, "block0 count=%d (expected %d)", n0, NT);
+    CHECK(info.block_type == PGWT_BLOCK_TRANSITIONS, "block0 type=TRANSITIONS");
+    CHECK(info.sample_period_ns == 0, "block0 period=0");
+    int tmiss = 0;
+    for (int i = 0; i < n0 && i < NT; i++) {
+        if (out[i].timestamp_ns != trans[i].timestamp_ns ||
+            out[i].pid != trans[i].pid ||
+            out[i].old_event != trans[i].old_event ||
+            out[i].new_event != trans[i].new_event ||
+            out[i].duration_ns != trans[i].duration_ns ||
+            out[i].query_id != trans[i].query_id ||
+            out[i].flags != 0)
+            tmiss++;
+    }
+    CHECK(tmiss == 0, "transition column mismatches: %d", tmiss);
+
+    /* Block 1: SAMPLES */
+    int n1 = pgwt_reader_decode_block_info(&r, 1, out, PGWT_BLOCK_EVENTS, &info);
+    CHECK(n1 == NS, "block1 count=%d (expected %d)", n1, NS);
+    CHECK(info.block_type == PGWT_BLOCK_SAMPLES, "block1 type=SAMPLES");
+    CHECK(info.sample_period_ns == SAMPLE_PERIOD,
+          "block1 period=%llu (expected %llu)",
+          (unsigned long long)info.sample_period_ns,
+          (unsigned long long)SAMPLE_PERIOD);
+    int smiss = 0;
+    for (int i = 0; i < n1 && i < NS; i++) {
+        if (out[i].timestamp_ns != samp[i].timestamp_ns ||
+            out[i].pid != samp[i].pid ||
+            out[i].new_event != samp[i].new_event ||   /* sampled event */
+            out[i].query_id != samp[i].query_id ||
+            out[i].old_event != 0 ||                    /* cleared */
+            out[i].duration_ns != 0 ||                  /* cleared */
+            (out[i].flags & PGWT_EVENT_FLAG_SAMPLE) == 0)  /* flagged */
+            smiss++;
+    }
+    CHECK(smiss == 0, "sample column mismatches: %d", smiss);
+
+    /* block_info without decode should agree */
+    struct pgwt_block_info bi0, bi1;
+    CHECK(pgwt_reader_block_info(&r, 0, &bi0) == 0, "block_info(0)");
+    CHECK(pgwt_reader_block_info(&r, 1, &bi1) == 0, "block_info(1)");
+    CHECK(bi0.block_type == PGWT_BLOCK_TRANSITIONS, "bi0 transitions");
+    CHECK(bi1.block_type == PGWT_BLOCK_SAMPLES, "bi1 samples");
+    CHECK(bi1.sample_period_ns == SAMPLE_PERIOD, "bi1 period");
+
+    pgwt_reader_close(&r);
+    cleanup_test_dir();
+}
+
+/* ── Test 2: SAMPLES-only trace ───────────────────────────── */
+
+static void test_samples_only(void)
+{
+    printf("--- v2 SAMPLES-only round-trip ---\n");
+    cleanup_test_dir();
+    mkdir(TEST_DIR, 0755);
+
+    const int NS = 1000;
+    const uint64_t SAMPLE_PERIOD = 10000000ULL;  /* 10 ms = 100 Hz */
+    struct pgwt_trace_event *samp = calloc(NS, sizeof(*samp));
+    for (int i = 0; i < NS; i++) {
+        samp[i].timestamp_ns = 5000000ULL + (uint64_t)i * SAMPLE_PERIOD;
+        samp[i].pid = 3000 + (i % 50);
+        samp[i].new_event = (i % 7 == 0) ? 0 : (0x08000000U + (uint32_t)(i % 20));
+        samp[i].query_id = (uint64_t)(100 + i);
+    }
+
+    struct pgwt_event_writer w;
+    CHECK(pgwt_writer_init(&w, TEST_DIR, 17, 24, NULL) == 0, "writer_init");
+    CHECK(pgwt_writer_push_samples(&w, samp, NS, SAMPLE_PERIOD) == 0,
+          "push_samples (%d)", NS);
+    pgwt_writer_close(&w);
+    pgwt_writer_destroy(&w);
+
+    char path[512];
+    snprintf(path, sizeof(path), "%s/current.trace", TEST_DIR);
+
+    struct pgwt_event_reader r;
+    CHECK(pgwt_reader_open(&r, path) == 0, "reader_open");
+    CHECK(r.num_blocks >= 1, "num_blocks=%d", r.num_blocks);
+
+    struct pgwt_trace_event out[PGWT_BLOCK_EVENTS];
+    int total = 0, miss = 0;
+    for (int b = 0; b < r.num_blocks; b++) {
+        struct pgwt_block_info info;
+        int n = pgwt_reader_decode_block_info(&r, b, out, PGWT_BLOCK_EVENTS, &info);
+        CHECK(info.block_type == PGWT_BLOCK_SAMPLES, "block %d is SAMPLES", b);
+        CHECK(info.sample_period_ns == SAMPLE_PERIOD, "block %d period", b);
+        for (int i = 0; i < n && total + i < NS; i++) {
+            int idx = total + i;
+            if (out[i].timestamp_ns != samp[idx].timestamp_ns ||
+                out[i].pid != samp[idx].pid ||
+                out[i].new_event != samp[idx].new_event ||
+                out[i].query_id != samp[idx].query_id ||
+                (out[i].flags & PGWT_EVENT_FLAG_SAMPLE) == 0)
+                miss++;
+        }
+        total += n;
+    }
+    CHECK(total == NS, "total=%d (expected %d)", total, NS);
+    CHECK(miss == 0, "samples-only mismatches: %d", miss);
+
+    pgwt_reader_close(&r);
+    free(samp);
+    cleanup_test_dir();
+}
+
+/* ── Test 3: v1 (old version byte) rejected, not crashing ─── */
+
+static void test_v1_rejected(void)
+{
+    printf("--- v1 file rejected with clear error ---\n");
+    cleanup_test_dir();
+    mkdir(TEST_DIR, 0755);
+
+    /* Write a valid v2 file, then flip the version byte to 1. */
+    struct pgwt_trace_event e = {
+        .timestamp_ns = 1000000, .pid = 4000,
+        .old_event = 0, .new_event = 0,
+        .duration_ns = 100, .query_id = 0, .flags = 0,
+    };
+    struct pgwt_event_writer w;
+    CHECK(pgwt_writer_init(&w, TEST_DIR, 18, 24, NULL) == 0, "writer_init");
+    CHECK(pgwt_writer_push_event(&w, &e) == 0, "push_event");
+    pgwt_writer_close(&w);
+    pgwt_writer_destroy(&w);
+
+    char path[512];
+    snprintf(path, sizeof(path), "%s/current.trace", TEST_DIR);
+
+    /* Patch version field (offset 4: after magic u32) to 1. */
+    FILE *fp = fopen(path, "r+b");
+    CHECK(fp != NULL, "open for patch");
+    if (fp) {
+        struct pgwt_trace_file_header hdr;
+        CHECK(fread(&hdr, sizeof(hdr), 1, fp) == 1, "read header");
+        CHECK(hdr.version == 2, "was v2");
+        hdr.version = 1;
+        fseek(fp, 0, SEEK_SET);
+        CHECK(fwrite(&hdr, sizeof(hdr), 1, fp) == 1, "write v1 header");
+        fclose(fp);
+    }
+
+    /* Also drop the meta file so the reader actually parses the header
+     * (meta is keyed to a valid v2 layout). It is fine either way: the
+     * version check happens before any block parsing. */
+    char meta[600];
+    snprintf(meta, sizeof(meta), "%s.meta", path);
+    unlink(meta);
+
+    struct pgwt_event_reader r;
+    int rc = pgwt_reader_open(&r, path);
+    CHECK(rc == -1, "v1 open rejected (rc=%d, expected -1)", rc);
+    /* No crash: if open returned 0 we'd close to avoid a leak. */
+    if (rc == 0) pgwt_reader_close(&r);
+
+    cleanup_test_dir();
+}
+
+int main(void)
+{
+    test_mixed_roundtrip();
+    test_samples_only();
+    test_v1_rejected();
+
+    printf("\n=== %d / %d tests passed ===\n", tests_passed, tests_run);
+    return (tests_passed == tests_run) ? 0 : 1;
+}


### PR DESCRIPTION
## Phase A1 — trace format v2 (typed transition/sample blocks), v2-only

Implements design decision D2 of `docs/REWORK_PLAN.md`. Adds the trace-format
capability the tiered-capture work needs: a single file can now carry both
**transition** data (exact, from the watchpoint path) and **sample** data
(from the A2 sampler), each in an explicitly typed block. This phase adds the
format only — the sampler itself is A2.

Per the locked-in decision (no deployed installs exist), this is **v2-only**:
no v1 compatibility reader path. Old local traces are regenerated, not migrated.

### Header change

`PGWT_TRACE_VERSION` bumped 1 → 2. The **block header** gains two fields and
grows from 28 to 40 bytes (explicitly sized, naturally aligned, with a
reserved field so a future v3 needs no further size bump):

```c
struct pgwt_trace_block_header {
    uint64_t first_timestamp_ns;
    uint64_t last_timestamp_ns;
    uint32_t num_events;
    uint32_t compressed_size;
    uint32_t uncompressed_size;
    uint16_t block_type;        /* PGWT_BLOCK_TRANSITIONS | PGWT_BLOCK_SAMPLES */
    uint16_t reserved;          /* 0 */
    uint64_t sample_period_ns;  /* SAMPLES: nominal interval; TRANSITIONS: 0 */
} __attribute__((packed));
```

The **file header** is unchanged (only the version byte differs); summary
files (own magic/version/block header) are unaffected.

### Block layouts

- **TRANSITIONS** — unchanged columnar content, now explicitly typed:
  ts (delta-varint), pid, old_event, new_event, duration_ns (varint), query_id.
- **SAMPLES** — reduced columnar layout, dropping the columns that don't apply:
  ts (delta-varint), pid, event (single u32), query_id. **No** old_event,
  **no** duration_ns.

### Sample representation to readers (for A3)

Each decoded sample is surfaced in `pgwt_trace_event` as a **point
observation**, distinguishable both per-record and per-block:

- per-record: `new_event` = sampled event id, `old_event = 0`,
  `duration_ns = 0`, and `flags` has `PGWT_EVENT_FLAG_SAMPLE` set. (The
  trace_event `_pad` field was renamed to `flags`; it is a reader-side
  annotation, always 0 on the wire/ringbuf.)
- per-block: `pgwt_reader_decode_block_info()` / `pgwt_reader_block_info()`
  fill a `struct pgwt_block_info { block_type, sample_period_ns,
  first/last_timestamp_ns }`.

So A3 can treat samples as observations worth `sample_period_ns` (ASH math),
never as interval durations, and can do the exact-wins merge using the
per-block time range + type. `pgwt_reader_decode_block()` keeps its old
signature (delegates to the info variant with NULL).

### Writer API

- `pgwt_writer_push_event()` unchanged — its blocks are now tagged TRANSITIONS.
- New `pgwt_writer_push_samples(w, samples, count, sample_period_ns)` for the
  A2 sampler: flushes any pending transition block first (blocks are never
  mixed), then writes one or more SAMPLES blocks (splitting at
  `PGWT_BLOCK_EVENTS`). Reads each record's `new_event`/`pid`/`query_id`/`ts`;
  ignores old_event/duration. Both block types update the committed-block meta
  watermark.

### v1-rejection behavior

A file whose version != 2 → clear error
(`ERROR: unsupported trace version N ...; regenerate with this build`) and a
clean open failure — never a crash on a stale layout.

### gen_test_traces (A3 fixtures)

Emits v2. New top-level `"samples"` array + `"sample_period_ns"` (default 10 Hz)
produce a SAMPLES block alongside the existing `"events"` TRANSITIONS block, so
a scenario can carry transitions, samples, or both. Input format documented in
the file header.

### Validation

Local build (no bpftool): `make pgwt-server`, `make -C tests` compile clean.

Remote box (Rocky 9, kernel 5.14, PG 18) — full BPF build + live:
- Full `make` (BPF daemon + pgwt-server) builds and links clean.
- C unit tests: **test_trace_v2 98/98** (mixed transition+sample round-trip,
  SAMPLES-only multi-block round-trip, v1-rejection); existing
  **test_event_writer / test_event_reader** still green with the 40-byte header.
- Synthetic data tests: **11/11** `test_data_*.py` + `test_current_trace` +
  `test_protocol_drift` green end-to-end on v2.
- Live: daemon under pgbench produced a real **v2** trace (header
  `50 47 57 54 02 00` = "PGWT" v2), 1,032,193 transition events / AAS 3.83;
  `pgwt-server --dump` and `--replay` both correct. A SAMPLES-only trace
  (gen_test_traces) dumps without crashing.

### Notes for A2 / A3

- A2 sampler: call `pgwt_writer_push_samples()` per drain with the tick's
  samples (sorted by ts), passing the nominal period; the existing writer
  rotation/meta machinery handles the rest.
- A3 compute: use `pgwt_reader_decode_block_info()` to get
  `block_type` + `sample_period_ns` per block; samples carry
  `PGWT_EVENT_FLAG_SAMPLE` and zeroed old_event/duration. Compute is otherwise
  untouched here — sample records currently flow through replay/dump as
  zero-duration entries (harmless, no crash); fidelity-aware estimators and
  the exact-wins merge are A3's scope.
