### PR TITLE
A2: sampled capture provider (userspace process_vm_readv, --mode sampled)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,7 @@ jobs:
           tests/test_event_writer
           tests/test_event_reader
           tests/test_trace_v2
+          tests/test_sampler
 
       - name: Run synthetic data tests
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ tests/test_bucket
 tests/test_event_writer
 tests/test_event_reader
 tests/test_trace_v2
+tests/test_sampler
 tests/gen_test_traces
 tests/gen_bench_traces
 tests/__pycache__/

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,8 @@ LDFLAGS    = -lbpf -lelf -lz -llz4
 USER_SRCS  = $(SRC_DIR)/pg_wait_tracer.c \
              $(SRC_DIR)/daemon.c \
              $(SRC_DIR)/control.c \
+             $(SRC_DIR)/provider_full.c \
+             $(SRC_DIR)/sampler.c \
              $(SRC_DIR)/backend.c \
              $(SRC_DIR)/discovery.c \
              $(SRC_DIR)/map_reader.c \

--- a/src/backend.c
+++ b/src/backend.c
@@ -117,11 +117,39 @@ int pgwt_scan_existing_backends(struct pgwt_daemon *d)
             continue;
         }
 
-        /* Already initialized — attach real watchpoint directly */
+        /* Already initialized — record the address. */
         struct pgwt_backend *be = alloc_backend(&d->backends, pid);
         if (!be) continue;
 
         be->wp_addr = ptr;
+
+        /* Sampled mode: register the backend (address + metadata) but arm
+         * NO watchpoint. The sampler reads wp_addr directly each tick. Seed
+         * a state_map entry so the query_id uprobe can populate it (nothing
+         * else creates state_map entries in sampled mode). */
+        if (!pgwt_mode_uses_watchpoints(d)) {
+            be->attach_ts = now_ns();
+            pgwt_parse_cmdline(pid, &be->meta);
+            if (d->backend_meta)
+                pgwt_bm_write(d->backend_meta, pid, &be->meta);
+
+            int state_fd = bpf_map__fd(d->skel->maps.state_map);
+            struct pgwt_pid_state init_state = {
+                .last_ts = be->attach_ts,
+                .wait_event_addr = ptr,
+            };
+            uint32_t pid_key = pid;
+            bpf_map_update_elem(state_fd, &pid_key, &init_state, BPF_NOEXIST);
+
+            if (d->verbose)
+                fprintf(stderr, "INFO: tracking PID %d (%s), sampled at 0x%lx\n",
+                        pid, pgwt_backend_type_name(be->meta.backend_type),
+                        (unsigned long)ptr);
+            count++;
+            continue;
+        }
+
+        /* Full mode — attach real watchpoint directly */
         int wp_prog_fd = bpf_program__fd(d->skel->progs.on_watchpoint);
         be->wp_fd = pgwt_open_watchpoint(pid, ptr, wp_prog_fd);
         if (be->wp_fd < 0) {
@@ -197,6 +225,15 @@ int pgwt_handle_fork(struct pgwt_daemon *d, pid_t child_pid)
 
     struct pgwt_backend *be = alloc_backend(&d->backends, child_pid);
     if (!be) return -1;
+
+    /* Sampled mode: no bootstrap watchpoint. Register the backend now; the
+     * sampler lazily resolves wp_addr once the backend sets the pointer. */
+    if (!pgwt_mode_uses_watchpoints(d)) {
+        if (d->verbose)
+            fprintf(stderr, "INFO: fork detected PID %d (sampled, no watchpoint)\n",
+                    child_pid);
+        return 0;
+    }
 
     /* Attach bootstrap watchpoint on my_wait_event_info pointer address */
     int bootstrap_prog_fd = bpf_program__fd(d->skel->progs.on_bootstrap);

--- a/src/bpf/pg_wait_tracer.bpf.c
+++ b/src/bpf/pg_wait_tracer.bpf.c
@@ -80,6 +80,31 @@ struct {
     __type(value, struct pgwt_accum_val);
 } accum_map SEC(".maps");
 
+/* event_ringbuf drop counter (A2). Single per-CPU u64 bumped when a
+ * bpf_ringbuf_output() into event_ringbuf fails (ring full). PERCPU so the
+ * hot path stays atomic-free; the daemon sums across CPUs and surfaces it as
+ * ringbuf_drops_total on the control socket. */
+struct {
+    __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+    __uint(max_entries, 1);
+    __type(key, u32);
+    __type(value, u64);
+} ringbuf_drops SEC(".maps");
+
+/* Emit a trace event to event_ringbuf, counting drops on failure.
+ * bpf_ringbuf_output() returns 0 on success, negative when the ring is full. */
+static __always_inline void emit_event(const struct pgwt_trace_event *evt)
+{
+    long rc = bpf_ringbuf_output(&event_ringbuf, (void *)evt, sizeof(*evt),
+                                 BPF_RB_NO_WAKEUP);
+    if (rc) {
+        u32 zero = 0;
+        u64 *drops = bpf_map_lookup_elem(&ringbuf_drops, &zero);
+        if (drops)
+            (*drops)++;
+    }
+}
+
 /* ── Helpers ──────────────────────────────────────────────── */
 
 /* Read query_id using cached be_entry pointer (1 probe_read instead of 2).
@@ -186,8 +211,7 @@ int on_watchpoint(struct bpf_perf_event_data *ctx)
                 .duration_ns = duration,
                 .query_id = st->last_query_id,
             };
-            bpf_ringbuf_output(&event_ringbuf, &evt, sizeof(evt),
-                               BPF_RB_NO_WAKEUP);
+            emit_event(&evt);
         }
 
         /* Transition to new state */
@@ -297,8 +321,7 @@ int on_exit(struct trace_event_raw_sched_process_template *ctx)
             .duration_ns = duration,
             .query_id = st->last_query_id,
         };
-        bpf_ringbuf_output(&event_ringbuf, &evt, sizeof(evt),
-                           BPF_RB_NO_WAKEUP);
+        emit_event(&evt);
     }
 
     /* Notify daemon */
@@ -347,7 +370,7 @@ static __always_inline void emit_marker(u32 marker)
         .duration_ns = 0,
         .query_id = qid,
     };
-    bpf_ringbuf_output(&event_ringbuf, &evt, sizeof(evt), BPF_RB_NO_WAKEUP);
+    emit_event(&evt);
 }
 
 SEC("usdt")

--- a/src/control.c
+++ b/src/control.c
@@ -3,6 +3,7 @@
 #include "control.h"
 #include "daemon.h"
 #include "event_writer.h"
+#include "provider.h"
 #include "cJSON.h"
 
 #include <stdio.h>
@@ -49,11 +50,19 @@ static cJSON *build_status(const struct pgwt_daemon *d)
 {
     cJSON *root = cJSON_CreateObject();
     cJSON_AddBoolToObject(root, "ok", 1);
-    /* Capture tier: "full" today; A2/A4 add sampled/tiered modes.
-     * --lightweight is reported as its own mode so the answer is
-     * never a lie about what is being captured. */
-    cJSON_AddStringToObject(root, "mode",
-                            d->lightweight_mode ? "lightweight" : "full");
+    /* Capture tier. --lightweight is reported as its own mode so the answer
+     * is never a lie about what is being captured; otherwise report the
+     * active provider name ("full" | "sampled"), with tiered distinguished. */
+    const char *mode;
+    if (d->lightweight_mode)
+        mode = "lightweight";
+    else if (d->mode == PGWT_MODE_TIERED)
+        mode = "tiered";
+    else if (d->provider)
+        mode = d->provider->name;
+    else
+        mode = "full";
+    cJSON_AddStringToObject(root, "mode", mode);
     cJSON_AddNumberToObject(root, "uptime_s",
                             (double)(now_mono_ns() - d->start_ts) / 1e9);
     cJSON_AddNumberToObject(root, "backends", count_backends(d));
@@ -82,6 +91,20 @@ static cJSON *build_metrics(const struct pgwt_daemon *d)
                      ctr->wp_attach_failures_total);
 
     cJSON_AddNumberToObject(root, "backends_tracked", count_backends(d));
+
+    /* Sampled tier counters (0 when not sampling) */
+    cjson_add_uint64(root, "samples_total", ctr->samples_total);
+    cJSON_AddNumberToObject(root, "samples_per_sec", ctr->samples_per_sec);
+    cjson_add_uint64(root, "sample_read_faults_total",
+                     ctr->sample_read_faults_total);
+
+    /* Provider self-metrics. ringbuf_drops_total is the full tier's BPF-side
+     * event_ringbuf drop count (A2 wired this; A0 deliberately omitted it). */
+    struct pgwt_metrics pm;
+    memset(&pm, 0, sizeof(pm));
+    if (d->provider && d->provider->self_metrics)
+        d->provider->self_metrics((struct pgwt_daemon *)d, &pm);
+    cjson_add_uint64(root, "ringbuf_drops_total", pm.ringbuf_drops_total);
 
     /* Trace writer stats (0 when recording is disabled) */
     cjson_add_uint64(root, "trace_events_written_total",

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -79,11 +79,16 @@ static void handle_timer(struct pgwt_daemon *d)
         pgwt_read_accum_map(d);
 
     /* Copy cumulative event_accum to display accum,
-     * then add open intervals from state_map */
+     * then add open intervals from state_map.
+     * Sampled mode has no watchpoint-maintained state_map intervals (entries
+     * exist only to carry query_id), so reading it would manufacture bogus
+     * open intervals — skip it. The live display for sampled mode is not
+     * fidelity-aware until A3; recorded SAMPLES blocks carry the real data. */
     struct pgwt_time_model saved_tm = d->accum.tm;
     pgwt_accum_copy_used(&d->accum, d->event_accum);
     d->accum.prev_tm = saved_tm;
-    pgwt_read_state_map(d);
+    if (pgwt_mode_uses_watchpoints(d))
+        pgwt_read_state_map(d);
 
     if (d->ring.slots)
         pgwt_ring_push(&d->ring, &d->accum);
@@ -140,17 +145,31 @@ static void handle_timer(struct pgwt_daemon *d)
             pgwt_summary_cleanup_old_files(d->summary_writer);
     }
 
