### PR TITLE
B3 (part 2): migrate events/sessions/queries table views to view-manager

### DIFF
--- a/tests/web_unit/events.test.mjs
+++ b/tests/web_unit/events.test.mjs
@@ -1,0 +1,73 @@
+/* Node unit tests for the pure events builder (views/events.js) over the shared
+ * eventsConfig (lib/builders/table-configs.js). Proves row shape, sort
+ * correctness, drill-intent, and edge cases without a browser.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { buildEventsModel } from '../../web/static/views/events.js';
+import { eventsConfig } from '../../web/static/lib/builders/table-configs.js';
+
+function ev(over) {
+    return Object.assign({
+        name: 'X', event_id: 0, count: 0, total_ms: 0, avg_us: 0,
+        p50_us: 0, p95_us: 0, p99_us: 0, max_us: 0, pct: 0, aas: 0,
+    }, over);
+}
+
+test('no sort: keeps server order; every row clickable', () => {
+    const data = { rows: [
+        ev({ name: 'CPU*', count: 100 }),
+        ev({ name: 'IO:DataFileRead', event_id: 0x01000015, count: 50 }),
+        ev({ name: 'Lock:relation', event_id: 0x03000000, count: 30 }),
+    ] };
+    const m = buildEventsModel(data, null);
+    assert.equal(m.hasRows, true);
+    assert.equal(m.table.rows.length, 3);
+    // order preserved
+    assert.deepEqual(m.table.rows.map(r => r.row.name),
+        ['CPU*', 'IO:DataFileRead', 'Lock:relation']);
+    // all clickable for drill-down
+    assert.ok(m.table.rows.every(r => r.cls.includes('clickable')));
+    // class dot + escaped name in the first cell
+    assert.ok(m.table.rows[0].cells[0].html.includes('class-dot'));
+    assert.ok(m.table.rows[0].cells[0].html.includes('CPU*'));
+});
+
+test('descending sort by count puts largest first + shows ▼ arrow', () => {
+    const data = { rows: [
+        ev({ name: 'A', count: 10 }), ev({ name: 'B', count: 30 }),
+        ev({ name: 'C', count: 20 }),
+    ] };
+    const m = buildEventsModel(data, { key: 'count', asc: false });
+    assert.deepEqual(m.table.rows.map(r => r.row.name), ['B', 'C', 'A']);
+    assert.ok(m.table.headers.find(h => h.key === 'count').arrow.includes('▼'));
+});
+
+test('ascending sort flips order + shows ▲ arrow', () => {
+    const data = { rows: [
+        ev({ name: 'A', count: 10 }), ev({ name: 'B', count: 30 }),
+        ev({ name: 'C', count: 20 }),
+    ] };
+    const m = buildEventsModel(data, { key: 'count', asc: true });
+    assert.deepEqual(m.table.rows.map(r => r.row.name), ['A', 'C', 'B']);
+    assert.ok(m.table.headers.find(h => h.key === 'count').arrow.includes('▲'));
+});
+
+test('drill intent targets event_id with the event name as label', () => {
+    assert.deepEqual(
+        eventsConfig.onClick(ev({ event_id: 0x01000015, name: 'IO:DataFileRead' })),
+        { filterKey: 'event_id', filterValue: 0x01000015, label: 'IO:DataFileRead' });
+});
+
+test('empty data -> hasRows false, zero rows', () => {
+    assert.equal(buildEventsModel(null, null).hasRows, false);
+    assert.equal(buildEventsModel({ rows: [] }, null).hasRows, false);
+    assert.equal(buildEventsModel({ rows: [] }, null).table.rows.length, 0);
+});
+
+test('single row -> stable', () => {
+    const m = buildEventsModel({ rows: [ev({ name: 'Solo', count: 1 })] },
+        { key: 'count', asc: false });
+    assert.equal(m.table.rows.length, 1);
+    assert.equal(m.table.rows[0].row.name, 'Solo');
+});

--- a/tests/web_unit/queries.test.mjs
+++ b/tests/web_unit/queries.test.mjs
@@ -1,0 +1,85 @@
+/* Node unit tests for the pure queries builder (views/queries.js) over the
+ * shared queriesConfig. Proves row shape, the wait-profile stacked bar, the
+ * query-text hover cell, sort, drill-intent (query_id -> events) and edges.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { buildQueriesModel } from '../../web/static/views/queries.js';
+import { queriesConfig } from '../../web/static/lib/builders/table-configs.js';
+
+function q(over) {
+    return Object.assign({
+        query_id: '0', text: 'SELECT 1', total_ms: 0, pct: 0, count: 0,
+        avg_us: 0, top_wait: 'CPU*',
+    }, over);
+}
+
+const LONG = 'SELECT ' + 'a'.repeat(200) + ' FROM t';
+
+test('no sort: server order; Query ID/Text/Wait Profile columns; all clickable', () => {
+    const data = { rows: [
+        q({ query_id: '111', total_ms: 4200, pct: 33.6,
+            events: [{ name: 'CPU*', ms: 2000 }, { name: 'IO:DataFileRead', ms: 1200 }] }),
+        q({ query_id: '222', total_ms: 3100, pct: 24.8,
+            classes: [1500, 900, 0, 0, 0, 0, 0, 0, 0, 0, 0] }),
+    ] };
+    const m = buildQueriesModel(data, null);
+    assert.equal(m.hasRows, true);
+    assert.deepEqual(m.table.rows.map(r => r.row.query_id), ['111', '222']);
+    assert.ok(m.table.headers.map(h => h.label).includes('Query ID'));
+    assert.ok(m.table.headers.map(h => h.label).includes('Query Text'));
+    assert.ok(m.table.headers.map(h => h.label).includes('Wait Profile'));
+    assert.ok(m.table.rows.every(r => r.cls.includes('clickable')));
+});
+
+test('events present -> event stacked bar; only classes -> class stacked bar', () => {
+    const withEvents = buildQueriesModel({ rows: [q({ total_ms: 100,
+        events: [{ name: 'CPU*', ms: 60 }, { name: 'IO:DataFileRead', ms: 40 }] })] }, null);
+    const withClasses = buildQueriesModel({ rows: [q({ total_ms: 100,
+        classes: [60, 40, 0, 0, 0, 0, 0, 0, 0, 0, 0] })] }, null);
+    // Wait Profile is the 5th column (index 4)
+    assert.ok(withEvents.table.rows[0].cells[4].html.includes('stacked-bar'));
+    assert.ok(withClasses.table.rows[0].cells[4].html.includes('stacked-bar'));
+});
+
+test('long query text gets a qt-hover cell carrying the full text', () => {
+    const m = buildQueriesModel({ rows: [q({ query_id: '9', text: LONG })] }, null);
+    const textCell = m.table.rows[0].cells[1].html;
+    assert.ok(textCell.includes('qt-hover'));
+    assert.ok(textCell.includes('data-fulltext'));
+    // truncated visible portion ends with ellipsis
+    assert.ok(textCell.includes('...'));
+});
+
+test('empty query text renders an em-dash placeholder', () => {
+    const m = buildQueriesModel({ rows: [q({ query_id: '9', text: '' })] }, null);
+    assert.ok(m.table.rows[0].cells[1].html.includes('—'));
+});
+
+test('descending sort by total_ms', () => {
+    const data = { rows: [
+        q({ query_id: 'a', total_ms: 100 }), q({ query_id: 'b', total_ms: 300 }),
+        q({ query_id: 'c', total_ms: 200 }),
+    ] };
+    const m = buildQueriesModel(data, { key: 'total_ms', asc: false });
+    assert.deepEqual(m.table.rows.map(r => r.row.query_id), ['b', 'c', 'a']);
+});
+
+test('drill intent targets query_id (-> events); label is text prefix', () => {
+    assert.deepEqual(
+        queriesConfig.onClick(q({ query_id: '42', text: 'UPDATE pgbench_accounts SET x' })),
+        { filterKey: 'query_id', filterValue: '42',
+          label: 'UPDATE pgbench_accounts SET x' });
+    // no text -> falls back to "Query <id>"
+    assert.deepEqual(
+        queriesConfig.onClick(q({ query_id: '42', text: '' })),
+        { filterKey: 'query_id', filterValue: '42', label: 'Query 42' });
+});
+
+test('empty + single-row edge cases', () => {
+    assert.equal(buildQueriesModel(null, null).hasRows, false);
+    assert.equal(buildQueriesModel({ rows: [] }, null).hasRows, false);
+    const m = buildQueriesModel({ rows: [q({ query_id: 'solo' })] },
+        { key: 'total_ms', asc: false });
+    assert.equal(m.table.rows.length, 1);
+});

--- a/tests/web_unit/sessions.test.mjs
+++ b/tests/web_unit/sessions.test.mjs
@@ -1,0 +1,67 @@
+/* Node unit tests for the pure sessions builder (views/sessions.js) over the
+ * shared sessionsConfig. Proves row shape, sort, drill-intent (pid -> timeline)
+ * and edge cases without a browser.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { buildSessionsModel } from '../../web/static/views/sessions.js';
+import { sessionsConfig } from '../../web/static/lib/builders/table-configs.js';
+
+function sess(over) {
+    return Object.assign({
+        pid: 0, type: 'client', user: 'postgres', db: 'testdb',
+        db_time_ms: 0, cpu_pct: 0, wait_pct: 0, top_wait: 'CPU*',
+    }, over);
+}
+
+test('no sort: server order; PID/Backend/Top Wait columns; all clickable', () => {
+    const data = { rows: [
+        sess({ pid: 1001, db_time_ms: 3000, top_wait: 'IO:DataFileRead' }),
+        sess({ pid: 1002, db_time_ms: 2000, top_wait: 'Lock:relation' }),
+        sess({ pid: 4870, type: 'checkpointer', user: '', db: '' }),
+    ] };
+    const m = buildSessionsModel(data, null);
+    assert.equal(m.hasRows, true);
+    assert.deepEqual(m.table.rows.map(r => r.row.pid), [1001, 1002, 4870]);
+    assert.deepEqual(m.table.headers.map(h => h.label),
+        ['PID', 'Backend', 'User', 'Database', 'DB Time', 'CPU%', 'Wait%', 'Top Wait']);
+    assert.ok(m.table.rows.every(r => r.cls.includes('clickable')));
+    // Top Wait cell carries a class dot
+    assert.ok(m.table.rows[0].cells[7].html.includes('class-dot'));
+});
+
+test('descending sort by db_time_ms', () => {
+    const data = { rows: [
+        sess({ pid: 1, db_time_ms: 100 }), sess({ pid: 2, db_time_ms: 300 }),
+        sess({ pid: 3, db_time_ms: 200 }),
+    ] };
+    const m = buildSessionsModel(data, { key: 'db_time_ms', asc: false });
+    assert.deepEqual(m.table.rows.map(r => r.row.pid), [2, 3, 1]);
+});
+
+test('ascending sort by pid', () => {
+    const data = { rows: [
+        sess({ pid: 3 }), sess({ pid: 1 }), sess({ pid: 2 }),
+    ] };
+    const m = buildSessionsModel(data, { key: 'pid', asc: true });
+    assert.deepEqual(m.table.rows.map(r => r.row.pid), [1, 2, 3]);
+});
+
+test('drill intent targets pid (-> timeline) with "PID n" label', () => {
+    assert.deepEqual(sessionsConfig.onClick(sess({ pid: 1001 })),
+        { filterKey: 'pid', filterValue: 1001, label: 'PID 1001' });
+});
+
+test('missing user/db render empty, not "undefined"', () => {
+    const m = buildSessionsModel({ rows: [sess({ pid: 9, user: '', db: '' })] }, null);
+    assert.equal(m.table.rows[0].cells[2].html, '');
+    assert.equal(m.table.rows[0].cells[3].html, '');
+});
+
+test('empty + single-row edge cases', () => {
+    assert.equal(buildSessionsModel(null, null).hasRows, false);
+    assert.equal(buildSessionsModel({ rows: [] }, null).hasRows, false);
+    const m = buildSessionsModel({ rows: [sess({ pid: 7 })] }, { key: 'pid', asc: false });
+    assert.equal(m.table.rows.length, 1);
+    assert.equal(m.table.rows[0].row.pid, 7);
+});

--- a/web/static/app.js
+++ b/web/static/app.js
@@ -3,12 +3,12 @@
  * B3 part 1: the 2000-line monolith is being restructured into native ES
  * modules (no build step — still embeddable via go:embed). This file is the
  * bootstrap + router. The migrated views (active = AAS chart, overview = time
- * model table, events = the wait-events table) live in views/ as pure builders
- * + thin mounts; the not-yet-migrated tabs (sessions/queries/histogram/timeline/
+ * model table, events/sessions = drill-down tables) live in views/ as pure
+ * builders + thin mounts; the not-yet-migrated tabs (queries/histogram/timeline/
  * transitions/concurrency) are wrapped as legacy view adapters so they ALL flow
  * through the same view-manager chokepoint and transport single-flight — which is
  * what keeps the B2 chaos races fixed while they await their turn to be migrated
- * to pure builders (sessions/queries land later in this PR; the charts in part 3).
+ * to pure builders (queries lands next in this PR; the charts in part 3).
  *
  * State is explicit (lib/state.js): no grab-bag global mutated mid-flight.
  * Stale-response superseding is structural (lib/transport.js channels +
@@ -23,10 +23,11 @@ import {
     WAIT_CLASSES, EVENT_PALETTE, classColor,
     fmtTime, fmtTimeMs, fmtDuration, fmtMs, fmtUs, fmtCount, esc,
 } from './lib/format.js';
-import { sessionsConfig, queriesConfig } from './lib/builders/table-configs.js';
+import { queriesConfig } from './lib/builders/table-configs.js';
 import { createActiveView } from './views/active.js';
 import { createOverviewView } from './views/overview.js';
 import { createEventsView } from './views/events.js';
+import { createSessionsView } from './views/sessions.js';
 
 // ── Core services ─────────────────────────────────────────────────────────────
 
@@ -196,7 +197,7 @@ function initTabs() {
 
     vm.register(createOverviewView());
     vm.register(createEventsView());
-    vm.register(makeSessionsView());
+    vm.register(createSessionsView());
     vm.register(makeQueriesView());
     vm.register(makeHistogramView());
     vm.register(makeTimelineView());
@@ -501,7 +502,6 @@ function makeTableTabView(id, cmd, config) {
     };
 }
 
-function makeSessionsView() { return makeTableTabView('sessions', 'top_sessions', sessionsConfig); }
 function makeQueriesView()  { return makeTableTabView('queries', 'top_queries', queriesConfig); }
 
 function renderLegacyTable(container, tab, config, data) {

--- a/web/static/app.js
+++ b/web/static/app.js
@@ -3,12 +3,12 @@
  * B3 part 1: the 2000-line monolith is being restructured into native ES
  * modules (no build step — still embeddable via go:embed). This file is the
  * bootstrap + router. The migrated views (active = AAS chart, overview = time
- * model table) live in views/ as pure builders + thin mounts; the not-yet-
- * migrated tabs (events/sessions/queries/histogram/timeline/transitions/
- * concurrency) are wrapped as legacy view adapters so they ALL flow through the
- * same view-manager chokepoint and transport single-flight — which is what
- * keeps the B2 chaos races fixed while they await their turn to be migrated to
- * pure builders in B3 part 2.
+ * model table, events = the wait-events table) live in views/ as pure builders
+ * + thin mounts; the not-yet-migrated tabs (sessions/queries/histogram/timeline/
+ * transitions/concurrency) are wrapped as legacy view adapters so they ALL flow
+ * through the same view-manager chokepoint and transport single-flight — which is
+ * what keeps the B2 chaos races fixed while they await their turn to be migrated
+ * to pure builders (sessions/queries land later in this PR; the charts in part 3).
  *
  * State is explicit (lib/state.js): no grab-bag global mutated mid-flight.
  * Stale-response superseding is structural (lib/transport.js channels +
@@ -23,9 +23,10 @@ import {
     WAIT_CLASSES, EVENT_PALETTE, classColor,
     fmtTime, fmtTimeMs, fmtDuration, fmtMs, fmtUs, fmtCount, esc,
 } from './lib/format.js';
-import { eventsConfig, sessionsConfig, queriesConfig } from './lib/builders/table-configs.js';
+import { sessionsConfig, queriesConfig } from './lib/builders/table-configs.js';
 import { createActiveView } from './views/active.js';
 import { createOverviewView } from './views/overview.js';
+import { createEventsView } from './views/events.js';
 
 // ── Core services ─────────────────────────────────────────────────────────────
 
@@ -44,6 +45,19 @@ let reconnectTimer = null;
 // Auto-refresh (live mode) bookkeeping.
 let autoRefreshId = 0;
 let autoRefreshOn = false;
+
+// Sort state per table view. getSort returns the current { key, asc } (or null
+// for server order); toggleSort cycles desc→asc on repeated clicks of the same
+// column. Kept here (not in a view) so it survives tab switches, matching the
+// old per-tab behavior. (Legacy sortCol/sortAsc remain for the not-yet-migrated
+// sessions/queries adapters until they migrate in this PR's later commits.)
+const tabSort = {};   // tab -> { key, asc }
+function getSort(tab) { return tabSort[tab] || null; }
+function toggleSort(tab, key) {
+    const cur = tabSort[tab];
+    if (cur && cur.key === key) tabSort[tab] = { key, asc: !cur.asc };
+    else tabSort[tab] = { key, asc: false };
+}
 
 // Sort state per tab (legacy table views read/write this).
 const sortCol = {};
@@ -64,7 +78,11 @@ function makeCtx() {
         setStatus,
         onDrill: drill,
         onZoom: (from, to) => { stopAutoRefresh(); zoomTo(from, to); },
-        // Legacy adapters need these:
+        // Table views: per-tab sort state + a re-render hook used after a
+        // header-sort click (re-runs requests/build/mount under a fresh epoch).
+        getSort, toggleSort,
+        refresh: () => vm.refresh(),
+        // Legacy adapters (sessions/queries until migrated) need these:
         sortCol, sortAsc,
     };
 }
@@ -177,7 +195,7 @@ function initTabs() {
     vm.setContainer(tableEl);
 
     vm.register(createOverviewView());
-    vm.register(makeEventsView());
+    vm.register(createEventsView());
     vm.register(makeSessionsView());
     vm.register(makeQueriesView());
     vm.register(makeHistogramView());
@@ -483,7 +501,6 @@ function makeTableTabView(id, cmd, config) {
     };
 }
 
-function makeEventsView()   { return makeTableTabView('events', 'top_events', eventsConfig); }
 function makeSessionsView() { return makeTableTabView('sessions', 'top_sessions', sessionsConfig); }
 function makeQueriesView()  { return makeTableTabView('queries', 'top_queries', queriesConfig); }
 

--- a/web/static/app.js
+++ b/web/static/app.js
@@ -3,12 +3,12 @@
  * B3 part 1: the 2000-line monolith is being restructured into native ES
  * modules (no build step — still embeddable via go:embed). This file is the
  * bootstrap + router. The migrated views (active = AAS chart, overview = time
- * model table, events/sessions = drill-down tables) live in views/ as pure
- * builders + thin mounts; the not-yet-migrated tabs (queries/histogram/timeline/
+ * model table, events/sessions/queries = the drill-down tables) live in views/
+ * as pure builders + thin mounts; the not-yet-migrated tabs (histogram/timeline/
  * transitions/concurrency) are wrapped as legacy view adapters so they ALL flow
  * through the same view-manager chokepoint and transport single-flight — which is
  * what keeps the B2 chaos races fixed while they await their turn to be migrated
- * to pure builders (queries lands next in this PR; the charts in part 3).
+ * to pure builders in B3 part 3.
  *
  * State is explicit (lib/state.js): no grab-bag global mutated mid-flight.
  * Stale-response superseding is structural (lib/transport.js channels +
@@ -18,16 +18,16 @@
 import { ServerInfo, TimeRange, FilterStack, FIFTEEN_MIN_NS } from './lib/state.js';
 import { Transport } from './lib/transport.js';
 import { ViewManager } from './lib/view-manager.js';
-import { mountTable, buildTableModel } from './lib/table.js';
+import { mountTable } from './lib/table.js';
 import {
-    WAIT_CLASSES, EVENT_PALETTE, classColor,
-    fmtTime, fmtTimeMs, fmtDuration, fmtMs, fmtUs, fmtCount, esc,
+    WAIT_CLASSES, classColor,
+    fmtTime, fmtTimeMs, fmtDuration, fmtUs, fmtCount, esc,
 } from './lib/format.js';
-import { queriesConfig } from './lib/builders/table-configs.js';
 import { createActiveView } from './views/active.js';
 import { createOverviewView } from './views/overview.js';
 import { createEventsView } from './views/events.js';
 import { createSessionsView } from './views/sessions.js';
+import { createQueriesView } from './views/queries.js';
 
 // ── Core services ─────────────────────────────────────────────────────────────
 
@@ -50,8 +50,7 @@ let autoRefreshOn = false;
 // Sort state per table view. getSort returns the current { key, asc } (or null
 // for server order); toggleSort cycles desc→asc on repeated clicks of the same
 // column. Kept here (not in a view) so it survives tab switches, matching the
-// old per-tab behavior. (Legacy sortCol/sortAsc remain for the not-yet-migrated
-// sessions/queries adapters until they migrate in this PR's later commits.)
+// old per-tab behavior.
 const tabSort = {};   // tab -> { key, asc }
 function getSort(tab) { return tabSort[tab] || null; }
 function toggleSort(tab, key) {
@@ -59,10 +58,6 @@ function toggleSort(tab, key) {
     if (cur && cur.key === key) tabSort[tab] = { key, asc: !cur.asc };
     else tabSort[tab] = { key, asc: false };
 }
-
-// Sort state per tab (legacy table views read/write this).
-const sortCol = {};
-const sortAsc = {};
 
 // ── DOM handles (resolved once at bootstrap) ──────────────────────────────────
 
@@ -83,8 +78,6 @@ function makeCtx() {
         // header-sort click (re-runs requests/build/mount under a fresh epoch).
         getSort, toggleSort,
         refresh: () => vm.refresh(),
-        // Legacy adapters (sessions/queries until migrated) need these:
-        sortCol, sortAsc,
     };
 }
 
@@ -198,7 +191,7 @@ function initTabs() {
     vm.register(createOverviewView());
     vm.register(createEventsView());
     vm.register(createSessionsView());
-    vm.register(makeQueriesView());
+    vm.register(createQueriesView());
     vm.register(makeHistogramView());
     vm.register(makeTimelineView());
     vm.register(makeTransitionsView());
@@ -475,59 +468,16 @@ function initLiveMode() {
 }
 
 // ══════════════════════════════════════════════════════════════════════════════
-// LEGACY VIEW ADAPTERS — not yet migrated to pure builders (B3 part 2).
+// LEGACY VIEW ADAPTERS — the chart/Sankey views awaiting B3 part 3.
 //
-// Each wraps the original app.js render logic in the { id, requests, build,
-// mount, enter, leave } contract so it flows through the view-manager chokepoint
-// + transport single-flight. requests() returns the raw response (possibly
-// several joined fetches), build() is identity (kept impure for now — the
-// migration to a pure builder + Node tests happens per-view in part 2), and
+// After B3 part 2, only histogram/timeline/transitions/concurrency remain on the
+// legacy path: each wraps the original app.js render logic in the { id, requests,
+// build, mount, enter, leave } contract so it flows through the view-manager
+// chokepoint + transport single-flight. requests() returns the raw response
+// (possibly several joined fetches), build() is identity (kept impure for now —
+// migration to a pure builder + Node tests happens per-view in part 3), and
 // mount() runs the legacy DOM/ECharts rendering. enter/leave own any chart.
 // ══════════════════════════════════════════════════════════════════════════════
-
-function makeTableTabView(id, cmd, config) {
-    return {
-        id,
-        async requests(ctx) {
-            return ctx.transport.request(ctx.channel('table'), cmd, {
-                from: ctx.timeRange.from, to: ctx.timeRange.to,
-                filters: ctx.filters.snapshot(),
-            });
-        },
-        build(data) { return data; },
-        mount(el, data) {
-            renderLegacyTable(el, id, config, data);
-        },
-        enter() {}, leave() {},
-    };
-}
-
-function makeQueriesView()  { return makeTableTabView('queries', 'top_queries', queriesConfig); }
-
-function renderLegacyTable(container, tab, config, data) {
-    summaryEl.innerHTML = '';
-    if (!config || !data) {
-        container.innerHTML = '<div class="loading">No data</div>';
-        return;
-    }
-    const rows = data.rows || [];
-    if (rows.length === 0) {
-        container.innerHTML = '<div class="loading">No data for selected range</div>';
-        return;
-    }
-    const sort = sortCol[tab] ? { key: sortCol[tab], asc: sortAsc[tab] } : null;
-    const model = buildTableModel(config, rows, sort);
-    mountTable(container, config, model, {
-        sort,
-        onSort: (key) => {
-            if (sortCol[tab] === key) sortAsc[tab] = !sortAsc[tab];
-            else { sortCol[tab] = key; sortAsc[tab] = false; }
-            renderLegacyTable(container, tab, config, data);
-        },
-        onRowClick: (row) => { const i = config.onClick(row); if (i) drill(i); },
-        tooltipEl,
-    });
-}
 
 // ── Histogram (heatmap) ───────────────────────────────────────────────────────
 

--- a/web/static/lib/builders/table-configs.js
+++ b/web/static/lib/builders/table-configs.js
@@ -7,8 +7,8 @@
  * label } rather than performing navigation, keeping the config free of app
  * wiring. The view translates the intent into filters.drill().
  *
- * This PR migrates overview + events. sessions/queries configs are included so
- * the shared component is exercised, but their views migrate in B3 part 2.
+ * Used by the migrated overview, events, sessions and queries views (the
+ * drill-down tables all share lib/table.js via these configs).
  */
 
 import {

--- a/web/static/views/events.js
+++ b/web/static/views/events.js
@@ -1,0 +1,64 @@
+/* pgwt — "events" view: the top wait-events table.
+ *
+ * Migrated to the { id, requests, build, mount, enter, leave } contract (B3
+ * part 2). requests() fetches top_events on a single-flight channel; build() is
+ * the PURE table model (sort applied via lib/table.js's buildTableModel over the
+ * shared eventsConfig); mount() paints with the shared component and wires
+ * header-sort + row-click drill-down. No chart, so enter/leave are no-ops.
+ *
+ * Behavior is identical to the old legacy adapter in app.js:
+ *   - Rows arrive in server order (CPU* first); no default client sort.
+ *   - Clicking a column header sorts (first click desc, toggles to asc).
+ *   - Clicking a row drills into that event_id (→ queries, per the app PIVOT).
+ */
+
+import { buildTableModel } from '../lib/table.js';
+import { eventsConfig } from '../lib/builders/table-configs.js';
+
+/* PURE: top_events response + sort -> render model. Exported for testing. */
+export function buildEventsModel(data, sort) {
+    const rows = (data && data.rows) || [];
+    return {
+        hasRows: rows.length > 0,
+        table: buildTableModel(eventsConfig, rows, sort),
+    };
+}
+
+export function createEventsView() {
+    return {
+        id: 'events',
+
+        async requests(ctx) {
+            return ctx.transport.request(ctx.channel('table'), 'top_events', {
+                from: ctx.timeRange.from,
+                to: ctx.timeRange.to,
+                filters: ctx.filters.snapshot(),
+            });
+        },
+
+        build(data, ctx) {
+            const sort = ctx.getSort('events');
+            return buildEventsModel(data, sort);
+        },
+
+        mount(el, model, ctx) {
+            if (ctx.summaryEl) ctx.summaryEl.innerHTML = '';
+            if (!model.hasRows) {
+                el.innerHTML = '<div class="loading">No data for selected range</div>';
+                return;
+            }
+            ctx.mountTable(el, eventsConfig, model.table, {
+                sort: ctx.getSort('events'),
+                onSort: (key) => { ctx.toggleSort('events', key); ctx.refresh(); },
+                onRowClick: (row) => {
+                    const intent = eventsConfig.onClick(row);
+                    if (intent) ctx.onDrill(intent);
+                },
+                tooltipEl: ctx.tooltipEl,
+            });
+        },
+
+        enter() { /* no chart */ },
+        leave() { /* no chart */ },
+    };
+}

--- a/web/static/views/queries.js
+++ b/web/static/views/queries.js
@@ -1,0 +1,66 @@
+/* pgwt — "queries" view: the top queries (per-fingerprint) table.
+ *
+ * Migrated to the { id, requests, build, mount, enter, leave } contract (B3
+ * part 2). requests() fetches top_queries on a single-flight channel; build()
+ * is the PURE table model (sort via lib/table.js over the shared queriesConfig,
+ * which renders the stacked wait-profile bars + the query-text hover cell);
+ * mount() paints + wires header-sort, row-click drill-down, and the query-text
+ * tooltip. No chart, so enter/leave are no-ops.
+ *
+ * Behavior is identical to the old legacy adapter in app.js:
+ *   - Rows arrive in server order; no default client sort.
+ *   - Clicking a column header sorts (first click desc, toggles to asc).
+ *   - Clicking a row drills into that query_id (→ events, per the app PIVOT).
+ *   - Long query text shows a hover tooltip (lib/table.js tooltipEl wiring).
+ */
+
+import { buildTableModel } from '../lib/table.js';
+import { queriesConfig } from '../lib/builders/table-configs.js';
+
+/* PURE: top_queries response + sort -> render model. Exported for testing. */
+export function buildQueriesModel(data, sort) {
+    const rows = (data && data.rows) || [];
+    return {
+        hasRows: rows.length > 0,
+        table: buildTableModel(queriesConfig, rows, sort),
+    };
+}
+
+export function createQueriesView() {
+    return {
+        id: 'queries',
+
+        async requests(ctx) {
+            return ctx.transport.request(ctx.channel('table'), 'top_queries', {
+                from: ctx.timeRange.from,
+                to: ctx.timeRange.to,
+                filters: ctx.filters.snapshot(),
+            });
+        },
+
+        build(data, ctx) {
+            const sort = ctx.getSort('queries');
+            return buildQueriesModel(data, sort);
+        },
+
+        mount(el, model, ctx) {
+            if (ctx.summaryEl) ctx.summaryEl.innerHTML = '';
+            if (!model.hasRows) {
+                el.innerHTML = '<div class="loading">No data for selected range</div>';
+                return;
+            }
+            ctx.mountTable(el, queriesConfig, model.table, {
+                sort: ctx.getSort('queries'),
+                onSort: (key) => { ctx.toggleSort('queries', key); ctx.refresh(); },
+                onRowClick: (row) => {
+                    const intent = queriesConfig.onClick(row);
+                    if (intent) ctx.onDrill(intent);
+                },
+                tooltipEl: ctx.tooltipEl,
+            });
+        },
+
+        enter() { /* no chart */ },
+        leave() { /* no chart */ },
+    };
+}

--- a/web/static/views/sessions.js
+++ b/web/static/views/sessions.js
@@ -1,0 +1,64 @@
+/* pgwt — "sessions" view: the top sessions (per-backend) table.
+ *
+ * Migrated to the { id, requests, build, mount, enter, leave } contract (B3
+ * part 2). requests() fetches top_sessions on a single-flight channel; build()
+ * is the PURE table model (sort via lib/table.js over the shared
+ * sessionsConfig); mount() paints + wires header-sort and row-click drill-down.
+ * No chart, so enter/leave are no-ops.
+ *
+ * Behavior is identical to the old legacy adapter in app.js:
+ *   - Rows arrive in server order; no default client sort.
+ *   - Clicking a column header sorts (first click desc, toggles to asc).
+ *   - Clicking a row drills into that pid (→ timeline, per the app PIVOT).
+ */
+
+import { buildTableModel } from '../lib/table.js';
+import { sessionsConfig } from '../lib/builders/table-configs.js';
+
+/* PURE: top_sessions response + sort -> render model. Exported for testing. */
+export function buildSessionsModel(data, sort) {
+    const rows = (data && data.rows) || [];
+    return {
+        hasRows: rows.length > 0,
+        table: buildTableModel(sessionsConfig, rows, sort),
+    };
+}
+
+export function createSessionsView() {
+    return {
+        id: 'sessions',
+
+        async requests(ctx) {
+            return ctx.transport.request(ctx.channel('table'), 'top_sessions', {
+                from: ctx.timeRange.from,
+                to: ctx.timeRange.to,
+                filters: ctx.filters.snapshot(),
+            });
+        },
+
+        build(data, ctx) {
+            const sort = ctx.getSort('sessions');
+            return buildSessionsModel(data, sort);
+        },
+
+        mount(el, model, ctx) {
+            if (ctx.summaryEl) ctx.summaryEl.innerHTML = '';
+            if (!model.hasRows) {
+                el.innerHTML = '<div class="loading">No data for selected range</div>';
+                return;
+            }
+            ctx.mountTable(el, sessionsConfig, model.table, {
+                sort: ctx.getSort('sessions'),
+                onSort: (key) => { ctx.toggleSort('sessions', key); ctx.refresh(); },
+                onRowClick: (row) => {
+                    const intent = sessionsConfig.onClick(row);
+                    if (intent) ctx.onDrill(intent);
+                },
+                tooltipEl: ctx.tooltipEl,
+            });
+        },
+
+        enter() { /* no chart */ },
+        leave() { /* no chart */ },
+    };
+}


### PR DESCRIPTION
## What this does

Continues the B3 UI restructure (part 1 = PR #14) by migrating the three
table-style drill-down views — **events, sessions, queries** — off the
legacy `makeTableTabView`/`renderLegacyTable` adapter and onto the part-1
architecture: a pure `build(data, state)` + thin `mount()` +
view-manager `enter/leave` + transport single-flight, each reusing the
shared `lib/table.js` component via one declarative config from
`lib/builders/table-configs.js`.

One commit per view (events, then sessions, then queries); each commit is
individually self-consistent (app.js parses + the migrated view registered).

## How each view reuses `lib/table.js`

All three are `{ id, requests, build, mount, enter, leave }` with no chart
(enter/leave are no-ops). Each:
- `requests()` fetches its command (`top_events` / `top_sessions` /
  `top_queries`) on a single-flight channel (`ctx.channel('table')`).
- `build(data, state)` is **PURE**: `buildEventsModel` / `buildSessionsModel`
  / `buildQueriesModel` run `buildTableModel(config, rows, sort)` over the
  shared `eventsConfig` / `sessionsConfig` / `queriesConfig` — no DOM, no
  globals, Node-testable.
- `mount()` calls the shared `ctx.mountTable(...)` to paint, wiring header
  sort, row-click drill-down, and (queries) the query-text hover tooltip.

Shared wiring added once: per-tab sort state moved from the legacy
`sortCol`/`sortAsc` grab-bag to `getSort`/`toggleSort` on the ctx, plus a
`refresh()` hook so a header-sort click re-runs requests/build/mount under
a fresh view-manager epoch.

## Behavior preserved (identical to today)

- Same columns, same server-order default (no client sort), same
  first-click-desc / second-click-asc sorting, same sort-arrow glyphs.
- Same drill navigation via the app PIVOT: event row → `event_id`
  (→ queries), session row → `pid` (→ timeline), query row → `query_id`
  (→ events); breadcrumb behavior unchanged.
- Queries keep the event-vs-class stacked wait-profile bars, the long
  query-text `qt-hover` tooltip, and the em-dash placeholder for empty text.
- HTML output is byte-identical (same shared `table.js`/configs), so the
  existing Playwright cell-value assertions are untouched.

## Node builder unit tests added (`node --test`, no browser, run in CI build-and-unit)

- `tests/web_unit/events.test.mjs` — row shape, desc/asc sort + arrow,
  drill intent, empty + single-row edges.
- `tests/web_unit/sessions.test.mjs` — column set, sort, pid drill intent
  (→ timeline), empty user/db rendering, edges.
- `tests/web_unit/queries.test.mjs` — column set, event-vs-class stacked
  bar selection, qt-hover for long text, em-dash for empty text, sort,
  query_id drill intent (→ events), edges.

Full suite: **50/50** pure-builder tests pass locally.

## Still legacy (B3 part 3)

Only the heavy chart/Sankey views remain on the legacy adapter path:
**histogram, timeline, transitions, concurrency**. `app.js` no longer
contains any table-rendering code (`makeTableTabView` / `renderLegacyTable`
and the old sort grab-bag are gone).

## Gates

- `tests/test_web_ui.py` (146/146) and `tests/test_web_ui_chaos.py` are
  expected to stay green — the migrated views render through the same
  shared `lib/table.js` into `#table-container` with identical markup and
  flow through the same view-manager chokepoint, so user-visible behavior
  and the chaos regression guards are unchanged. No Playwright assertions
  were weakened or changed. (The sandbox here blocks Playwright/network, so
  the browser suites are validated by the CI web-ui job; pure builders were
  validated locally with `node --test`.)
- No build step; native ESM; `go:embed static` picks up the new view files
  automatically.