### PR TITLE
A3: fidelity-aware compute — sampled estimators, exact-wins merge, unavailable for exact-only views

### DIFF
--- a/src/compute.h
+++ b/src/compute.h
@@ -35,6 +35,75 @@ static const char *pgwt_class_display[PGWT_NUM_CLASSES] = {
 /* Map wait_event_info → class index (0–10) */
 int pgwt_wait_class_index(uint32_t event_id);
 
+/* ── Fidelity (trace format v2 — D3) ───────────────────────── */
+
+/* The fidelity of the data covering a queried time window.
+ *
+ *   EXACT   — every covered range has TRANSITIONS (full-fidelity) blocks.
+ *   SAMPLED — every covered range has only SAMPLES blocks (point
+ *             observations); estimators use ASH math (each sample worth
+ *             one sample_period_ns).
+ *   MIXED   — the window spans both. Per the exact-wins merge rule,
+ *             transition data is authoritative inside transition-covered
+ *             ranges; samples only contribute outside them.
+ *   NONE    — no data at all in the window.
+ *
+ * The integer ordering is meaningful for merging window fidelities
+ * (see pgwt_fidelity_merge): NONE < EXACT < SAMPLED < MIXED. */
+enum pgwt_fidelity {
+    PGWT_FIDELITY_NONE    = 0,
+    PGWT_FIDELITY_EXACT   = 1,
+    PGWT_FIDELITY_SAMPLED = 2,
+    PGWT_FIDELITY_MIXED   = 3,
+};
+
+/* The fidelity a view requires to produce a meaningful result.
+ *   SAMPLED-capable views (time_model, system/session/query events, AAS,
+ *     active/sessions) work from samples via ASH math.
+ *   EXACT-required views (histogram/heatmap, transitions, fingerprints,
+ *     lock chains, interference, variants, concurrency) need real
+ *     intervals/order and report "unavailable" over a sampled-only window. */
+enum pgwt_required_fidelity {
+    PGWT_REQ_SAMPLED = 0,   /* samples are enough */
+    PGWT_REQ_EXACT   = 1,   /* needs full-fidelity transitions */
+};
+
+/* Derive the overall fidelity of a loaded window from what block types
+ * actually contributed records after the exact-wins merge. */
+static inline enum pgwt_fidelity
+pgwt_fidelity_of(int has_transitions, int has_samples)
+{
+    if (has_transitions && has_samples) return PGWT_FIDELITY_MIXED;
+    if (has_transitions)                return PGWT_FIDELITY_EXACT;
+    if (has_samples)                    return PGWT_FIDELITY_SAMPLED;
+    return PGWT_FIDELITY_NONE;
+}
+
+/* Lowercase token used in JSON responses ("exact"|"sampled"|"mixed"|"none"). */
+static inline const char *pgwt_fidelity_str(enum pgwt_fidelity fid)
+{
+    switch (fid) {
+    case PGWT_FIDELITY_EXACT:   return "exact";
+    case PGWT_FIDELITY_SAMPLED: return "sampled";
+    case PGWT_FIDELITY_MIXED:   return "mixed";
+    default:                    return "none";
+    }
+}
+
+/* True when a view requiring `req` fidelity cannot be produced from a
+ * window of the given `fid`. EXACT-required views are unavailable over a
+ * window that contributed no transition data (SAMPLED or NONE). */
+static inline int
+pgwt_fidelity_unavailable(enum pgwt_required_fidelity req, enum pgwt_fidelity fid)
+{
+    if (req != PGWT_REQ_EXACT)
+        return 0;
+    return (fid != PGWT_FIDELITY_EXACT && fid != PGWT_FIDELITY_MIXED);
+}
+
+/* Canonical message for an EXACT-required view over a sampled-only window. */
+#define PGWT_UNAVAILABLE_MSG "requires full-fidelity data"
+
 /* ── Filters ──────────────────────────────────────────────── */
 
 struct pgwt_filter {

--- a/src/server.c
+++ b/src/server.c
@@ -102,6 +102,15 @@ struct bm_entry {
 
 /* ── Server state ─────────────────────────────────────────── */
 
+/* A time range [start, end] in wall ns covered by a TRANSITIONS block.
+ * Used for the exact-wins merge (D3): samples inside a transition-covered
+ * range are dropped at read time so a sampler running through a
+ * full-fidelity window does not double-count. */
+struct trans_range {
+    uint64_t start_wall_ns;
+    uint64_t end_wall_ns;
+};
+
 /* Per-file event cache — for immutable .trace.lz4 files only */
 struct file_cache_entry {
     char     path[512];
@@ -110,6 +119,24 @@ struct file_cache_entry {
     int      immutable;
     uint64_t first_wall_ns;  /* earliest event timestamp (for range skip) */
     uint64_t last_wall_ns;   /* latest event timestamp */
+
+    /* Fidelity (trace format v2). Samples are stored already normalized:
+     * old_event = sampled event, duration_ns = sample_period_ns, with the
+     * PGWT_EVENT_FLAG_SAMPLE bit set so estimators apply ASH math and the
+     * exact-wins merge can identify them. */
+    int       has_transitions;
+    int       has_samples;
+    uint64_t  sample_period_ns;
+    struct trans_range *trans_ranges;  /* malloc'd; TRANSITIONS block ranges */
+    int       num_trans_ranges;
+};
+
+/* Fidelity summary of a loaded window, returned alongside the event array
+ * so handlers can tag responses and gate EXACT-required views. */
+struct pgwt_load_info {
+    int      has_transitions;   /* a TRANSITIONS block contributed records */
+    int      has_samples;       /* a SAMPLES record survived the merge */
+    uint64_t sample_period_ns;  /* nominal sample interval (0 if no samples) */
 };
 
 struct pgwt_server {
@@ -446,6 +473,8 @@ static void cache_evict_oldest(struct pgwt_server *srv)
     /* Evict the first (oldest) cached entry */
     free(srv->cache[0].events);
     srv->cache[0].events = NULL;
+    free(srv->cache[0].trans_ranges);
+    srv->cache[0].trans_ranges = NULL;
     memmove(&srv->cache[0], &srv->cache[1],
             (srv->cache_count - 1) * sizeof(srv->cache[0]));
     srv->cache_count--;
@@ -509,8 +538,35 @@ get_cached_immutable(struct pgwt_server *srv, const char *path)
             reader.block_index[reader.num_blocks - 1].timestamp_ns);
     }
 
+    int tr_cap = 0;
     for (int b = 0; b < reader.num_blocks; b++) {
-        int n = pgwt_reader_decode_block(&reader, b, block_buf, PGWT_BLOCK_EVENTS);
+        struct pgwt_block_info bi;
+        int n = pgwt_reader_decode_block_info(&reader, b, block_buf,
+                                              PGWT_BLOCK_EVENTS, &bi);
+        if (n < 0) continue;
+
+        if (bi.block_type == PGWT_BLOCK_SAMPLES) {
+            ce->has_samples = 1;
+            if (bi.sample_period_ns)
+                ce->sample_period_ns = bi.sample_period_ns;
+        } else {
+            ce->has_transitions = 1;
+            /* Record this transition block's wall range for the merge. */
+            if (ce->num_trans_ranges >= tr_cap) {
+                tr_cap = tr_cap ? tr_cap * 2 : 16;
+                struct trans_range *tmp = realloc(ce->trans_ranges,
+                                                  tr_cap * sizeof(*tmp));
+                if (tmp) ce->trans_ranges = tmp;
+            }
+            if (ce->trans_ranges && ce->num_trans_ranges < tr_cap) {
+                ce->trans_ranges[ce->num_trans_ranges].start_wall_ns =
+                    pgwt_reader_mono_to_wall(&reader, bi.first_timestamp_ns);
+                ce->trans_ranges[ce->num_trans_ranges].end_wall_ns =
+                    pgwt_reader_mono_to_wall(&reader, bi.last_timestamp_ns);
+                ce->num_trans_ranges++;
+            }
+        }
+
         for (int i = 0; i < n; i++) {
             if (ce->count >= cap) {
                 cap *= 2;
@@ -519,6 +575,13 @@ get_cached_immutable(struct pgwt_server *srv, const char *path)
                 ce->events = tmp;
             }
             ce->events[ce->count] = block_buf[i];
+            /* Normalize samples into interval shape so the duration-based
+             * estimators apply ASH math (each sample worth sample_period_ns).
+             * Keep the SAMPLE flag for the exact-wins merge and fidelity. */
+            if (block_buf[i].flags & PGWT_EVENT_FLAG_SAMPLE) {
+                ce->events[ce->count].old_event = block_buf[i].new_event;
+                ce->events[ce->count].duration_ns = bi.sample_period_ns;
+            }
             ce->events[ce->count].timestamp_ns =
                 pgwt_reader_mono_to_wall(&reader, block_buf[i].timestamp_ns);
             ce->count++;
@@ -543,14 +606,37 @@ get_cached_immutable(struct pgwt_server *srv, const char *path)
     return ce;
 }
 
-/* Read events from current.trace for a time range — on demand, no caching.
+/* Append one transition range to a growable collector. */
+static void trans_ranges_add(struct trans_range **ranges, int *count, int *cap,
+                             uint64_t start_wall_ns, uint64_t end_wall_ns)
+{
+    if (*count >= *cap) {
+        int newcap = *cap ? *cap * 2 : 16;
+        struct trans_range *tmp = realloc(*ranges, newcap * sizeof(**ranges));
+        if (!tmp) return;
+        *ranges = tmp;
+        *cap = newcap;
+    }
+    (*ranges)[*count].start_wall_ns = start_wall_ns;
+    (*ranges)[*count].end_wall_ns   = end_wall_ns;
+    (*count)++;
+}
+
+/* Read events from a trace file for a time range — on demand, no caching.
  * Opens file, seeks to the right blocks via block index, decodes only
  * the blocks that overlap [from_wall_ns, to_wall_ns].
- * Appends to events array at *total, growing if needed. */
+ * Appends events at *total (growing as needed) and, for the exact-wins
+ * merge, appends each TRANSITIONS block's wall range to *ranges. Sets
+ * fidelity flags / sample period in *info. SAMPLES records are normalized
+ * to interval shape (old_event = sampled event, duration_ns =
+ * sample_period_ns) so the duration-based estimators apply ASH math. */
 static void load_current_trace_range(const char *path,
                                       uint64_t from_wall_ns, uint64_t to_wall_ns,
                                       struct pgwt_trace_event **events,
-                                      int *total, int *cap)
+                                      int *total, int *cap,
+                                      struct trans_range **ranges,
+                                      int *nranges, int *ranges_cap,
+                                      struct pgwt_load_info *info)
 {
     struct pgwt_event_reader reader;
     if (pgwt_reader_open(&reader, path) != 0)
@@ -566,7 +652,20 @@ static void load_current_trace_range(const char *path,
         if (reader.block_index[b].timestamp_ns > to_mono)
             break;
 
-        int n = pgwt_reader_decode_block(&reader, b, block_buf, PGWT_BLOCK_EVENTS);
+        struct pgwt_block_info bi;
+        int n = pgwt_reader_decode_block_info(&reader, b, block_buf,
+                                              PGWT_BLOCK_EVENTS, &bi);
+        if (n < 0) continue;
+
+        if (bi.block_type == PGWT_BLOCK_SAMPLES) {
+            if (info && bi.sample_period_ns)
+                info->sample_period_ns = bi.sample_period_ns;
+        } else if (ranges) {
+            trans_ranges_add(ranges, nranges, ranges_cap,
+                pgwt_reader_mono_to_wall(&reader, bi.first_timestamp_ns),
+                pgwt_reader_mono_to_wall(&reader, bi.last_timestamp_ns));
+        }
+
         for (int i = 0; i < n; i++) {
             uint64_t ts_mono = block_buf[i].timestamp_ns;
             if (ts_mono < from_mono) continue;
@@ -580,6 +679,10 @@ static void load_current_trace_range(const char *path,
             }
 
             (*events)[*total] = block_buf[i];
+            if (block_buf[i].flags & PGWT_EVENT_FLAG_SAMPLE) {
+                (*events)[*total].old_event = block_buf[i].new_event;
+                (*events)[*total].duration_ns = bi.sample_period_ns;
+            }
             (*events)[*total].timestamp_ns =
                 pgwt_reader_mono_to_wall(&reader, ts_mono);
             (*total)++;
@@ -607,18 +710,37 @@ static uint64_t get_current_trace_latest(const char *path)
 
 /* ── Event loading ────────────────────────────────────────── */
 
+/* True if wall_ns falls inside any collected transition range [start,end]. */
+static int ts_in_trans_range(const struct trans_range *ranges, int n,
+                             uint64_t wall_ns)
+{
+    for (int i = 0; i < n; i++)
+        if (wall_ns >= ranges[i].start_wall_ns &&
+            wall_ns <= ranges[i].end_wall_ns)
+            return 1;
+    return 0;
+}
+
 /*
  * Load events in [from_wall_ns, to_wall_ns] from trace files.
  * Immutable .trace.lz4: from cache (read once per session).
  * current.trace: on-demand block reads (no caching, no memory growth).
  * Returns malloc'd array. Caller must free(). Sets *out_count.
+ *
+ * Fidelity (trace format v2, D3): SAMPLES records are normalized so the
+ * duration-based estimators apply ASH math. The exact-wins merge drops any
+ * sample whose timestamp falls inside a TRANSITIONS block's range, so a
+ * sampler running through a full-fidelity window does not double-count.
+ * When `info` is non-NULL it is filled with what actually contributed
+ * (has_transitions / has_samples / sample_period_ns).
  */
 static struct pgwt_trace_event *
-server_load_events(struct pgwt_server *srv,
-                   uint64_t from_wall_ns, uint64_t to_wall_ns,
-                   int *out_count)
+server_load_events_fi(struct pgwt_server *srv,
+                      uint64_t from_wall_ns, uint64_t to_wall_ns,
+                      int *out_count, struct pgwt_load_info *info)
 {
     *out_count = 0;
+    if (info) memset(info, 0, sizeof(*info));
 
     /* Quick rescan for new files (directory listing only, no file opens) */
     srv->num_files = pgwt_scan_trace_files(srv->trace_dir, srv->files, 256);
@@ -633,20 +755,36 @@ server_load_events(struct pgwt_server *srv,
     if (!events) return NULL;
     int total = 0;
 
+    /* Build the set of transition-covered ranges first, across ALL files,
+     * so the exact-wins merge sees a sampler in one file overlapping an
+     * escalation window in another. */
+    struct trans_range *ranges = NULL;
+    int nranges = 0, ranges_cap = 0;
+    uint64_t sample_period_ns = 0;
+
     for (int fi = 0; fi < srv->num_files; fi++) {
         const char *path = srv->files[fi].path;
 
         if (is_current_trace(path)) {
             /* On-demand: read only blocks in [from, to] */
+            struct pgwt_load_info fileinfo = {0};
             load_current_trace_range(path, from_wall_ns, to_wall_ns,
-                                     &events, &total, &cap);
+                                     &events, &total, &cap,
+                                     &ranges, &nranges, &ranges_cap, &fileinfo);
+            if (fileinfo.sample_period_ns)
+                sample_period_ns = fileinfo.sample_period_ns;
         } else {
             /* Immutable: try cache, fall back to on-demand for large files */
             struct file_cache_entry *ce = get_cached_immutable(srv, path);
             if (!ce || !ce->events) {
                 /* Cache miss (file too large or alloc failed) — read on demand */
+                struct pgwt_load_info fileinfo = {0};
                 load_current_trace_range(path, from_wall_ns, to_wall_ns,
-                                         &events, &total, &cap);
+                                         &events, &total, &cap,
+                                         &ranges, &nranges, &ranges_cap,
+                                         &fileinfo);
+                if (fileinfo.sample_period_ns)
+                    sample_period_ns = fileinfo.sample_period_ns;
                 continue;
             }
 
@@ -655,6 +793,15 @@ server_load_events(struct pgwt_server *srv,
                 continue;
             if (ce->last_wall_ns > 0 && ce->last_wall_ns < from_wall_ns)
                 continue;
+
+            if (ce->sample_period_ns)
+                sample_period_ns = ce->sample_period_ns;
+
+            /* Contribute this file's transition ranges to the merge set */
+            for (int r = 0; r < ce->num_trans_ranges; r++)
+                trans_ranges_add(&ranges, &nranges, &ranges_cap,
+                                 ce->trans_ranges[r].start_wall_ns,
+                                 ce->trans_ranges[r].end_wall_ns);
 
             /* Filter cached events by time range */
             for (int i = 0; i < ce->count; i++) {
@@ -665,7 +812,7 @@ server_load_events(struct pgwt_server *srv,
                 if (total >= cap) {
                     cap *= 2;
                     struct pgwt_trace_event *tmp = realloc(events, cap * sizeof(*tmp));
-                    if (!tmp) { *out_count = total; return events; }
+                    if (!tmp) { free(ranges); *out_count = total; return events; }
                     events = tmp;
                 }
                 events[total++] = ce->events[i];
@@ -673,8 +820,41 @@ server_load_events(struct pgwt_server *srv,
         }
     }
 
+    /* Exact-wins merge: drop samples inside any transition range, then
+     * derive what actually contributed for the fidelity indicator. */
+    int has_transitions = 0, has_samples = 0;
+    int kept = 0;
+    for (int i = 0; i < total; i++) {
+        if (events[i].flags & PGWT_EVENT_FLAG_SAMPLE) {
+            if (nranges > 0 &&
+                ts_in_trans_range(ranges, nranges, events[i].timestamp_ns))
+                continue;  /* transition data is authoritative here */
+            has_samples = 1;
+        } else {
+            has_transitions = 1;
+        }
+        events[kept++] = events[i];
+    }
+    total = kept;
+    free(ranges);
+
+    if (info) {
+        info->has_transitions = has_transitions;
+        info->has_samples = has_samples;
+        info->sample_period_ns = has_samples ? sample_period_ns : 0;
+    }
+
     *out_count = total;
     return events;
+}
+
+/* Backward-compatible wrapper for callers that don't need fidelity info. */
+static struct pgwt_trace_event *
+server_load_events(struct pgwt_server *srv,
+                   uint64_t from_wall_ns, uint64_t to_wall_ns,
+                   int *out_count)
+{
+    return server_load_events_fi(srv, from_wall_ns, to_wall_ns, out_count, NULL);
 }
 
 /* ── Server init ──────────────────────────────────────────── */
@@ -756,6 +936,43 @@ static int should_use_summaries(struct pgwt_server *srv, struct pgwt_request *re
     return (range_ns >= 120ULL * 1000000000ULL);
 }
 
+/* ── Fidelity (trace format v2, D3) ───────────────────────── */
+
+/* Derive the window fidelity from a load and add it as a "fidelity" field
+ * to a response. Every view carries this so the client (B5) can render the
+ * exact/sampled/mixed distinction. */
+static enum pgwt_fidelity load_fidelity(const struct pgwt_load_info *info)
+{
+    return pgwt_fidelity_of(info->has_transitions, info->has_samples);
+}
+
+static void add_fidelity(cJSON *root, const struct pgwt_load_info *info)
+{
+    enum pgwt_fidelity fid = load_fidelity(info);
+    cJSON_AddStringToObject(root, "fidelity", pgwt_fidelity_str(fid));
+    if (info->has_samples && info->sample_period_ns)
+        cjson_add_uint64(root, "sample_period_ns", info->sample_period_ns);
+}
+
+/* When summaries are used the window is full-fidelity transition data
+ * (summaries are derived from the watchpoint path). */
+static void add_fidelity_exact(cJSON *root)
+{
+    cJSON_AddStringToObject(root, "fidelity", "exact");
+}
+
+/* Emit the structured "unavailable" response for an EXACT-required view over
+ * a window with no transition coverage (sampled-only). NEVER a silent empty
+ * result — the client renders an explicit "escalate to capture" state. */
+static void emit_unavailable(uint64_t req_id, enum pgwt_fidelity fid)
+{
+    cJSON *root = cJSON_CreateObject();
+    cJSON_AddNumberToObject(root, "id", (double)req_id);
+    cJSON_AddStringToObject(root, "unavailable", PGWT_UNAVAILABLE_MSG);
+    cJSON_AddStringToObject(root, "fidelity", pgwt_fidelity_str(fid));
+    emit_json(root);
+}
+
 /* ── Command handlers ─────────────────────────────────────── */
 
 static void handle_info(struct pgwt_server *srv, struct pgwt_request *req)
@@ -808,15 +1025,18 @@ static void handle_aas(struct pgwt_server *srv, struct pgwt_request *req)
     int detail_events = (strcmp(req->detail, "events") == 0);
 
     struct pgwt_aas_result aas;
+    struct pgwt_load_info linfo = {0};
+    int from_summaries = 0;
 
     /* Event-detail mode always uses raw events (no summary path yet) */
     if (!detail_events && should_use_summaries(srv, req)) {
         pgwt_compute_aas_from_summaries(srv->trace_dir, from, to,
                                          &req->filter, num_buckets, &aas);
+        from_summaries = 1;
     } else {
         int count;
         struct pgwt_trace_event *events =
-            server_load_events(srv, req->from_ns, req->to_ns, &count);
+            server_load_events_fi(srv, req->from_ns, req->to_ns, &count, &linfo);
         pgwt_compute_aas(events, count, &req->filter, from, to, num_buckets,
                          detail_events, AAS_MAX_EVENT_SERIES, &aas);
         free(events);
@@ -824,6 +1044,8 @@ static void handle_aas(struct pgwt_server *srv, struct pgwt_request *req)
 
     cJSON *root = cJSON_CreateObject();
     cJSON_AddNumberToObject(root, "id", (double)req->id);
+    if (from_summaries) add_fidelity_exact(root);
+    else                add_fidelity(root, &linfo);
 
     if (aas.num_event_series > 0) {
         /* Event-breakdown mode */
@@ -877,20 +1099,25 @@ static void handle_time_model(struct pgwt_server *srv, struct pgwt_request *req)
     double wall_ms = (double)(to - from) / 1e6;
 
     struct pgwt_tm_result tm;
+    struct pgwt_load_info linfo = {0};
+    int from_summaries = 0;
 
     if (should_use_summaries(srv, req)) {
         pgwt_compute_time_model_from_summaries(srv->trace_dir, from, to,
                                                 &req->filter, wall_ms, &tm);
+        from_summaries = 1;
     } else {
         int count;
         struct pgwt_trace_event *events =
-            server_load_events(srv, req->from_ns, req->to_ns, &count);
+            server_load_events_fi(srv, req->from_ns, req->to_ns, &count, &linfo);
         pgwt_compute_time_model(events, count, &req->filter, wall_ms, &tm);
         free(events);
     }
 
     cJSON *root = cJSON_CreateObject();
     cJSON_AddNumberToObject(root, "id", (double)req->id);
+    if (from_summaries) add_fidelity_exact(root);
+    else                add_fidelity(root, &linfo);
 
     cJSON *rows = cJSON_AddArrayToObject(root, "rows");
     for (int i = 0; i < tm.num_rows; i++) {
@@ -919,20 +1146,25 @@ static void handle_top_events(struct pgwt_server *srv, struct pgwt_request *req)
     double wall_ms = (double)(to - from) / 1e6;
 
     struct pgwt_events_result res;
+    struct pgwt_load_info linfo = {0};
+    int from_summaries = 0;
 
     if (should_use_summaries(srv, req)) {
         pgwt_compute_top_events_from_summaries(srv->trace_dir, from, to,
                                                 &req->filter, wall_ms, &res);
+        from_summaries = 1;
     } else {
         int count;
         struct pgwt_trace_event *events =
-            server_load_events(srv, req->from_ns, req->to_ns, &count);
+            server_load_events_fi(srv, req->from_ns, req->to_ns, &count, &linfo);
         pgwt_compute_top_events(events, count, &req->filter, wall_ms, &res);
         free(events);
     }
 
     cJSON *root = cJSON_CreateObject();
     cJSON_AddNumberToObject(root, "id", (double)req->id);
+    if (from_summaries) add_fidelity_exact(root);
+    else                add_fidelity(root, &linfo);
 
     cJSON *rows = cJSON_AddArrayToObject(root, "rows");
     for (int i = 0; i < res.num_rows; i++) {
@@ -966,21 +1198,26 @@ static void handle_top_sessions(struct pgwt_server *srv, struct pgwt_request *re
     double wall_ms = (double)(to - from) / 1e6;
 
     struct pgwt_sessions_result res;
+    struct pgwt_load_info linfo = {0};
+    int from_summaries = 0;
 
     /* Sessions + query_id: summaries lack per-session query data, use raw events */
     if (should_use_summaries(srv, req) && req->filter.query_id == 0) {
         pgwt_compute_top_sessions_from_summaries(srv->trace_dir, from, to,
                                                   &req->filter, wall_ms, &res);
+        from_summaries = 1;
     } else {
         int count;
         struct pgwt_trace_event *events =
-            server_load_events(srv, req->from_ns, req->to_ns, &count);
+            server_load_events_fi(srv, req->from_ns, req->to_ns, &count, &linfo);
         pgwt_compute_top_sessions(events, count, &req->filter, wall_ms, &res);
         free(events);
     }
 
     cJSON *root = cJSON_CreateObject();
     cJSON_AddNumberToObject(root, "id", (double)req->id);
+    if (from_summaries) add_fidelity_exact(root);
+    else                add_fidelity(root, &linfo);
 
     cJSON *rows = cJSON_AddArrayToObject(root, "rows");
     for (int i = 0; i < res.num_rows; i++) {
@@ -1019,14 +1256,18 @@ static void handle_top_queries(struct pgwt_server *srv, struct pgwt_request *req
     int ecount = 0;
     struct pgwt_trace_event *all_events = NULL;
     struct pgwt_queries_result res;
+    struct pgwt_load_info linfo = {0};
+    int from_summaries = 0;
 
     /* Use summaries for large ranges (>120s) for the class breakdown.
      * Always load raw events for lifecycle stats (exec/plan counts).
      * Large files are read on-demand (not cached) so this is safe. */
-    all_events = server_load_events(srv, req->from_ns, req->to_ns, &ecount);
+    all_events = server_load_events_fi(srv, req->from_ns, req->to_ns, &ecount,
+                                       &linfo);
     if (!has_event_filter && should_use_summaries(srv, req)) {
         pgwt_compute_top_queries_from_summaries(srv->trace_dir, from, to,
                                                  &req->filter, wall_ms, &res);
+        from_summaries = 1;
     } else {
         pgwt_compute_top_queries(all_events, ecount, &req->filter, wall_ms, &res);
     }
@@ -1119,6 +1360,8 @@ static void handle_top_queries(struct pgwt_server *srv, struct pgwt_request *req
 
     cJSON *root = cJSON_CreateObject();
     cJSON_AddNumberToObject(root, "id", (double)req->id);
+    if (from_summaries) add_fidelity_exact(root);
+    else                add_fidelity(root, &linfo);
 
     cJSON *rows = cJSON_AddArrayToObject(root, "rows");
     for (int i = 0; i < res.num_rows; i++) {
@@ -1256,15 +1499,25 @@ static void handle_heatmap(struct pgwt_server *srv, struct pgwt_request *req)
     int num_buckets = req->num_buckets > 0 ? req->num_buckets : 200;
 
     struct pgwt_heatmap_result res;
+    int from_summaries = 0;
 
-    /* Heatmap + query_id: summaries lack per-query histograms, use raw events */
+    /* Heatmap (latency distribution) is EXACT-required: it needs real
+     * per-event durations, which samples do not carry. */
     if (should_use_summaries(srv, req) && req->filter.query_id == 0) {
         pgwt_compute_heatmap_from_summaries(srv->trace_dir, from, to,
                                              &req->filter, num_buckets, &res);
+        from_summaries = 1;
     } else {
         int count;
+        struct pgwt_load_info linfo = {0};
         struct pgwt_trace_event *events =
-            server_load_events(srv, req->from_ns, req->to_ns, &count);
+            server_load_events_fi(srv, req->from_ns, req->to_ns, &count, &linfo);
+        enum pgwt_fidelity fid = load_fidelity(&linfo);
+        if (pgwt_fidelity_unavailable(PGWT_REQ_EXACT, fid)) {
+            free(events);
+            emit_unavailable(req->id, fid);
+            return;
+        }
         pgwt_compute_heatmap(events, count, &req->filter,
                              from, to, num_buckets, &res);
         free(events);
@@ -1280,6 +1533,8 @@ static void handle_heatmap(struct pgwt_server *srv, struct pgwt_request *req)
 
     cJSON *root = cJSON_CreateObject();
     cJSON_AddNumberToObject(root, "id", (double)req->id);
+    add_fidelity_exact(root);
+    (void)from_summaries;
 
     cJSON *times_arr = cJSON_AddArrayToObject(root, "times");
     for (int i = 0; i < res.num_buckets; i++)
@@ -1320,8 +1575,9 @@ static void handle_heatmap(struct pgwt_server *srv, struct pgwt_request *req)
 static void handle_session_timeline(struct pgwt_server *srv, struct pgwt_request *req)
 {
     int count;
+    struct pgwt_load_info linfo = {0};
     struct pgwt_trace_event *events =
-        server_load_events(srv, req->from_ns, req->to_ns, &count);
+        server_load_events_fi(srv, req->from_ns, req->to_ns, &count, &linfo);
 
     /* First pass: count matching events and collect unique PIDs */
     uint32_t pids[TIMELINE_MAX_PIDS];
@@ -1368,6 +1624,7 @@ static void handle_session_timeline(struct pgwt_server *srv, struct pgwt_request
     /* Build JSON response */
     cJSON *root = cJSON_CreateObject();
     cJSON_AddNumberToObject(root, "id", (double)req->id);
+    add_fidelity(root, &linfo);
 
     cJSON *pids_arr = cJSON_AddArrayToObject(root, "pids");
     for (int p = 0; p < num_pids; p++)
@@ -1491,8 +1748,17 @@ static void handle_session_timeline(struct pgwt_server *srv, struct pgwt_request
 static void handle_transitions(struct pgwt_server *srv, struct pgwt_request *req)
 {
     int count;
+    struct pgwt_load_info linfo = {0};
     struct pgwt_trace_event *events =
-        server_load_events(srv, req->from_ns, req->to_ns, &count);
+        server_load_events_fi(srv, req->from_ns, req->to_ns, &count, &linfo);
+
+    /* Transitions need real old→new order: EXACT-required. */
+    enum pgwt_fidelity fid = load_fidelity(&linfo);
+    if (pgwt_fidelity_unavailable(PGWT_REQ_EXACT, fid)) {
+        free(events);
+        emit_unavailable(req->id, fid);
+        return;
+    }
 
     int max_rows = req->num_buckets > 0 ? req->num_buckets : 50;
     struct pgwt_transitions_result res;
@@ -1500,6 +1766,7 @@ static void handle_transitions(struct pgwt_server *srv, struct pgwt_request *req
 
     cJSON *root = cJSON_CreateObject();
     cJSON_AddNumberToObject(root, "id", (double)req->id);
+    cJSON_AddStringToObject(root, "fidelity", pgwt_fidelity_str(fid));
     cjson_add_uint64(root, "total", res.total_transitions);
 
     /* Compute per-node total time directly from ALL events.
@@ -1577,8 +1844,17 @@ static void handle_transitions(struct pgwt_server *srv, struct pgwt_request *req
 static void handle_fingerprints(struct pgwt_server *srv, struct pgwt_request *req)
 {
     int count;
+    struct pgwt_load_info linfo = {0};
     struct pgwt_trace_event *events =
-        server_load_events(srv, req->from_ns, req->to_ns, &count);
+        server_load_events_fi(srv, req->from_ns, req->to_ns, &count, &linfo);
+
+    /* Fingerprints aggregate transition sequences: EXACT-required. */
+    enum pgwt_fidelity fid = load_fidelity(&linfo);
+    if (pgwt_fidelity_unavailable(PGWT_REQ_EXACT, fid)) {
+        free(events);
+        emit_unavailable(req->id, fid);
+        return;
+    }
 
     struct pgwt_fingerprint_result res;
     pgwt_compute_fingerprints(events, count, &req->filter, &res);
@@ -1586,6 +1862,7 @@ static void handle_fingerprints(struct pgwt_server *srv, struct pgwt_request *re
 
     cJSON *root = cJSON_CreateObject();
     cJSON_AddNumberToObject(root, "id", (double)req->id);
+    cJSON_AddStringToObject(root, "fidelity", pgwt_fidelity_str(fid));
 
     cJSON *rows = cJSON_AddArrayToObject(root, "rows");
     for (int i = 0; i < res.num_rows; i++) {
@@ -1621,8 +1898,17 @@ static void handle_fingerprints(struct pgwt_server *srv, struct pgwt_request *re
 static void handle_lock_chains(struct pgwt_server *srv, struct pgwt_request *req)
 {
     int count;
+    struct pgwt_load_info linfo = {0};
     struct pgwt_trace_event *events =
-        server_load_events(srv, req->from_ns, req->to_ns, &count);
+        server_load_events_fi(srv, req->from_ns, req->to_ns, &count, &linfo);
+
+    /* Lock-chain inference needs real wait/CPU overlap intervals: EXACT. */
+    enum pgwt_fidelity fid = load_fidelity(&linfo);
+    if (pgwt_fidelity_unavailable(PGWT_REQ_EXACT, fid)) {
+        free(events);
+        emit_unavailable(req->id, fid);
+        return;
+    }
 
     struct pgwt_lock_chains_result res;
     pgwt_compute_lock_chains(events, count, &req->filter, 50, &res);
@@ -1630,6 +1916,7 @@ static void handle_lock_chains(struct pgwt_server *srv, struct pgwt_request *req
 
     cJSON *root = cJSON_CreateObject();
     cJSON_AddNumberToObject(root, "id", (double)req->id);
+    cJSON_AddStringToObject(root, "fidelity", pgwt_fidelity_str(fid));
 
     cJSON *chains = cJSON_AddArrayToObject(root, "chains");
     for (int i = 0; i < res.num_links; i++) {
@@ -1650,8 +1937,17 @@ static void handle_lock_chains(struct pgwt_server *srv, struct pgwt_request *req
 static void handle_interference(struct pgwt_server *srv, struct pgwt_request *req)
 {
     int count;
+    struct pgwt_load_info linfo = {0};
     struct pgwt_trace_event *events =
-        server_load_events(srv, req->from_ns, req->to_ns, &count);
+        server_load_events_fi(srv, req->from_ns, req->to_ns, &count, &linfo);
+
+    /* Interference scoring needs real simultaneous-wait overlap: EXACT. */
+    enum pgwt_fidelity fid = load_fidelity(&linfo);
+    if (pgwt_fidelity_unavailable(PGWT_REQ_EXACT, fid)) {
+        free(events);
+        emit_unavailable(req->id, fid);
+        return;
+    }
 
     struct pgwt_interference_result res;
     pgwt_compute_interference(events, count, &req->filter, 30, &res);
@@ -1659,6 +1955,7 @@ static void handle_interference(struct pgwt_server *srv, struct pgwt_request *re
 
     cJSON *root = cJSON_CreateObject();
     cJSON_AddNumberToObject(root, "id", (double)req->id);
+    cJSON_AddStringToObject(root, "fidelity", pgwt_fidelity_str(fid));
 
     cJSON *rows = cJSON_AddArrayToObject(root, "rows");
     for (int i = 0; i < res.num_rows; i++) {
@@ -1679,8 +1976,17 @@ static void handle_interference(struct pgwt_server *srv, struct pgwt_request *re
 static void handle_concurrency(struct pgwt_server *srv, struct pgwt_request *req)
 {
     int count;
+    struct pgwt_load_info linfo = {0};
     struct pgwt_trace_event *events =
-        server_load_events(srv, req->from_ns, req->to_ns, &count);
+        server_load_events_fi(srv, req->from_ns, req->to_ns, &count, &linfo);
+
+    /* Burst detection needs real simultaneous-wait intervals: EXACT. */
+    enum pgwt_fidelity fid = load_fidelity(&linfo);
+    if (pgwt_fidelity_unavailable(PGWT_REQ_EXACT, fid)) {
+        free(events);
+        emit_unavailable(req->id, fid);
+        return;
+    }
 
     uint64_t from = req->from_ns ? req->from_ns : srv->earliest_wall_ns;
     uint64_t to   = req->to_ns   ? req->to_ns   : srv->latest_wall_ns;
@@ -1696,6 +2002,7 @@ static void handle_concurrency(struct pgwt_server *srv, struct pgwt_request *req
 
     cJSON *root = cJSON_CreateObject();
     cJSON_AddNumberToObject(root, "id", (double)req->id);
+    cJSON_AddStringToObject(root, "fidelity", pgwt_fidelity_str(fid));
     cjson_add_uint64(root, "bucket_ns", res.bucket_ns);
 
     /* Peak concurrency per bucket */
@@ -1787,8 +2094,18 @@ static cJSON *serialize_variants(struct pgwt_server *srv,
 static void handle_variants(struct pgwt_server *srv, struct pgwt_request *req)
 {
     int count;
+    struct pgwt_load_info linfo = {0};
     struct pgwt_trace_event *events =
-        server_load_events(srv, req->from_ns, req->to_ns, &count);
+        server_load_events_fi(srv, req->from_ns, req->to_ns, &count, &linfo);
+
+    /* Variants are built from marker-delimited transition sequences, which
+     * only exist in full-fidelity data: EXACT-required. */
+    enum pgwt_fidelity fid = load_fidelity(&linfo);
+    if (pgwt_fidelity_unavailable(PGWT_REQ_EXACT, fid)) {
+        free(events);
+        emit_unavailable(req->id, fid);
+        return;
+    }
 
     int max_v = req->num_buckets > 0 ? req->num_buckets : 20;
 
@@ -1806,6 +2123,7 @@ static void handle_variants(struct pgwt_server *srv, struct pgwt_request *req)
 
     cJSON *root = cJSON_CreateObject();
     cJSON_AddNumberToObject(root, "id", (double)req->id);
+    cJSON_AddStringToObject(root, "fidelity", pgwt_fidelity_str(fid));
 
     /* Execution */
     cJSON *exec_obj = cJSON_AddObjectToObject(root, "exec");
@@ -2044,9 +2362,11 @@ static void dump_summary(struct pgwt_server *srv)
     double wall_ms = (double)(to - from) / 1e6;
     struct pgwt_filter filt = {0};
 
-    /* Load all events */
+    /* Load all events (fidelity-aware: samples normalized, exact-wins merge) */
     int count;
-    struct pgwt_trace_event *events = server_load_events(srv, from, to, &count);
+    struct pgwt_load_info linfo = {0};
+    struct pgwt_trace_event *events =
+        server_load_events_fi(srv, from, to, &count, &linfo);
 
     /* Count sample vs transition records so a sampled-mode trace is visible
      * at a glance (A2 evidence: SAMPLES blocks landed). */
@@ -2055,9 +2375,20 @@ static void dump_summary(struct pgwt_server *srv)
         if (events[i].flags & PGWT_EVENT_FLAG_SAMPLE)
             n_samples++;
 
+    enum pgwt_fidelity fid = load_fidelity(&linfo);
+
     printf("════════════════════════════════════════════════════════════════════════════════\n");
     printf("pgwt-server — Summary    Events: %d (%d transitions, %d samples)    Duration: %.1fs\n",
            count, count - n_samples, n_samples, wall_ms / 1000.0);
+    printf("Fidelity: %s", pgwt_fidelity_str(fid));
+    if (linfo.has_samples && linfo.sample_period_ns)
+        printf("    Sample period: %.1f ms (%.0f Hz)",
+               (double)linfo.sample_period_ns / 1e6,
+               1e9 / (double)linfo.sample_period_ns);
+    printf("\n");
+    if (fid == PGWT_FIDELITY_SAMPLED)
+        printf("Note: histogram / transitions / lock chains / interference / variants "
+               "require full-fidelity data and are unavailable for this window.\n");
     printf("════════════════════════════════════════════════════════════════════════════════\n");
 
     /* Time Model */

--- a/tests/mock_server.py
+++ b/tests/mock_server.py
@@ -326,11 +326,30 @@ _CANNED["session_timeline"] = {
 }
 
 
+# View commands that carry a per-window "fidelity" indicator (A3 / D3).
+# The mock's canned dataset is full-fidelity transition data, so every view
+# reports "exact" — matching what the real server returns for the
+# transition-only protocol-drift fixture.
+_FIDELITY_VIEWS = {
+    "aas", "time_model", "top_events", "top_sessions", "top_queries",
+    "heatmap", "session_timeline", "transitions", "fingerprints",
+    "concurrency", "lock_chains", "interference", "variants",
+}
+
+
 def handle_request(msg):
     """Dispatch a WebSocket JSON request and return canned response."""
     cmd = msg.get("cmd", "")
     req_id = msg.get("id", 0)
+    resp = _handle_request_inner(cmd, req_id, msg)
+    # Tag every view response with its window fidelity (A3). Done centrally so
+    # the schema stays aligned with the real server across all views.
+    if cmd in _FIDELITY_VIEWS and "fidelity" not in resp and "error" not in resp:
+        resp["fidelity"] = "exact"
+    return resp
 
+
+def _handle_request_inner(cmd, req_id, msg):
     if cmd == "info":
         return {"id": req_id, **_CANNED["info"]}
 

--- a/tests/run_all.sh
+++ b/tests/run_all.sh
@@ -91,6 +91,7 @@ if [[ -x "$PROJECT_DIR/pgwt-server" ]] && [[ -x "$SCRIPT_DIR/gen_test_traces" ]]
     run_test "test_data_edge" python3 "$SCRIPT_DIR/test_data_edge.py"
     run_test "test_data_transitions" python3 "$SCRIPT_DIR/test_data_transitions.py"
     run_test "test_data_lock_chains" python3 "$SCRIPT_DIR/test_data_lock_chains.py"
+    run_test "test_data_fidelity" python3 "$SCRIPT_DIR/test_data_fidelity.py"
     run_test "test_current_trace" python3 "$SCRIPT_DIR/test_current_trace.py"
     run_test "test_protocol_drift" python3 "$SCRIPT_DIR/test_protocol_drift.py"
 else

--- a/tests/test_data_fidelity.py
+++ b/tests/test_data_fidelity.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python3
+"""test_data_fidelity.py — A3: fidelity-aware compute (sampled estimators,
+exact-wins merge, unavailable for exact-only views).
+
+Covers design decision D3 of docs/REWORK_PLAN.md:
+
+  1. Sampled-only trace with a KNOWN sample stream → exact expected
+     time_model / system_event / AAS estimates (ASH math: N samples of
+     event X at period P → X gets N*P time; AAS = active-sample-time /
+     window). An idle event (Client:ClientRead) is visible in breakdowns
+     but excluded from DB Time / AAS.
+  2. EXACT-required view (histogram, transitions) over a sampled-only
+     window → explicit {"unavailable": ...}, never a silent empty result.
+  3. Mixed-window merge: overlapping transition + sample coverage →
+     transition data wins inside its range, samples only contribute
+     outside it (no double counting).
+
+These run without a live PostgreSQL: gen_test_traces emits SAMPLES blocks
+from the "samples"/"sample_period_ns" inputs (A1).
+"""
+import os
+import subprocess
+import sys
+
+sys.path.insert(0, os.path.dirname(__file__))
+from server_harness import (
+    ServerHarness, generate_traces, cleanup_traces, TestRunner, SERVER_BIN,
+    CPU, IO_DATA_FILE_READ, LOCK_RELATION, CLIENT_READ,
+)
+
+BASE_TS = 10_000_000_000_000  # 10000s in ns (> 1hr so server range expansion is safe)
+PERIOD = 100_000_000          # 100ms = 10 Hz sample period
+
+
+def sample_at(pid, ts, event, qid=0):
+    return {"pid": pid, "ts": ts, "event": event, "qid": qid}
+
+
+# ── 1. Sampled-only estimators ────────────────────────────────────────
+
+def build_sampled_only():
+    """A pure SAMPLES stream with a known composition.
+
+    At 10 Hz (period = 100ms), each sample is worth 100ms = 100ms of time.
+
+      PID 1000: 10 samples of IO:DataFileRead  → 10 * 100ms = 1000ms IO
+      PID 1000:  5 samples of Lock:relation     →  5 * 100ms =  500ms Lock
+      PID 1001:  3 samples of CPU (event=0)     →  3 * 100ms =  300ms CPU
+      PID 1002:  4 samples of Client:ClientRead →  4 * 100ms =  400ms (idle,
+                 visible in event list but excluded from DB Time / AAS)
+
+    Expected DB Time = 1000 + 500 + 300 = 1800ms (ClientRead excluded).
+    """
+    samples = []
+    ts = BASE_TS
+    for _ in range(10):
+        ts += PERIOD
+        samples.append(sample_at(1000, ts, IO_DATA_FILE_READ, 100))
+    for _ in range(5):
+        ts += PERIOD
+        samples.append(sample_at(1000, ts, LOCK_RELATION, 100))
+    for _ in range(3):
+        ts += PERIOD
+        samples.append(sample_at(1001, ts, CPU, 200))
+    for _ in range(4):
+        ts += PERIOD
+        samples.append(sample_at(1002, ts, CLIENT_READ, 0))
+    # Keep sorted by ts (writer requires it)
+    samples.sort(key=lambda s: s["ts"])
+    return {
+        "backends": [
+            {"pid": 1000, "type": "client", "user": "test", "db": "testdb"},
+            {"pid": 1001, "type": "client", "user": "test", "db": "testdb"},
+            {"pid": 1002, "type": "client", "user": "test", "db": "testdb"},
+        ],
+        "queries": [
+            {"id": 100, "text": "SELECT 1"},
+            {"id": 200, "text": "SELECT 2"},
+        ],
+        "sample_period_ns": PERIOD,
+        "samples": samples,
+    }
+
+
+def test_sampled_only(t):
+    print("\n### 1. Sampled-only estimators (ASH math) ###")
+    trace_dir = generate_traces(build_sampled_only())
+    try:
+        with ServerHarness(trace_dir) as srv:
+            # --- time_model: ASH-estimated DB Time + class breakdown ---
+            tm = srv.query("time_model")
+            t.check_eq(tm.get("fidelity"), "sampled",
+                       "time_model fidelity = sampled")
+            rows = {r["name"]: r for r in tm["rows"]}
+            t.check_approx(rows["DB Time"]["ms"], 1800.0, 0.001,
+                           "DB Time = 1800ms (3 non-idle classes, ClientRead excluded)")
+            t.check_approx(rows.get("IO", {}).get("ms", -1), 1000.0, 0.001,
+                           "IO = 1000ms (10 samples * 100ms)")
+            t.check_approx(rows.get("Lock", {}).get("ms", -1), 500.0, 0.001,
+                           "Lock = 500ms (5 samples * 100ms)")
+            t.check_approx(rows.get("CPU*", {}).get("ms", -1), 300.0, 0.001,
+                           "CPU = 300ms (3 samples * 100ms)")
+            # ClientRead is idle → must NOT count toward DB Time.
+            t.check("Client" not in rows or rows["Client"]["ms"] < 0.001,
+                    "Client class excluded from DB Time (idle ClientRead)")
+
+            # --- system_event (top_events): ClientRead visible but %DB excludes it ---
+            ev = srv.query("top_events")
+            t.check_eq(ev.get("fidelity"), "sampled",
+                       "top_events fidelity = sampled")
+            evrows = {r["name"]: r for r in ev["rows"]}
+            t.check("Client:ClientRead" in evrows,
+                    "ClientRead is visible in the event list")
+            cr = evrows.get("Client:ClientRead", {})
+            t.check_approx(cr.get("total_ms", -1), 400.0, 0.001,
+                           "ClientRead total = 400ms (4 samples * 100ms)")
+            t.check_approx(ev.get("db_time_ms", -1), 1800.0, 0.001,
+                           "top_events db_time excludes idle ClientRead = 1800ms")
+            io = evrows.get("IO:DataFileRead", {})
+            t.check_eq(io.get("count"), 10, "IO:DataFileRead sample count = 10")
+
+            # --- AAS: active-sample-time / window ---
+            # 28 total samples span (28-1) periods = 2700ms of wall-clock.
+            # The harness queries the full file range. Verify AAS integrates
+            # to the expected DB-Time across all buckets.
+            aas = srv.query("aas", buckets=1)
+            t.check_eq(aas.get("fidelity"), "sampled", "aas fidelity = sampled")
+            b = aas["buckets"][0]
+            bucket_ns = aas["bucket_ns"]
+            # Sum non-idle class AAS for the single bucket → average active
+            # sessions over the window. active_time = sum_class_aas * bucket_ns.
+            active_aas = sum(v for k, v in b.items()
+                             if k not in ("t",) and isinstance(v, (int, float)))
+            active_ms = active_aas * bucket_ns / 1e6
+            t.check_approx(active_ms, 1800.0, 0.02,
+                           "AAS integrates to 1800ms active DB Time (idle excluded)")
+            # ClientRead (client class) must contribute ~0 to AAS load.
+            t.check(b.get("client", 0.0) < 1e-6,
+                    "ClientRead contributes ~0 to AAS load (idle)")
+    finally:
+        cleanup_traces(trace_dir)
+
+
+# ── 2. EXACT-required views unavailable over sampled-only ─────────────
+
+def test_exact_unavailable(t):
+    print("\n### 2. EXACT-required views → unavailable over sampled-only ###")
+    trace_dir = generate_traces(build_sampled_only())
+    try:
+        with ServerHarness(trace_dir) as srv:
+            for view in ("heatmap", "transitions", "lock_chains",
+                         "interference", "concurrency", "fingerprints",
+                         "variants"):
+                resp = srv.query(view)
+                t.check("unavailable" in resp,
+                        f"{view}: explicit 'unavailable' (not silent-empty)")
+                t.check_eq(resp.get("fidelity"), "sampled",
+                           f"{view}: fidelity = sampled in unavailable response")
+                t.check("full-fidelity" in resp.get("unavailable", ""),
+                        f"{view}: unavailable message mentions full-fidelity data")
+    finally:
+        cleanup_traces(trace_dir)
+
+
+# ── 3. Mixed-window exact-wins merge (no double counting) ─────────────
+
+def build_mixed():
+    """Transition coverage overlapping a continuous sample stream.
+
+    The exact-wins merge (D3) drops any sample whose timestamp falls inside
+    a TRANSITIONS block's [first_ts, last_ts] span — i.e. the span of the
+    transition events' timestamps. So the transition block must actually
+    SPAN the overlap window.
+
+    TRANSITIONS (exact) for PID 1000: a chain of IO:DataFileRead intervals
+    with event timestamps from BASE+1.0s to BASE+2.0s (the block's
+    [first_ts,last_ts] = [1.0s, 2.0s]). Each is a 100ms IO interval, so the
+    exact IO total over the window is 11 * 100ms = 1100ms.
+
+    SAMPLES (10 Hz) of Lock:relation run continuously over
+    [BASE+1.0s .. BASE+4.0s] (31 samples). Samples whose ts is in
+    [1.0s, 2.0s] (11 of them) are DROPPED — transition data is
+    authoritative there. The remaining 20 out-of-range samples each add
+    100ms → 2000ms of Lock. No double counting in the overlap.
+    """
+    one_s = 1_000_000_000
+    trans_start = BASE_TS + one_s
+    trans_end = BASE_TS + 2 * one_s
+
+    # Transition chain spanning [1.0s, 2.0s]: 11 IO intervals of 100ms each.
+    events = []
+    ts = trans_start
+    while ts <= trans_end:
+        events.append({"pid": 1000, "ts": ts, "dur": PERIOD,
+                       "old": IO_DATA_FILE_READ, "new": IO_DATA_FILE_READ,
+                       "qid": 100})
+        ts += PERIOD
+    n_trans = len(events)
+    exact_io_ms = n_trans * (PERIOD / 1e6)  # 11 * 100ms = 1100ms
+
+    # Continuous Lock samples over [1.0s, 4.0s].
+    samples = []
+    ts = trans_start
+    while ts <= BASE_TS + 4 * one_s:
+        samples.append(sample_at(1001, ts, LOCK_RELATION, 200))
+        ts += PERIOD
+    samples.sort(key=lambda s: s["ts"])
+
+    # Samples inside the transition block span [first_ts, last_ts] are dropped.
+    in_range = sum(1 for s in samples
+                   if trans_start <= s["ts"] <= trans_end)
+    out_range = len(samples) - in_range
+
+    return ({
+        "backends": [
+            {"pid": 1000, "type": "client", "user": "test", "db": "testdb"},
+            {"pid": 1001, "type": "client", "user": "test", "db": "testdb"},
+        ],
+        "queries": [
+            {"id": 100, "text": "SELECT 1"},
+            {"id": 200, "text": "SELECT 2"},
+        ],
+        "events": events,
+        "sample_period_ns": PERIOD,
+        "samples": samples,
+    }, out_range, exact_io_ms)
+
+
+def test_mixed_merge(t):
+    print("\n### 3. Mixed-window exact-wins merge (no double counting) ###")
+    scenario, out_range, exact_io_ms = build_mixed()
+    expected_lock_ms = out_range * (PERIOD / 1e6)  # surviving samples * 100ms
+    trace_dir = generate_traces(scenario)
+    try:
+        with ServerHarness(trace_dir) as srv:
+            tm = srv.query("time_model")
+            t.check_eq(tm.get("fidelity"), "mixed",
+                       "mixed window fidelity = mixed")
+            rows = {r["name"]: r for r in tm["rows"]}
+            # IO comes only from the exact transition chain.
+            t.check_approx(rows.get("IO", {}).get("ms", -1), exact_io_ms, 0.001,
+                           f"IO = exact {exact_io_ms:.0f}ms from transition block")
+            # Lock comes only from samples OUTSIDE the transition range.
+            t.check_approx(rows.get("Lock", {}).get("ms", -1),
+                           expected_lock_ms, 0.001,
+                           f"Lock = {expected_lock_ms:.0f}ms "
+                           f"(only {out_range} out-of-range samples survive)")
+
+            # transitions view IS available (transition coverage exists).
+            tr = srv.query("transitions")
+            t.check("unavailable" not in tr,
+                    "transitions available in a mixed window (has exact data)")
+            t.check_eq(tr.get("fidelity"), "mixed",
+                       "transitions fidelity = mixed")
+    finally:
+        cleanup_traces(trace_dir)
+
+
+# ── 4. --dump annotates fidelity ──────────────────────────────────────
+
+def test_dump_annotation(t):
+    print("\n### 4. --dump annotates fidelity ###")
+    trace_dir = generate_traces(build_sampled_only())
+    try:
+        out = subprocess.run([SERVER_BIN, "--dump", trace_dir],
+                             capture_output=True, text=True)
+        text = out.stdout
+        t.check("Fidelity: sampled" in text,
+                "--dump reports 'Fidelity: sampled' for a sampled-only trace")
+        t.check("require full-fidelity data" in text or
+                "full-fidelity data" in text,
+                "--dump notes which views require full-fidelity data")
+    finally:
+        cleanup_traces(trace_dir)
+
+
+def main():
+    t = TestRunner("test_data_fidelity")
+    print(f"=== {t.name} ===")
+    test_sampled_only(t)
+    test_exact_unavailable(t)
+    test_mixed_merge(t)
+    test_dump_annotation(t)
+    sys.exit(0 if t.summary() else 1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Phase A3 — fidelity-aware compute (D3)

Makes `pgwt-server`'s compute layer understand trace format v2 SAMPLES blocks (A1/A2): correctly derives views from samples, falls back explicitly where samples are insufficient, and merges mixed traces without double-counting. Builds directly on #12 (v2 format) and #13 (sampler).

### Per-view fidelity classification

| View | Required fidelity | Sampled-window behavior |
|------|-------------------|-------------------------|
| time_model | SAMPLED | ASH estimate |
| top_events (system event) | SAMPLED | ASH estimate (latency percentiles degenerate, expected) |
| top_sessions (session event) | SAMPLED | ASH estimate |
| top_queries (query event) | SAMPLED | ASH estimate |
| aas | SAMPLED | ASH estimate |
| session_timeline (active) | SAMPLED | renders from samples |
| heatmap (histogram) | EXACT | `unavailable` |
| transitions | EXACT | `unavailable` |
| fingerprints | EXACT | `unavailable` |
| lock_chains | EXACT | `unavailable` |
| interference | EXACT | `unavailable` |
| concurrency | EXACT | `unavailable` |
| variants | EXACT | `unavailable` |

### Estimator math (standard ASH)

Each sample of a **non-idle** session contributes one `sample_period_ns` of time to its (event, session, query) cells. Implemented without touching the estimators: at load time a SAMPLES record is normalized into interval shape — `old_event = sampled event`, `duration_ns = sample_period_ns` — so the existing duration-based code produces `N samples of X at period P → N*P` time, `AAS = active-sample-time / window`. Idle classification reuses the existing `pgwt_is_idle_event` / `pgwt_is_hidden_event` split unchanged: `Client:ClientRead` samples are visible in breakdowns but excluded from DB Time / AAS, exactly like transitions.

### Exact-wins merge

When a window is covered by both transition and sample blocks, transitions are authoritative. `server_load_events_fi()` builds the set of every TRANSITIONS block's `[first_ts,last_ts]` wall range (across all files, via `pgwt_reader_decode_block_info`) first, then drops any sample whose timestamp falls inside one. A sampler running through an escalation window cannot double-count. The immutable file cache stores per-file transition ranges + sample period.

### Fidelity in responses (for B5)

Every view response carries `"fidelity": "exact" | "sampled" | "mixed"`, plus `"sample_period_ns"` when samples contributed. Summary-path responses report `"exact"` (summaries derive from the watchpoint tier). EXACT-required views over a sampled-only window return a structured `{"unavailable": "requires full-fidelity data", "fidelity": "sampled"}` — never a silent-empty result. `--dump` annotates window fidelity, the sample period, and which views need full-fidelity data.

### Tests

`tests/test_data_fidelity.py` (wired into `run_all.sh`; picked up by the CI `test_data_*.py` glob) — **42/42**:
- Sampled-only stream with a known composition → exact ASH estimates (DB Time = 1800ms from 18 non-idle samples × 100ms; idle ClientRead = 400ms visible but excluded from DB Time/AAS).
- All seven EXACT-required views over a sampled-only window → explicit `unavailable`.
- Mixed window: transitions win inside their block range (exact 1100ms IO), samples only contribute outside it (2000ms Lock, no double counting).
- `--dump` fidelity annotation.

All existing synthetic tests unchanged; `mock_server.py` now tags views with `"fidelity":"exact"` so **protocol-drift stays green (48/48)**.

### Validation

- Local: `make pgwt-server` clean; full synthetic suite + protocol-drift green.
- Remote box (Rocky 9, PG 18): full BPF build (`pg_wait_tracer` + `pgwt-server`) links clean; `test_trace_v2` 98/98, `test_sampler` 24/24; all `test_data_*.py` + protocol-drift green.
- Live `--mode sampled` (50 Hz) under pgbench: real 176KB sampled trace. `--dump` → `Fidelity: sampled    Sample period: 20.0 ms (50 Hz)` + the unavailable-views note; views return `fidelity:"sampled"` with `sample_period_ns`; `transitions`/`heatmap` return `{"unavailable":"requires full-fidelity data","fidelity":"sampled"}`.

### Notes for A4 / B5

- **A4 (escalation):** mixed traces produced by escalation windows are handled by the exact-wins merge today; the merge keys on transition-block timestamp spans, so a realistic escalation block (many events) correctly shadows the overlapping samples.
- **B5 (fidelity UI):** consume the top-level `fidelity` field (`exact`/`sampled`/`mixed`) on every view, `sample_period_ns` for sampled windows, and the `{"unavailable": "requires full-fidelity data"}` shape to render the "escalate to capture" state instead of an empty chart.
- Sampled estimator error at low rates is real (risk #2): a live 50 Hz pgbench run over sub-ms transactions captured mostly idle/aux samples, so non-idle ASH totals were sparse. A3 classifies this correctly (sampled fidelity, idle excluded); quantifying/raising the default rate is A4's cross-validation job — not papered over here.