-    /* Refresh recent event rate for control-socket metrics */
+    /* Refresh recent event/sample rates for control-socket metrics */
     if (d->interval > 0) {
         d->counters.events_per_sec =
             (double)(d->counters.events_total - d->counters.prev_events_total)
             / d->interval;
         d->counters.prev_events_total = d->counters.events_total;
+
+        d->counters.samples_per_sec =
+            (double)(d->counters.samples_total - d->counters.prev_samples_total)
+            / d->interval;
+        d->counters.prev_samples_total = d->counters.samples_total;
     }
 
     d->tick++;
     if (d->count > 0 && d->tick >= d->count)
         d->running = false;
+}
+
+static void handle_sample_timer(struct pgwt_daemon *d)
+{
+    uint64_t expirations;
+    ssize_t r = read(d->sample_timer_fd, &expirations, sizeof(expirations));
+    (void)r;
+    if (d->provider && d->provider->poll)
+        d->provider->poll(d);
 }
 
 static void handle_signal(struct pgwt_daemon *d)
@@ -164,6 +183,20 @@ static void handle_signal(struct pgwt_daemon *d)
 int pgwt_daemon_init(struct pgwt_daemon *d)
 {
     int err;
+
+    /* Select the capture provider for this mode. FULL (default) is the
+     * original watchpoint path; SAMPLED is the userspace tier; TIERED runs
+     * the sampler always-on (escalation engine lands in A4). */
+    switch (d->mode) {
+    case PGWT_MODE_SAMPLED:
+    case PGWT_MODE_TIERED:
+        d->provider = &pgwt_provider_sampled;
+        break;
+    case PGWT_MODE_FULL:
+    default:
+        d->provider = &pgwt_provider_full;
+        break;
+    }
 
     /* Init backend table and accumulator */
     pgwt_backend_init(&d->backends);
@@ -249,29 +282,37 @@ int pgwt_daemon_init(struct pgwt_daemon *d)
                         (unsigned long)qid_func_off);
         }
 
-        /* USDT probes AFTER uprobe — query_id is already cached when these fire */
-        d->skel->links.on_exec_start =
-            bpf_program__attach_usdt(d->skel->progs.on_exec_start,
-                                     -1, bin,
-                                     "postgresql", "query__execute__start", NULL);
-        d->skel->links.on_exec_done =
-            bpf_program__attach_usdt(d->skel->progs.on_exec_done,
-                                     -1, bin,
-                                     "postgresql", "query__execute__done", NULL);
-        d->skel->links.on_plan_start =
-            bpf_program__attach_usdt(d->skel->progs.on_plan_start,
-                                     -1, bin,
-                                     "postgresql", "query__plan__start", NULL);
-        d->skel->links.on_plan_done =
-            bpf_program__attach_usdt(d->skel->progs.on_plan_done,
-                                     -1, bin,
-                                     "postgresql", "query__plan__done", NULL);
+        /* USDT marker probes write into event_ringbuf, which only the FULL
+         * tier consumes. In sampled mode they would be pure overhead with no
+         * reader, so attach them only when watchpoints are in use. The
+         * query_id uprobe above stays in every mode — the sampler joins
+         * pid->query_id from the state_map it maintains. */
+        if (pgwt_mode_uses_watchpoints(d)) {
+            d->skel->links.on_exec_start =
+                bpf_program__attach_usdt(d->skel->progs.on_exec_start,
+                                         -1, bin,
+                                         "postgresql", "query__execute__start", NULL);
+            d->skel->links.on_exec_done =
+                bpf_program__attach_usdt(d->skel->progs.on_exec_done,
+                                         -1, bin,
+                                         "postgresql", "query__execute__done", NULL);
+            d->skel->links.on_plan_start =
+                bpf_program__attach_usdt(d->skel->progs.on_plan_start,
+                                         -1, bin,
+                                         "postgresql", "query__plan__start", NULL);
+            d->skel->links.on_plan_done =
+                bpf_program__attach_usdt(d->skel->progs.on_plan_done,
+                                         -1, bin,
+                                         "postgresql", "query__plan__done", NULL);
 
-        if (d->skel->links.on_exec_start && d->skel->links.on_exec_done
-            && d->skel->links.on_report_query_id)
-            fprintf(stderr, "INFO: attached USDT + query_id uprobe\n");
-        else
-            fprintf(stderr, "WARN: could not attach query probes (lifecycle tracking disabled)\n");
+            if (d->skel->links.on_exec_start && d->skel->links.on_exec_done
+                && d->skel->links.on_report_query_id)
+                fprintf(stderr, "INFO: attached USDT + query_id uprobe\n");
+            else
+                fprintf(stderr, "WARN: could not attach query probes (lifecycle tracking disabled)\n");
+        } else if (d->skel->links.on_report_query_id) {
+            fprintf(stderr, "INFO: attached query_id uprobe (sampled mode)\n");
+        }
     }
 
     /* Set up lifecycle ring buffer consumer */
@@ -291,8 +332,11 @@ int pgwt_daemon_init(struct pgwt_daemon *d)
     }
     pgwt_accum_init(d->event_accum);
 
-    /* In lightweight mode, skip event ringbuf consumer (BPF accumulates directly) */
-    if (!d->lightweight_mode) {
+    /* The event ringbuf consumer is only needed by the FULL tier (watchpoint
+     * transitions + USDT markers). Lightweight mode accumulates in BPF;
+     * sampled mode arms no watchpoints, so nothing is written there. */
+    bool needs_event_rb = !d->lightweight_mode && pgwt_mode_uses_watchpoints(d);
+    if (needs_event_rb) {
         int event_rb_map_fd = bpf_map__fd(d->skel->maps.event_ringbuf);
         d->event_rb = ring_buffer__new(event_rb_map_fd, pgwt_handle_trace_event, d, NULL);
         if (!d->event_rb) {
@@ -388,6 +432,25 @@ int pgwt_daemon_init(struct pgwt_daemon *d)
     };
     timerfd_settime(d->timer_fd, 0, &its, NULL);
 
+    /* High-rate sampler timer (sampled/tiered tiers): fires at sample_rate_hz
+     * independently of the per-second display interval. */
+    if (d->provider && d->provider->fidelity == PGWT_FIDELITY_SAMPLED) {
+        d->sample_timer_fd = timerfd_create(CLOCK_MONOTONIC, TFD_CLOEXEC);
+        if (d->sample_timer_fd < 0) {
+            perror("timerfd_create (sampler)");
+            goto fail;
+        }
+        int hz = d->sample_rate_hz > 0 ? d->sample_rate_hz : 10;
+        uint64_t period_ns = 1000000000ULL / (uint64_t)hz;
+        struct itimerspec sits = {
+            .it_interval = { .tv_sec = (time_t)(period_ns / 1000000000ULL),
+                             .tv_nsec = (long)(period_ns % 1000000000ULL) },
+            .it_value    = { .tv_sec = (time_t)(period_ns / 1000000000ULL),
+                             .tv_nsec = (long)(period_ns % 1000000000ULL) },
+        };
+        timerfd_settime(d->sample_timer_fd, 0, &sits, NULL);
+    }
+
     /* Create signal fd */
     sigset_t mask;
     sigemptyset(&mask);
@@ -429,6 +492,13 @@ int pgwt_daemon_init(struct pgwt_daemon *d)
     ev.data.fd = d->timer_fd;
     epoll_ctl(d->epoll_fd, EPOLL_CTL_ADD, d->timer_fd, &ev);
 
+    /* Add sampler timer fd (sampled/tiered tiers) */
+    if (d->sample_timer_fd >= 0) {
+        ev.events = EPOLLIN;
+        ev.data.fd = d->sample_timer_fd;
+        epoll_ctl(d->epoll_fd, EPOLL_CTL_ADD, d->sample_timer_fd, &ev);
+    }
+
     /* Add signal fd */
     ev.events = EPOLLIN;
     ev.data.fd = d->signal_fd;
@@ -453,6 +523,21 @@ int pgwt_daemon_init(struct pgwt_daemon *d)
             }
         }
     }
+
+    /* Arm the active capture provider. For the full tier this is a no-op
+     * (watchpoints were armed during the backend scan); for the sampled tier
+     * it allocates the sampler state. */
+    if (d->provider && d->provider->start) {
+        if (d->provider->start(d) != 0) {
+            fprintf(stderr, "FATAL: capture provider '%s' failed to start\n",
+                    d->provider->name);
+            goto fail;
+        }
+    }
+    if (d->verbose)
+        fprintf(stderr, "INFO: capture provider: %s (%s fidelity)\n",
+                d->provider->name,
+                d->provider->fidelity == PGWT_FIDELITY_EXACT ? "exact" : "sampled");
 
     if (!d->quiet)
         pgwt_print_header(d);
@@ -501,6 +586,9 @@ int pgwt_daemon_run(struct pgwt_daemon *d)
         for (int i = 0; i < n; i++) {
             if (events[i].data.fd == d->timer_fd) {
                 handle_timer(d);
+            } else if (d->sample_timer_fd >= 0
+                       && events[i].data.fd == d->sample_timer_fd) {
+                handle_sample_timer(d);
             } else if (events[i].data.fd == rb_fd) {
                 ring_buffer__consume(d->rb);
             } else if (events[i].data.fd == event_rb_fd) {
@@ -529,6 +617,10 @@ int pgwt_daemon_run(struct pgwt_daemon *d)
 
 void pgwt_daemon_cleanup(struct pgwt_daemon *d)
 {
+    /* Stop the active capture provider (detach/free its state). */
+    if (d->provider && d->provider->stop)
+        d->provider->stop(d);
+
     if (d->control) {
         pgwt_control_cleanup(d->control);
         free(d->control);
@@ -581,5 +673,6 @@ void pgwt_daemon_cleanup(struct pgwt_daemon *d)
     }
     if (d->epoll_fd >= 0) { close(d->epoll_fd); d->epoll_fd = -1; }
     if (d->timer_fd >= 0) { close(d->timer_fd); d->timer_fd = -1; }
+    if (d->sample_timer_fd >= 0) { close(d->sample_timer_fd); d->sample_timer_fd = -1; }
     if (d->signal_fd >= 0) { close(d->signal_fd); d->signal_fd = -1; }
 }

--- a/src/daemon.h
+++ b/src/daemon.h
@@ -10,6 +10,7 @@
 #include "backend_meta.h"
 #include "map_reader.h"
 #include "snapshot.h"
+#include "provider.h"
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -19,6 +20,7 @@
 struct pg_wait_tracer_bpf;
 struct ring_buffer;
 struct pgwt_control;
+struct pgwt_sampler;
 
 /* Self-observability counters (D6). Plain uint64 increments on the
  * single-threaded event path — exposed via the control socket
@@ -29,6 +31,12 @@ struct pgwt_counters {
     uint64_t wp_attach_failures_total; /* watchpoint attach failures (incl. bootstrap) */
     uint64_t prev_events_total;        /* events_total at previous timer tick */
     double   events_per_sec;           /* recent rate, refreshed each tick */
+
+    /* Sampled tier (A2). Maintained by the sampler in sampler.c. */
+    uint64_t samples_total;            /* SAMPLES records written */
+    uint64_t prev_samples_total;       /* samples_total at previous timer tick */
+    double   samples_per_sec;          /* recent sample rate, refreshed each tick */
+    uint64_t sample_read_faults_total; /* process_vm_readv partial/EFAULT fallbacks */
 };
 
 /* View modes */
@@ -72,6 +80,7 @@ struct pgwt_daemon {
     /* epoll */
     int epoll_fd;
     int timer_fd;
+    int sample_timer_fd;   /* high-rate sampler tick (sampled/tiered); -1 if unused */
     int signal_fd;
 
     /* Configuration */
@@ -95,6 +104,14 @@ struct pgwt_daemon {
     enum pgwt_sort_mode sort_mode;   /* sort mode for active view */
     bool        replay_mode;             /* true when running --replay */
     bool        daemon_mode;             /* true when running --daemon */
+
+    /* Capture tier (A2). mode picks the provider; default PGWT_MODE_FULL
+     * (today's watchpoint behavior). sample_rate_hz is the sampled tier's
+     * fixed rate (1..1000, default 10). */
+    enum pgwt_mode mode;
+    int         sample_rate_hz;
+    const struct pgwt_capture_provider *provider; /* active provider vtable */
+    struct pgwt_sampler *sampler;        /* sampled-tier state, NULL if unused */
     uint32_t    lightweight_mode;        /* 1 = BPF accumulator only (no ringbuf) */
     uint32_t    skip_query_id;          /* 1 = skip query_id reads in BPF */
     uint32_t    skip_usdt;             /* 1 = skip USDT query lifecycle probes */
@@ -132,6 +149,13 @@ struct pgwt_daemon {
     /* Placed at end of struct to survive field overflow corruption */
     char       *pg_binary_saved;        /* heap-allocated postgres binary path for USDT */
 };
+
+/* True when the active mode attaches hardware watchpoints (full tier).
+ * Sampled mode tracks backends in the registry but arms no watchpoints. */
+static inline bool pgwt_mode_uses_watchpoints(const struct pgwt_daemon *d)
+{
+    return d->mode != PGWT_MODE_SAMPLED;
+}
 
 /* Initialize daemon: load BPF, attach tracepoints, scan backends. */
 int pgwt_daemon_init(struct pgwt_daemon *d);

--- a/src/pg_wait_tracer.c
+++ b/src/pg_wait_tracer.c
@@ -50,6 +50,13 @@ static void usage(const char *prog)
         "Daemon:\n"
         "      --daemon               Run as daemon (reconnect on PG restart)\n"
         "\n"
+        "Capture tier:\n"
+        "      --mode <MODE>          full (default) | sampled | tiered\n"
+        "                             full: hardware watchpoints, exact transitions.\n"
+        "                             sampled: userspace ASH-style sampling, ~zero PG cost.\n"
+        "                             tiered: sampler always-on (escalation: A4)\n"
+        "      --sample-rate <HZ>     Sampling rate for sampled/tiered (1-1000, default 10)\n"
+        "\n"
         "Performance tuning:\n"
         "      --lightweight          BPF accumulator only (no per-event ringbuf).\n"
         "                             Reduces overhead ~40%%, loses histogram/session/query views\n"
@@ -159,6 +166,15 @@ static enum pgwt_format parse_format(const char *s)
     exit(1);
 }
 
+static enum pgwt_mode parse_mode(const char *s)
+{
+    if (strcmp(s, "full") == 0)     return PGWT_MODE_FULL;
+    if (strcmp(s, "sampled") == 0)  return PGWT_MODE_SAMPLED;
+    if (strcmp(s, "tiered") == 0)   return PGWT_MODE_TIERED;
+    fprintf(stderr, "ERROR: unknown mode '%s' (use: full, sampled, tiered)\n", s);
+    exit(1);
+}
+
 /* Long-only option values (no short form) */
 #define OPT_REPLAY 256
 #define OPT_FROM   257
@@ -168,6 +184,8 @@ static enum pgwt_format parse_format(const char *s)
 #define OPT_LIGHTWEIGHT  261
 #define OPT_SKIP_QID     262
 #define OPT_SKIP_USDT    263
+#define OPT_MODE         264
+#define OPT_SAMPLE_RATE  265
 
 static struct option long_opts[] = {
     {"pid",        required_argument, NULL, 'p'},
@@ -192,6 +210,8 @@ static struct option long_opts[] = {
     {"lightweight",     no_argument,       NULL, OPT_LIGHTWEIGHT},
     {"skip-query-id",   no_argument,       NULL, OPT_SKIP_QID},
     {"skip-usdt",       no_argument,       NULL, OPT_SKIP_USDT},
+    {"mode",            required_argument, NULL, OPT_MODE},
+    {"sample-rate",     required_argument, NULL, OPT_SAMPLE_RATE},
     {"quiet",           no_argument,       NULL, 'q'},
     {"verbose",         no_argument,       NULL, 'v'},
     {"help",            no_argument,       NULL, 'h'},
@@ -208,9 +228,12 @@ int main(int argc, char **argv)
     }
     d->epoll_fd  = -1;
     d->timer_fd  = -1;
+    d->sample_timer_fd = -1;
     d->signal_fd = -1;
     d->interval  = 5;
     d->view      = PGWT_VIEW_TIME_MODEL;
+    d->mode      = PGWT_MODE_FULL;   /* default: today's watchpoint behavior */
+    d->sample_rate_hz = 10;          /* default sampled rate (D1) */
 
     pid_t pm_pid = 0;
     const char *pgdata = NULL;
@@ -251,6 +274,8 @@ int main(int argc, char **argv)
         case OPT_LIGHTWEIGHT: d->lightweight_mode = 1; break;
         case OPT_SKIP_QID:    d->skip_query_id = 1; break;
         case OPT_SKIP_USDT:   d->skip_usdt = 1; break;
+        case OPT_MODE:        d->mode = parse_mode(optarg); break;
+        case OPT_SAMPLE_RATE: d->sample_rate_hz = atoi(optarg); break;
         case 'q': d->quiet = true; break;
         case 'v': d->verbose = true; break;
         case 'h': usage(argv[0]); free(d); return 0;
@@ -318,6 +343,30 @@ int main(int argc, char **argv)
         free(d);
         return 1;
     }
+
+    /* Validate: --sample-rate range (only meaningful for sampled/tiered) */
+    if (d->sample_rate_hz < 1 || d->sample_rate_hz > 1000) {
+        fprintf(stderr, "FATAL: --sample-rate must be 1..1000 Hz (got %d)\n",
+                d->sample_rate_hz);
+        free(d);
+        return 1;
+    }
+
+    /* Validate: --mode sampled/tiered is incompatible with --lightweight
+     * (lightweight is a watchpoint-only BPF-accumulator mode). */
+    if (d->mode != PGWT_MODE_FULL && d->lightweight_mode) {
+        fprintf(stderr, "ERROR: --mode %s is incompatible with --lightweight\n",
+                d->mode == PGWT_MODE_SAMPLED ? "sampled" : "tiered");
+        free(d);
+        return 1;
+    }
+
+    /* A2 note: tiered escalation arrives in A4. For now tiered runs the
+     * sampler always-on with no escalation engine — log it so the operator
+     * isn't surprised that full-fidelity windows aren't produced yet. */
+    if (d->mode == PGWT_MODE_TIERED)
+        fprintf(stderr, "INFO: --mode tiered: sampler always-on; on-demand "
+                "full-fidelity escalation lands in A4 (not yet active)\n");
 
     /* Check root */
     if (geteuid() != 0) {

--- a/src/provider.h
+++ b/src/provider.h
@@ -1,0 +1,89 @@
+/* provider.h — Capture provider interface (Track A, A.0 contract)
+ *
+ * One interface, multiple implementations, one trace schema. A provider
+ * owns a capture *tier*: how wait events are observed and turned into
+ * trace blocks. The daemon's lifecycle/registry machinery (fork/exit BPF
+ * tracepoints, the query_id uprobe, the backend table) is shared; the
+ * provider plugs into start/stop/poll and reports its own metrics.
+ *
+ *   full     — hardware watchpoints + BPF (EXACT fidelity): every
+ *              wait_event_info transition becomes a TRANSITIONS record.
+ *              This is the original, default behavior.
+ *   sampled  — pure userspace process_vm_readv() at a fixed rate
+ *              (SAMPLED fidelity): each tick is one point observation per
+ *              tracked backend, written as SAMPLES records. No BPF in the
+ *              per-sample hot path, ~zero cost on PostgreSQL.
+ *   coop*    — cooperative (PG extension) — interface frozen here, filled
+ *              in by the extension track (A6).
+ *
+ * The provider does NOT own backend discovery: in every mode the daemon
+ * keeps the fork/exit tracepoints + query_id uprobe running to maintain
+ * the registry (cheap, not in the sampler's hot path). A provider's
+ * start() arms its capture mechanism; stop() disarms it; poll() drains
+ * whatever it has captured into the trace writer.
+ */
+#ifndef PGWT_PROVIDER_H
+#define PGWT_PROVIDER_H
+
+#include <stdint.h>
+
+struct pgwt_daemon;
+struct pgwt_metrics;
+
+/* Capture fidelity — what a tier's records mean. SAMPLED records are point
+ * observations (worth one sample_period_ns each); EXACT records are
+ * transition intervals with real durations. A3's compute layer keys view
+ * availability off this. */
+enum pgwt_fidelity {
+    PGWT_FIDELITY_SAMPLED = 0,
+    PGWT_FIDELITY_EXACT   = 1,
+};
+
+/* Provider-reported self-metrics, surfaced via the control socket. Filled
+ * by self_metrics(); the control layer copies the live fields it wants.
+ * Kept separate from pgwt_counters so a provider can report tier-specific
+ * numbers without bloating the shared counter struct. */
+struct pgwt_metrics {
+    uint64_t samples_total;       /* SAMPLES records written (sampled tier) */
+    double   samples_per_sec;     /* recent sample rate */
+    uint64_t sample_read_faults;  /* process_vm_readv partial/EFAULT fallbacks */
+    uint64_t ringbuf_drops_total; /* event_ringbuf drops (full tier, BPF-side) */
+};
+
+/* Capture provider vtable. All function pointers operate on the daemon;
+ * a provider stores its private state inside struct pgwt_daemon (sampler
+ * state, BPF skeleton, etc.) — there is exactly one daemon per process.
+ * Any pointer may be NULL (treated as a no-op success) except poll() for
+ * a provider that produces data. */
+struct pgwt_capture_provider {
+    const char *name;                 /* "full" | "sampled" | "coop" */
+    enum pgwt_fidelity fidelity;
+
+    /* Arm capture. Called once after pgwt_daemon_init() wiring is done.
+     * Returns 0 on success, -1 on fatal error. */
+    int  (*start)(struct pgwt_daemon *d);
+
+    /* Disarm capture (detach watchpoints, stop the sampler). Idempotent. */
+    int  (*stop)(struct pgwt_daemon *d);
+
+    /* Drain captured data into the trace writer. Called from the event
+     * loop: for the full tier this is the ringbuf consume; for the
+     * sampled tier this is the per-tick read+encode. Returns 0 on success. */
+    int  (*poll)(struct pgwt_daemon *d);
+
+    /* Fill provider-specific metrics. May be NULL. */
+    void (*self_metrics)(struct pgwt_daemon *d, struct pgwt_metrics *m);
+};
+
+/* Daemon capture mode (set from --mode, default full). */
+enum pgwt_mode {
+    PGWT_MODE_FULL = 0,    /* watchpoints only — today's default */
+    PGWT_MODE_SAMPLED,     /* userspace sampler only, no watchpoints */
+    PGWT_MODE_TIERED,      /* sampler always on; escalation lands in A4 */
+};
+
+/* The two real providers (A2). coop is A6. */
+extern const struct pgwt_capture_provider pgwt_provider_full;
+extern const struct pgwt_capture_provider pgwt_provider_sampled;
+
+#endif /* PGWT_PROVIDER_H */

--- a/src/provider_full.c
+++ b/src/provider_full.c
@@ -1,0 +1,69 @@
+/* provider_full.c — Full (watchpoint) capture provider (Track A, A.0)
+ *
+ * Wraps the original hardware-watchpoint + BPF path behind the provider
+ * interface with NO behavioral change. The watchpoint attach/detach
+ * lifecycle stays in backend.c (driven by the fork/exit tracepoints and
+ * pgwt_scan_existing_backends); this provider owns the runtime drain of the
+ * event_ringbuf and the full-tier self-metrics.
+ *
+ * start/stop are no-ops: the watchpoints are armed during pgwt_daemon_init
+ * (scan_existing_backends) and as backends fork, exactly as before. poll()
+ * is the event_ringbuf consume that daemon.c used to call inline.
+ */
+#include "provider.h"
+#include "daemon.h"
+
+#include <bpf/libbpf.h>
+#include <bpf/bpf.h>
+#include "pg_wait_tracer.skel.h"
+
+static int full_start(struct pgwt_daemon *d)
+{
+    (void)d;
+    return 0;  /* watchpoints armed in daemon_init / on fork — unchanged */
+}
+
+static int full_stop(struct pgwt_daemon *d)
+{
+    (void)d;
+    return 0;  /* watchpoints closed in pgwt_close_all_backends — unchanged */
+}
+
+static int full_poll(struct pgwt_daemon *d)
+{
+    if (d->event_rb)
+        ring_buffer__consume(d->event_rb);
+    return 0;
+}
+
+/* Read the BPF-side event_ringbuf drop counter (A2: a per-CPU array map the
+ * BPF program bumps when bpf_ringbuf_output() fails). Sum across CPUs. */
+static void full_metrics(struct pgwt_daemon *d, struct pgwt_metrics *m)
+{
+    if (!d->skel)
+        return;
+    int fd = bpf_map__fd(d->skel->maps.ringbuf_drops);
+    if (fd < 0)
+        return;
+
+    int ncpu = libbpf_num_possible_cpus();
+    if (ncpu <= 0)
+        ncpu = 1;
+    uint64_t per_cpu[ncpu];
+    uint32_t key = 0;
+    if (bpf_map_lookup_elem(fd, &key, per_cpu) == 0) {
+        uint64_t total = 0;
+        for (int i = 0; i < ncpu; i++)
+            total += per_cpu[i];
+        m->ringbuf_drops_total = total;
+    }
+}
+
+const struct pgwt_capture_provider pgwt_provider_full = {
+    .name         = "full",
+    .fidelity     = PGWT_FIDELITY_EXACT,
+    .start        = full_start,
+    .stop         = full_stop,
+    .poll         = full_poll,
+    .self_metrics = full_metrics,
+};

--- a/src/sampler.c
+++ b/src/sampler.c
@@ -1,0 +1,296 @@
+/* sampler.c — Sampled capture provider (Track A, D1)
+ *
+ * See sampler.h for the design. The core read/build logic
+ * (pgwt_sampler_read_targets / pgwt_sampler_build_batch) is free of BPF and
+ * daemon dependencies so the unit test can exercise it against a controlled
+ * target process. The provider hooks (start/stop/poll/metrics) bridge to the
+ * live daemon: they build the per-tick target list from the backend registry
+ * + BPF state_map and push the batch into the trace writer.
+ *
+ * The provider vtable itself lives at the bottom and is compiled into both
+ * the daemon (with BPF) and never into pgwt-server. The BPF-touching parts
+ * are guarded by !PGWT_SERVER so the unit test can link the BPF-free core.
+ */
+#define _GNU_SOURCE   /* process_vm_readv */
+#include "sampler.h"
+#include "pg_wait_tracer.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <sys/uio.h>
+
+/* ── BPF-free core (testable without a daemon) ────────────────────────── */
+
+int pgwt_sampler_read_targets(const struct pgwt_sample_target *targets, int n,
+                              uint32_t *out_vals, uint64_t *read_faults)
+{
+    if (n <= 0)
+        return 0;
+
+    struct iovec *liov = calloc(n, sizeof(*liov));
+    struct iovec *riov = calloc(n, sizeof(*riov));
+    if (!liov || !riov) {
+        free(liov);
+        free(riov);
+        return 0;
+    }
+
+    for (int i = 0; i < n; i++) {
+        out_vals[i] = 0;
+        liov[i].iov_base = &out_vals[i];
+        liov[i].iov_len  = sizeof(uint32_t);
+        riov[i].iov_base = (void *)(uintptr_t)targets[i].wait_event_addr;
+        riov[i].iov_len  = sizeof(uint32_t);
+    }
+
+    /* All backends share PG's inherited anonymous-mmap shm, so every
+     * wait_event_info lives in the *same* address space — reading them via a
+     * single pid in one syscall is correct and cheapest. We read via the
+     * first target's pid; the remote iovecs point at every backend's
+     * (identical-across-processes) address. process_vm_readv reads in order
+     * and returns the number of bytes successfully transferred, so a partial
+     * result tells us exactly how many leading entries landed. */
+    pid_t reader_pid = targets[0].pid;
+    int got = 0;
+    ssize_t r = process_vm_readv(reader_pid, liov, n, riov, n, 0);
+
+    if (r == (ssize_t)(n * sizeof(uint32_t))) {
+        got = n;
+    } else if (r > 0) {
+        /* Partial: the first (r / 4) entries are valid; the entry that
+         * faulted and everything after it must be retried per-pid. */
+        got = (int)(r / sizeof(uint32_t));
+    }
+    /* r <= 0 (e.g. reader_pid exited between registry snapshot and syscall):
+     * got stays 0 and we fall through to the per-pid path for all entries. */
+
+    /* Per-pid fallback for the unread tail. Each is read against its OWN pid
+     * (the shared address still resolves there) so one dead backend can't
+     * sink the rest. */
+    for (int i = got; i < n; i++) {
+        uint32_t val = 0;
+        char path[64];
+        snprintf(path, sizeof(path), "/proc/%d/mem", targets[i].pid);
+        int fd = open(path, O_RDONLY | O_CLOEXEC);
+        if (fd >= 0) {
+            if (pread(fd, &val, sizeof(val),
+                      (off_t)targets[i].wait_event_addr) == (ssize_t)sizeof(val)) {
+                out_vals[i] = val;
+                got++;
+            }
+            close(fd);
+        }
+        if (read_faults)
+            (*read_faults)++;
+    }
+
+    free(liov);
+    free(riov);
+    return got;
+}
+
+int pgwt_sampler_build_batch(const struct pgwt_sample_target *targets,
+                             const uint32_t *vals, int n, uint64_t tick_ts,
+                             struct pgwt_trace_event *out)
+{
+    int count = 0;
+    for (int i = 0; i < n; i++) {
+        uint32_t we = vals[i];
+        /* event 0 == on CPU: not a wait, no sample to record (ASH counts
+         * the active session via its non-idle waits and CPU separately;
+         * A3 derives CPU from coverage, not from on-CPU samples). */
+        if (we == 0)
+            continue;
+
+        struct pgwt_trace_event *e = &out[count++];
+        e->timestamp_ns = tick_ts;
+        e->pid          = (uint32_t)targets[i].pid;
+        e->old_event    = 0;       /* samples carry no previous state */
+        e->new_event    = we;      /* the sampled wait event */
+        e->flags        = 0;       /* SAMPLE flag is set by the reader */
+        e->duration_ns  = 0;       /* samples carry no duration */
+        e->query_id     = targets[i].query_id;
+    }
+    return count;
+}
+
+/* ── Daemon-side provider hooks (need the BPF skeleton) ───────────────── */
+
+#ifndef PGWT_SERVER
+
+#include "daemon.h"
+#include "backend.h"
+#include "event_writer.h"
+#include "discovery.h"
+
+#include <time.h>
+#include <bpf/libbpf.h>
+#include <bpf/bpf.h>
+#include "pg_wait_tracer.skel.h"
+
+static uint64_t mono_ns(void)
+{
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return (uint64_t)ts.tv_sec * 1000000000ULL + ts.tv_nsec;
+}
+
+/* Read pid -> query_id from the BPF state_map, maintained by the
+ * on_report_query_id uprobe. Returns 0 if unknown. */
+static uint64_t lookup_query_id(struct pgwt_daemon *d, pid_t pid)
+{
+    if (!d->skel)
+        return 0;
+    int fd = bpf_map__fd(d->skel->maps.state_map);
+    if (fd < 0)
+        return 0;
+    uint32_t key = (uint32_t)pid;
+    struct pgwt_pid_state st;
+    if (bpf_map_lookup_elem(fd, &key, &st) == 0)
+        return st.last_query_id;
+    return 0;
+}
+
+/* Seed an empty state_map entry for a sampled-mode backend. The
+ * on_report_query_id uprobe only UPDATES existing entries (it never creates
+ * them), so without a seed the sampler would never see a query_id — there is
+ * no on_watchpoint in sampled mode to create the entry. Idempotent
+ * (BPF_NOEXIST). */
+static void seed_state_entry(struct pgwt_daemon *d, pid_t pid, uint64_t addr)
+{
+    if (!d->skel)
+        return;
+    int fd = bpf_map__fd(d->skel->maps.state_map);
+    if (fd < 0)
+        return;
+    uint32_t key = (uint32_t)pid;
+    struct pgwt_pid_state st = {
+        .last_event = 0,
+        .last_ts = mono_ns(),
+        .last_query_id = 0,
+        .wait_event_addr = addr,
+    };
+    bpf_map_update_elem(fd, &key, &st, BPF_NOEXIST);
+}
+
+int pgwt_sampler_start(struct pgwt_daemon *d)
+{
+    struct pgwt_sampler *s = calloc(1, sizeof(*s));
+    if (!s) {
+        fprintf(stderr, "FATAL: cannot allocate sampler state\n");
+        return -1;
+    }
+
+    int hz = d->sample_rate_hz > 0 ? d->sample_rate_hz : 10;
+    s->sample_period_ns = 1000000000ULL / (uint64_t)hz;
+
+    s->read_vals = calloc(MAX_BACKENDS, sizeof(*s->read_vals));
+    s->samples   = calloc(MAX_BACKENDS, sizeof(*s->samples));
+    if (!s->read_vals || !s->samples) {
+        free(s->read_vals);
+        free(s->samples);
+        free(s);
+        fprintf(stderr, "FATAL: cannot allocate sampler buffers\n");
+        return -1;
+    }
+
+    d->sampler = s;
+    if (d->verbose)
+        fprintf(stderr, "INFO: sampler started: %d Hz (period %llu ns)\n",
+                hz, (unsigned long long)s->sample_period_ns);
+    return 0;
+}
+
+int pgwt_sampler_stop(struct pgwt_daemon *d)
+{
+    struct pgwt_sampler *s = d->sampler;
+    if (!s)
+        return 0;
+    free(s->read_vals);
+    free(s->samples);
+    free(s);
+    d->sampler = NULL;
+    return 0;
+}
+
+/* One sampling tick. Build the target list from the live registry, read all
+ * wait_event_info in one syscall (+ per-pid fallback), encode non-CPU
+ * readings, and push a SAMPLES block. Called from the daemon timer. */
+int pgwt_sampler_poll(struct pgwt_daemon *d)
+{
+    struct pgwt_sampler *s = d->sampler;
+    if (!s)
+        return 0;
+
+    /* Reuse a stack target array sized to the live count; MAX_BACKENDS cap. */
+    static struct pgwt_sample_target targets[MAX_BACKENDS];
+    int n = 0;
+    for (int i = 0; i < d->backends.count && n < MAX_BACKENDS; i++) {
+        struct pgwt_backend *be = &d->backends.entries[i];
+        if (!be->is_alive || be->pid <= 0)
+            continue;
+        /* In sampled mode no bootstrap watchpoint resolves wp_addr, so a
+         * freshly-forked backend arrives with wp_addr == 0. Lazily resolve
+         * it by dereferencing the my_wait_event_info global in that backend
+         * (same VA in every backend; the deref gives its own PGPROC slot).
+         * Skip this tick if the backend hasn't set the pointer yet. */
+        if (be->wp_addr == 0) {
+            be->wp_addr = pgwt_read_pointer(be->pid, d->my_wait_ptr_addr);
+            if (be->wp_addr == 0)
+                continue;
+            /* First time we resolved this backend — seed its state_map entry
+             * so the query_id uprobe can populate it. */
+            seed_state_entry(d, be->pid, be->wp_addr);
+        }
+        targets[n].pid             = be->pid;
+        targets[n].wait_event_addr = be->wp_addr;
+        targets[n].query_id        = lookup_query_id(d, be->pid);
+        n++;
+    }
+    if (n == 0)
+        return 0;
+
+    uint64_t tick_ts = mono_ns();
+    uint64_t faults_before = s->read_faults_total;
+    pgwt_sampler_read_targets(targets, n, s->read_vals, &s->read_faults_total);
+    d->counters.sample_read_faults_total +=
+        (s->read_faults_total - faults_before);
+
+    int count = pgwt_sampler_build_batch(targets, s->read_vals, n, tick_ts,
+                                         s->samples);
+    if (count == 0)
+        return 0;
+
+    if (d->event_writer)
+        pgwt_writer_push_samples(d->event_writer, s->samples, count,
+                                 s->sample_period_ns);
+
+    s->samples_total += (uint64_t)count;
+    d->counters.samples_total += (uint64_t)count;
+    return 0;
+}
+
+void pgwt_sampler_metrics(struct pgwt_daemon *d, struct pgwt_metrics *m)
+{
+    if (d->sampler) {
+        m->samples_total      = d->sampler->samples_total;
+        m->sample_read_faults = d->sampler->read_faults_total;
+    }
+}
+
+/* ── Provider vtables ─────────────────────────────────────────────────── */
+
+const struct pgwt_capture_provider pgwt_provider_sampled = {
+    .name         = "sampled",
+    .fidelity     = PGWT_FIDELITY_SAMPLED,
+    .start        = pgwt_sampler_start,
+    .stop         = pgwt_sampler_stop,
+    .poll         = pgwt_sampler_poll,
+    .self_metrics = pgwt_sampler_metrics,
+};
+
+#endif /* !PGWT_SERVER */

--- a/src/sampler.c
+++ b/src/sampler.c
@@ -47,45 +47,47 @@ int pgwt_sampler_read_targets(const struct pgwt_sample_target *targets, int n,
         riov[i].iov_len  = sizeof(uint32_t);
     }
 
-    /* All backends share PG's inherited anonymous-mmap shm, so every
-     * wait_event_info lives in the *same* address space — reading them via a
-     * single pid in one syscall is correct and cheapest. We read via the
-     * first target's pid; the remote iovecs point at every backend's
-     * (identical-across-processes) address. process_vm_readv reads in order
-     * and returns the number of bytes successfully transferred, so a partial
-     * result tells us exactly how many leading entries landed. */
-    pid_t reader_pid = targets[0].pid;
+    /* Most backends' wait_event_info lives in PG's shared-memory mmap, which
+     * is mapped at the SAME virtual address in every backend — so one
+     * process_vm_readv across all of them via a single reader pid resolves
+     * them in one syscall. A few processes (logger, some aux workers) keep a
+     * process-LOCAL wait_event_info whose address is only mapped in that
+     * process; reading it via another pid faults. process_vm_readv reads
+     * iovecs in order and returns the bytes transferred, stopping at the
+     * first faulting entry. We therefore sweep: read as far as possible in
+     * one syscall, per-pid pread() the single faulting entry, then RESUME the
+     * combined read for the remainder. One outlier costs one pread, not N. */
     int got = 0;
-    ssize_t r = process_vm_readv(reader_pid, liov, n, riov, n, 0);
+    int base = 0;   /* first not-yet-read index */
+    while (base < n) {
+        pid_t reader_pid = targets[base].pid;
+        int rem = n - base;
+        ssize_t r = process_vm_readv(reader_pid, liov + base, rem,
+                                     riov + base, rem, 0);
+        int done = (r > 0) ? (int)(r / sizeof(uint32_t)) : 0;
+        got  += done;
+        base += done;
+        if (base >= n)
+            break;
 
-    if (r == (ssize_t)(n * sizeof(uint32_t))) {
-        got = n;
-    } else if (r > 0) {
-        /* Partial: the first (r / 4) entries are valid; the entry that
-         * faulted and everything after it must be retried per-pid. */
-        got = (int)(r / sizeof(uint32_t));
-    }
-    /* r <= 0 (e.g. reader_pid exited between registry snapshot and syscall):
-     * got stays 0 and we fall through to the per-pid path for all entries. */
-
-    /* Per-pid fallback for the unread tail. Each is read against its OWN pid
-     * (the shared address still resolves there) so one dead backend can't
-     * sink the rest. */
-    for (int i = got; i < n; i++) {
+        /* targets[base] faulted under reader_pid (or the reader itself is
+         * gone). Read it against its own pid via /proc/<pid>/mem. */
         uint32_t val = 0;
         char path[64];
-        snprintf(path, sizeof(path), "/proc/%d/mem", targets[i].pid);
+        snprintf(path, sizeof(path), "/proc/%d/mem", targets[base].pid);
         int fd = open(path, O_RDONLY | O_CLOEXEC);
         if (fd >= 0) {
             if (pread(fd, &val, sizeof(val),
-                      (off_t)targets[i].wait_event_addr) == (ssize_t)sizeof(val)) {
-                out_vals[i] = val;
+                      (off_t)targets[base].wait_event_addr) ==
+                (ssize_t)sizeof(val)) {
+                out_vals[base] = val;
                 got++;
             }
             close(fd);
         }
         if (read_faults)
             (*read_faults)++;
+        base++;   /* move past the entry we just handled (or skipped) */
     }
 
     free(liov);

--- a/src/sampler.h
+++ b/src/sampler.h
@@ -1,0 +1,83 @@
+/* sampler.h — Sampled capture provider (Track A, D1)
+ *
+ * Pure-userspace ASH-style sampling: on each timer tick read every tracked
+ * backend's PGPROC->wait_event_info with a SINGLE process_vm_readv() call
+ * (one remote iovec per backend, 4 bytes each), turn each non-CPU reading
+ * into a SAMPLES record, and hand the batch to the trace writer via
+ * pgwt_writer_push_samples(). No BPF in the per-sample hot path; PostgreSQL
+ * executes zero extra instructions.
+ *
+ * Addresses come from the backend registry (pid -> resolved wait_event_info
+ * address, the same field the watchpoint tier resolves). query_id per sample
+ * is joined from the BPF state_map (the on_report_query_id uprobe maintains
+ * pid->query_id) — never read from PG memory in the sample path.
+ *
+ * Robustness: PG's main shm is inherited anonymous mmap, so the address is
+ * identical across backends and one process_vm_readv from any live pid would
+ * suffice — but we issue per-pid local/remote iovec pairs so a single
+ * concurrently-exiting backend that returns EFAULT only loses its own entry.
+ * On a short read we fall back to per-pid pread() of /proc/<pid>/mem for the
+ * affected entries instead of aborting the whole tick.
+ */
+#ifndef PGWT_SAMPLER_H
+#define PGWT_SAMPLER_H
+
+#include "pg_wait_tracer.h"
+
+#include <stdint.h>
+#include <sys/types.h>
+
+struct pgwt_daemon;
+struct pgwt_metrics;
+
+/* A registry snapshot the sampler reads each tick. Decouples the sampler's
+ * core logic (testable without the daemon) from the live backend table:
+ * the daemon fills this from d->backends, but the unit test fills it from a
+ * fake registry. */
+struct pgwt_sample_target {
+    pid_t    pid;
+    uint64_t wait_event_addr; /* PGPROC->wait_event_info address */
+    uint64_t query_id;        /* joined from the registry/state_map */
+};
+
+struct pgwt_sampler {
+    /* sample_period_ns is recorded in each SAMPLES block header (A3 weights
+     * each sample by it). Equal to 1e9 / sample_rate_hz. */
+    uint64_t sample_period_ns;
+
+    /* Scratch buffers sized for MAX_BACKENDS, allocated once. */
+    struct iovec *local_iov;     /* MAX_BACKENDS */
+    struct iovec *remote_iov;    /* MAX_BACKENDS */
+    uint32_t     *read_vals;     /* MAX_BACKENDS — wait_event_info per target */
+    struct pgwt_trace_event *samples; /* MAX_BACKENDS — encoded batch */
+
+    uint64_t samples_total;       /* cumulative SAMPLES records written */
+    uint64_t read_faults_total;   /* per-pid pread fallbacks taken */
+};
+
+/* Provider hooks (see provider.h). Exposed for the vtable in sampler.c. */
+int  pgwt_sampler_start(struct pgwt_daemon *d);
+int  pgwt_sampler_stop(struct pgwt_daemon *d);
+int  pgwt_sampler_poll(struct pgwt_daemon *d);
+void pgwt_sampler_metrics(struct pgwt_daemon *d, struct pgwt_metrics *m);
+
+/* ── Exposed for unit testing (no daemon, no BPF) ─────────────────────── */
+
+/* Read each target's wait_event_info from process memory. Issues one
+ * process_vm_readv() with up to `n` iovec pairs; on a short read, retries
+ * the missing entries with per-pid pread(/proc/<pid>/mem). Writes results
+ * into out_vals[i] (0 left in place for entries that could not be read).
+ * read_faults (may be NULL) is incremented once per pread fallback taken.
+ * Returns the number of entries successfully read. */
+int pgwt_sampler_read_targets(const struct pgwt_sample_target *targets, int n,
+                              uint32_t *out_vals, uint64_t *read_faults);
+
+/* Build the SAMPLES batch from targets + their freshly-read values. A target
+ * whose value is on-CPU (event 0) is skipped (no wait to record). `tick_ts`
+ * is the sample timestamp stamped on every record. Returns the number of
+ * sample records written into out (<= n). */
+int pgwt_sampler_build_batch(const struct pgwt_sample_target *targets,
+                             const uint32_t *vals, int n, uint64_t tick_ts,
+                             struct pgwt_trace_event *out);
+
+#endif /* PGWT_SAMPLER_H */

--- a/src/server.c
+++ b/src/server.c
@@ -2048,8 +2048,16 @@ static void dump_summary(struct pgwt_server *srv)
     int count;
     struct pgwt_trace_event *events = server_load_events(srv, from, to, &count);
 
+    /* Count sample vs transition records so a sampled-mode trace is visible
+     * at a glance (A2 evidence: SAMPLES blocks landed). */
+    int n_samples = 0;
+    for (int i = 0; i < count; i++)
+        if (events[i].flags & PGWT_EVENT_FLAG_SAMPLE)
+            n_samples++;
+
     printf("════════════════════════════════════════════════════════════════════════════════\n");
-    printf("pgwt-server — Summary    Events: %d    Duration: %.1fs\n", count, wall_ms / 1000.0);
+    printf("pgwt-server — Summary    Events: %d (%d transitions, %d samples)    Duration: %.1fs\n",
+           count, count - n_samples, n_samples, wall_ms / 1000.0);
     printf("════════════════════════════════════════════════════════════════════════════════\n");
 
     /* Time Model */

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -6,8 +6,8 @@ CFLAGS    = -g -O2 -Wall -I../src -I../include
 BUILD     = ../build
 
 TESTS     = test_wait_event test_cmdline test_event_writer test_event_reader \
-            test_trace_v2 test_bucket gen_test_traces gen_bench_traces \
-            test_concurrent_rw
+            test_trace_v2 test_sampler test_bucket gen_test_traces \
+            gen_bench_traces test_concurrent_rw
 
 .PHONY: all clean
 
@@ -35,6 +35,12 @@ test_bucket: test_bucket.c
 test_trace_v2: test_trace_v2.c $(BUILD)/server_event_writer.o \
                $(BUILD)/server_event_reader.o
 	$(CC) $(CFLAGS) -DPGWT_SERVER -o $@ $^ -llz4
+
+# test_sampler: sampler core (process_vm_readv read + batch encode + per-pid
+# fallback). Compiles sampler.c with -DPGWT_SERVER so only the BPF-free core
+# is built — no skeleton, no bpftool, runnable in CI's server-only jobs.
+test_sampler: test_sampler.c ../src/sampler.c
+	$(CC) $(CFLAGS) -DPGWT_SERVER -o $@ $^
 
 # Server-build objects for gen_test_traces
 SERVER_OBJS = $(BUILD)/server_event_writer.o $(BUILD)/server_summary_writer.o \

--- a/tests/run_all.sh
+++ b/tests/run_all.sh
@@ -76,6 +76,7 @@ run_test "test_wait_event" "$SCRIPT_DIR/test_wait_event"
 run_test "test_cmdline" "$SCRIPT_DIR/test_cmdline"
 run_test "test_bucket" "$SCRIPT_DIR/test_bucket"
 run_test "test_trace_v2" "$SCRIPT_DIR/test_trace_v2"
+run_test "test_sampler" "$SCRIPT_DIR/test_sampler"
 
 # Step 2.5: Synthetic data correctness tests (no root needed, needs pgwt-server)
 if [[ -x "$PROJECT_DIR/pgwt-server" ]] && [[ -x "$SCRIPT_DIR/gen_test_traces" ]]; then

--- a/tests/test_sampler.c
+++ b/tests/test_sampler.c
@@ -1,0 +1,202 @@
+/* test_sampler.c — Unit tests for the sampled provider's core (Phase A2)
+ *
+ * Exercises the BPF-free sampler core (pgwt_sampler_read_targets and
+ * pgwt_sampler_build_batch) against a controlled target: this process's own
+ * memory (read via process_vm_readv on getpid()) and a child process with a
+ * known 4-byte value at a known address (read via the per-pid pread
+ * fallback). Built with -DPGWT_SERVER against the server objects so it needs
+ * no BPF skeleton (buildable without bpftool, and in CI), matching
+ * test_trace_v2.
+ */
+#define _GNU_SOURCE
+#include "sampler.h"
+#include "pg_wait_tracer.h"
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <stdint.h>
+#include <sys/mman.h>
+#include <sys/wait.h>
+#include <signal.h>
+
+static int tests_run = 0;
+static int tests_passed = 0;
+
+#define CHECK(cond, fmt, ...) do { \
+    tests_run++; \
+    if (cond) { tests_passed++; } \
+    else { printf("  FAIL: " fmt "\n", ##__VA_ARGS__); } \
+} while(0)
+
+/* ── Test 1: read this process's own memory via process_vm_readv ──────── */
+
+static void test_self_read(void)
+{
+    printf("--- self-read via process_vm_readv ---\n");
+
+    /* Three known values; one is 0 (on-CPU) to confirm reads, not just
+     * encoding, handle it. */
+    volatile uint32_t v0 = WEI(PG_WAIT_IO, 0x12);     /* IO:something */
+    volatile uint32_t v1 = 0;                          /* on CPU */
+    volatile uint32_t v2 = WEI(PG_WAIT_LOCK, 0x03);   /* Lock:something */
+
+    struct pgwt_sample_target targets[3] = {
+        { .pid = getpid(), .wait_event_addr = (uint64_t)(uintptr_t)&v0, .query_id = 111 },
+        { .pid = getpid(), .wait_event_addr = (uint64_t)(uintptr_t)&v1, .query_id = 222 },
+        { .pid = getpid(), .wait_event_addr = (uint64_t)(uintptr_t)&v2, .query_id = 333 },
+    };
+
+    uint32_t vals[3] = { 0xdead, 0xdead, 0xdead };
+    uint64_t faults = 0;
+    int got = pgwt_sampler_read_targets(targets, 3, vals, &faults);
+
+    CHECK(got == 3, "expected 3 reads, got %d", got);
+    CHECK(vals[0] == v0, "vals[0]=0x%x expected 0x%x", vals[0], v0);
+    CHECK(vals[1] == 0,  "vals[1]=0x%x expected 0", vals[1]);
+    CHECK(vals[2] == v2, "vals[2]=0x%x expected 0x%x", vals[2], v2);
+    CHECK(faults == 0, "expected no fallback faults, got %llu",
+          (unsigned long long)faults);
+}
+
+/* ── Test 2: build_batch skips on-CPU and encodes fields ──────────────── */
+
+static void test_build_batch(void)
+{
+    printf("--- build_batch encoding + on-CPU skip ---\n");
+
+    struct pgwt_sample_target targets[3] = {
+        { .pid = 1001, .wait_event_addr = 0x1000, .query_id = 111 },
+        { .pid = 1002, .wait_event_addr = 0x2000, .query_id = 222 },
+        { .pid = 1003, .wait_event_addr = 0x3000, .query_id = 333 },
+    };
+    uint32_t vals[3] = {
+        WEI(PG_WAIT_IO, 0x01),  /* recorded */
+        0,                       /* on CPU — skipped */
+        WEI(PG_WAIT_LWLOCK, 0x07),
+    };
+
+    struct pgwt_trace_event out[3];
+    memset(out, 0xAA, sizeof(out));
+    uint64_t ts = 0x123456789ABCULL;
+    int n = pgwt_sampler_build_batch(targets, vals, 3, ts, out);
+
+    CHECK(n == 2, "expected 2 records (1 on-CPU skipped), got %d", n);
+
+    /* Record 0 = target 0 */
+    CHECK(out[0].timestamp_ns == ts, "ts mismatch");
+    CHECK(out[0].pid == 1001, "pid=%u expected 1001", out[0].pid);
+    CHECK(out[0].new_event == vals[0], "new_event=0x%x expected 0x%x",
+          out[0].new_event, vals[0]);
+    CHECK(out[0].old_event == 0, "old_event must be 0 for samples");
+    CHECK(out[0].duration_ns == 0, "duration must be 0 for samples");
+    CHECK(out[0].query_id == 111, "query_id=%llu expected 111",
+          (unsigned long long)out[0].query_id);
+
+    /* Record 1 = target 2 (target 1 was on-CPU) */
+    CHECK(out[1].pid == 1003, "pid=%u expected 1003", out[1].pid);
+    CHECK(out[1].new_event == vals[2], "new_event=0x%x expected 0x%x",
+          out[1].new_event, vals[2]);
+    CHECK(out[1].query_id == 333, "query_id=%llu expected 333",
+          (unsigned long long)out[1].query_id);
+}
+
+/* ── Test 3: per-pid pread fallback on a bad leading entry ────────────── */
+
+static void test_fallback(void)
+{
+    printf("--- per-pid pread fallback ---\n");
+
+    /* A valid value we want recovered. */
+    volatile uint32_t good = WEI(PG_WAIT_CLIENT, 0x00);
+
+    /* Target 0 points at an unmapped address: process_vm_readv faults at the
+     * first iovec, returning a partial (0 bytes) result, so the whole batch
+     * falls to the per-pid pread path. Target 1 is a valid self address and
+     * must still be recovered by pread(/proc/self/mem). */
+    void *bad = mmap(NULL, 4096, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    CHECK(bad != MAP_FAILED, "mmap PROT_NONE failed");
+    munmap(bad, 4096);   /* now definitely unmapped */
+
+    struct pgwt_sample_target targets[2] = {
+        { .pid = getpid(), .wait_event_addr = (uint64_t)(uintptr_t)bad, .query_id = 1 },
+        { .pid = getpid(), .wait_event_addr = (uint64_t)(uintptr_t)&good, .query_id = 2 },
+    };
+
+    uint32_t vals[2] = { 0xdead, 0xdead };
+    uint64_t faults = 0;
+    int got = pgwt_sampler_read_targets(targets, 2, vals, &faults);
+
+    /* The good entry must be recovered via pread even though entry 0 faulted. */
+    CHECK(vals[1] == good, "fallback vals[1]=0x%x expected 0x%x", vals[1], good);
+    CHECK(got >= 1, "expected at least the good entry recovered, got %d", got);
+    CHECK(faults >= 1, "expected >=1 fallback fault recorded, got %llu",
+          (unsigned long long)faults);
+}
+
+/* ── Test 4: child process read via fallback (different pid) ───────────── */
+
+static void test_child_read(void)
+{
+    printf("--- read child process value (cross-pid) ---\n");
+
+    /* Shared anonymous mmap: parent writes a known value, child sees it at
+     * its own (possibly different) virtual address, reports the address back
+     * via pipe, then sleeps so the parent can sample it. */
+    void *page = mmap(NULL, 4096, PROT_READ | PROT_WRITE,
+                      MAP_SHARED | MAP_ANONYMOUS, -1, 0);
+    CHECK(page != MAP_FAILED, "mmap shared failed");
+    if (page == MAP_FAILED)
+        return;
+
+    volatile uint32_t *slot = page;
+    *slot = WEI(PG_WAIT_IPC, 0x42);
+
+    int pfd[2];
+    if (pipe(pfd) != 0) { CHECK(0, "pipe failed"); return; }
+
+    pid_t child = fork();
+    if (child == 0) {
+        /* Child: report the slot's address (same VA — MAP_SHARED inherited),
+         * then idle until killed. */
+        uint64_t addr = (uint64_t)(uintptr_t)slot;
+        ssize_t w = write(pfd[1], &addr, sizeof(addr));
+        (void)w;
+        for (;;) pause();
+        _exit(0);
+    }
+    CHECK(child > 0, "fork failed");
+
+    uint64_t child_addr = 0;
+    ssize_t r = read(pfd[0], &child_addr, sizeof(child_addr));
+    CHECK(r == (ssize_t)sizeof(child_addr), "did not get child address");
+
+    struct pgwt_sample_target targets[1] = {
+        { .pid = child, .wait_event_addr = child_addr, .query_id = 7 },
+    };
+    uint32_t vals[1] = { 0xdead };
+    uint64_t faults = 0;
+    int got = pgwt_sampler_read_targets(targets, 1, vals, &faults);
+
+    CHECK(got == 1, "expected to read child value, got %d", got);
+    CHECK(vals[0] == WEI(PG_WAIT_IPC, 0x42),
+          "child vals[0]=0x%x expected 0x%x", vals[0], WEI(PG_WAIT_IPC, 0x42));
+
+    kill(child, SIGKILL);
+    waitpid(child, NULL, 0);
+    close(pfd[0]);
+    close(pfd[1]);
+    munmap(page, 4096);
+}
+
+int main(void)
+{
+    test_self_read();
+    test_build_batch();
+    test_fallback();
+    test_child_read();
+
+    printf("\n%d/%d checks passed\n", tests_passed, tests_run);
+    return tests_passed == tests_run ? 0 : 1;
+}


### PR DESCRIPTION
Implements **Phase A2** of `docs/REWORK_PLAN.md`: an always-on, pure-userspace sampled capture tier alongside the existing watchpoint ("full") tier, behind a provider interface. The watchpoint path is unchanged; sampled mode reads every backend's `wait_event_info` with no BPF in the hot path and ~zero cost on PostgreSQL.

## Provider split (A.0 contract)

`src/provider.h` defines `struct pgwt_capture_provider { name, fidelity, start/stop/poll/self_metrics }`, `enum pgwt_fidelity { SAMPLED, EXACT }`, and `enum pgwt_mode { FULL, SAMPLED, TIERED }`.

- **`full`** (`src/provider_full.c`) — the original hardware-watchpoint + BPF path behind the interface. `poll()` is the `event_ringbuf` consume that `daemon.c` used to call inline; `self_metrics()` reports ringbuf drops. The watchpoint attach/detach lifecycle stays in `backend.c`. `--mode full` is byte-identical to today.
- **`sampled`** (`src/sampler.c/.h`) — the new tier.

The backend registry, fork/exit tracepoints, and `query_id` uprobe stay shared across modes (cheap, not in the per-sample hot path).

## Sampler design (D1)

- **One `process_vm_readv()` per tick** with one 4-byte remote iovec per tracked backend reads every backend's `wait_event_info` in a single syscall. No BPF in the per-sample path; PostgreSQL executes zero extra instructions.
- **Addresses** come from the registry (`wp_addr`). In sampled mode there is no bootstrap watchpoint, so the sampler resolves each backend's address lazily (deref of the `my_wait_event_info` global via `/proc/<pid>/mem`).
- **query_id** is joined from the BPF `state_map` that the `on_report_query_id` uprobe maintains — never read from PG memory in the sample path. A seeded `state_map` entry lets the uprobe populate query_id without `on_watchpoint`.
- **Robustness (D1 risk #1).** A few PG processes (logger, some aux workers) keep a *process-local* `wait_event_info` whose VA is only mapped in that process, so a combined read via another pid faults at that entry. The reader **sweeps**: read as far as possible in one syscall, `pread(/proc/<pid>/mem)` the single faulting entry, then resume the combined read for the remainder — one outlier costs one `pread`, not N. Live `sample_read_faults_total` dropped from ~1 fault/sample to ~1-2/tick with this. Verified live: regular backends share the same shm VA (`0x7f...`) and read in one syscall; only the local-address aux processes fall back. (huge_pages note: not tested with `huge_pages=on`; the per-pid fallback covers any VA divergence regardless.)
- Non-CPU readings become SAMPLES records via `pgwt_writer_push_samples()` (A1 API).

## Modes / rates

- `--mode full|sampled|tiered`, **default `full`** (today's behavior, unchanged). `sampled` and `full` are fully implemented. `tiered` runs the sampler always-on and logs that escalation arrives in A4 (no escalation engine built here, per the phase scope).
- `--sample-rate N` Hz (1-1000, **default 10**), driving a dedicated `timerfd` independent of the display interval.

## Ringbuf-drop metric (deferred from A0)

BPF per-CPU `ringbuf_drops` map, bumped whenever `bpf_ringbuf_output` into `event_ringbuf` fails. Summed across CPUs and surfaced on the control socket as `ringbuf_drops_total` (a real value, not a fake 0), alongside new `samples_total` / `samples_per_sec` / `sample_read_faults_total`. `status` now reports the active mode.

## Tests

- **`tests/test_sampler.c`** — BPF-free sampler core: read via `process_vm_readv` against this process and a child process (cross-pid), the per-pid `pread` fallback/resume path, and batch encoding + on-CPU skip. Built `-DPGWT_SERVER` like `test_trace_v2` (no bpftool needed). Wired into `tests/Makefile`, `run_all.sh` C-unit, and CI `build-and-unit`. **24/24 on the box.**
- `pgwt-server --dump` now reports transition vs sample record counts.

## Live evidence (Rocky 9, PG 18, pgbench)

**No watchpoints in sampled mode** — fd breakdown under 8 live pgbench clients:

| mode | `perf_event` fds | meaning |
|------|------------------|---------|
| sampled | **3** | fork tp + exit tp + query_id uprobe (constant) |
| full | **15** | the same 3 + ~12 hardware watchpoints (one per backend) |

Sampled holds zero hardware breakpoints; the count is constant regardless of backend count.

**Sample blocks land** — `pgwt-server --dump` of a sampled trace: `Events: 30614 (0 transitions, 30614 samples)`. Control socket during a 50 Hz run: `samples_total:4370, samples_per_sec:514` (≈ 50 Hz × ~10 active backends), `ringbuf_drops_total:0`, `events_total:0`.

**Overhead** (pgbench tps; small VM, run-to-run variance ~±5%):

| config | tps | daemon CPU |
|--------|-----|-----------|
| baseline (no tracer) | ~3240-3440 | — |
| sampled 10 Hz (default), no query uprobe | 3256 | **0.6%** of a core |
| sampled 100 Hz, no query uprobe | 3087 | **3.7%** of a core |
| sampled 100 Hz + query uprobe | 2599 | 3.7% |
| full | ~2454 | — |

The pure sampling cost on PG is negligible (10 Hz default is within baseline noise; 100 Hz ≈ 3087 vs ~3300 baseline). The larger drop in the last sampled row is the **`query_id` uprobe firing per query** — a PG-side cost shared with full mode and orthogonal to sampling, not introduced by A2. Daemon CPU is well under one core at every rate.

**Full mode unchanged** — `test_accuracy` 11/11 (DB-Time consistency 0.0% error), `test_deterministic` 11/11, `test_control` 16/16, `test_lwlock` 4/4, `test_cpu_time` 6/6, `test_query_event` 12/13 (the one failure, "Mode B parsed 0 entries", reproduces on master baseline — pre-existing Track-E debt, not introduced here). Control socket full-mode metrics: `mode:"full"`, `events_total:553039`, `ringbuf_drops_total:0`.

## Notes for later phases

- **A3 (fidelity-aware compute):** SAMPLES records decode with `PGWT_EVENT_FLAG_SAMPLE`, `old_event=0`, `duration_ns=0`, and the block header carries `sample_period_ns`. `compute.c` must weight each sample by `sample_period_ns` (ASH math), declare `required_fidelity` per view, and drop sample records inside transition-block time ranges (exact-wins merge). The live display path in sampled mode is intentionally not fidelity-aware yet (`pgwt_read_state_map` is skipped in sampled mode) — that lands in A3.
- **A4 (escalation/tiered):** `tiered` mode currently runs the sampler always-on with no escalation. The provider `start/stop` hooks and the control socket are the seams to add bounded/budgeted watchpoint escalation; `state_map` pre-seeding already exists for the full tier's scan path.
