### PR TITLE
A6: cooperative provider stub (interface freeze)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,7 @@ jobs:
           tests/test_trace_v2
           tests/test_sampler
           tests/test_anomaly
+          tests/test_coop
 
       - name: Run synthetic data tests
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ tests/test_event_reader
 tests/test_trace_v2
 tests/test_sampler
 tests/test_anomaly
+tests/test_coop
 tests/dump_markers
 tests/gen_test_traces
 tests/gen_bench_traces

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ USER_SRCS  = $(SRC_DIR)/pg_wait_tracer.c \
              $(SRC_DIR)/daemon.c \
              $(SRC_DIR)/control.c \
              $(SRC_DIR)/provider_full.c \
+             $(SRC_DIR)/provider_coop.c \
              $(SRC_DIR)/sampler.c \
              $(SRC_DIR)/escalation.c \
              $(SRC_DIR)/anomaly.c \

--- a/docs/REWORK_PLAN.md
+++ b/docs/REWORK_PLAN.md
@@ -347,10 +347,40 @@ rather than in `escalation.c`/`compute.c` — the baseline is derived from
 the sampler's per-tick batch in `sampler.c`, so no `compute.c` change was
 needed.
 
-### Phase A6 — Cooperative provider stub (interface freeze only)
+### Phase A6 — Cooperative provider stub (interface freeze only) ✅ DONE
 Scope: `coop` provider compiled but returning "not available"; document
 the contract the extension must satisfy (same event schema, EXACT
 fidelity, its own start/stop). No further work in this track.
+
+Delivered: `src/provider_coop.{c,h}` — a `coop` provider implementing the
+`struct pgwt_capture_provider` vtable, advertising `PGWT_FIDELITY_EXACT`,
+whose `start()` cleanly reports "cooperative provider not available in this
+build" and returns -1 so the daemon aborts startup with a clear message (no
+crash). `enum pgwt_mode` gains `PGWT_MODE_COOP`; `--mode coop` parses to it
+(`src/pg_wait_tracer.c`) and `pgwt_daemon_init()` selects the stub
+(`src/daemon.c`); coop arms neither watchpoints nor the sampler
+(`pgwt_mode_uses_watchpoints`/`_uses_sampler` in `daemon.h`). Default
+behavior and full/sampled/tiered selection are unchanged.
+
+The FROZEN CONTRACT for the extension track is documented in detail in the
+`provider_coop.h` header comment. In short, the cooperative provider must:
+(1) emit the SAME v2 trace records as the other tiers — a wait transition is
+a TRANSITIONS record byte-identical to the `full` tier's; (2) advertise
+`PGWT_FIDELITY_EXACT` so it satisfies the EXACT-required views with no
+view-side change; (3) hand every event to the trace writer through the SAME
+path the full tier uses (poll() drains the extension's delivery into
+`src/event_stream.c` `handle_event` → `src/event_writer.c`), taking backend
+identity from the SHARED registry (`src/backend.c`); (4) implement all four
+vtable entry points (start/stop/poll/self_metrics); (5) not own backend
+discovery (mode-independent registry/lifecycle stays in the daemon). The
+extension track replaces the stub bodies in `provider_coop.c`; nothing else
+in the daemon changes.
+
+Tests: `tests/test_coop.c` — BPF-free unit test (built `-DPGWT_SERVER`,
+matching test_sampler/test_anomaly) asserting the coop provider registers,
+advertises EXACT, exposes the full vtable, and that `start()` returns the
+clean not-available status (with NULL-daemon tolerance and no-op stop/poll/
+metrics while unarmed). Wired into `run_all.sh` C-unit + CI build-and-unit.
 
 ---
 

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -8,6 +8,7 @@
 #include "map_reader.h"
 #include "output.h"
 #include "perf_event.h"
+#include "provider_coop.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -191,6 +192,12 @@ int pgwt_daemon_init(struct pgwt_daemon *d)
     case PGWT_MODE_SAMPLED:
     case PGWT_MODE_TIERED:
         d->provider = &pgwt_provider_sampled;
+        break;
+    case PGWT_MODE_COOP:
+        /* A6 interface freeze: the coop provider is recognized but its
+         * start() cleanly reports "not available in this build" (the
+         * cooperative tier ships in the separate extension track). */
+        d->provider = &pgwt_provider_coop;
         break;
     case PGWT_MODE_FULL:
     default:

--- a/src/daemon.h
+++ b/src/daemon.h
@@ -177,6 +177,9 @@ static inline bool pgwt_mode_uses_watchpoints(const struct pgwt_daemon *d)
         return false;
     if (d->mode == PGWT_MODE_TIERED)
         return d->escalation.active;
+    if (d->mode == PGWT_MODE_COOP)
+        return false;   /* A6: capture comes from the extension, not watchpoints
+                           (and the stub refuses activation in this build) */
     return true;   /* PGWT_MODE_FULL */
 }
 

--- a/src/pg_wait_tracer.c
+++ b/src/pg_wait_tracer.c
@@ -51,11 +51,13 @@ static void usage(const char *prog)
         "      --daemon               Run as daemon (reconnect on PG restart)\n"
         "\n"
         "Capture tier:\n"
-        "      --mode <MODE>          full (default) | sampled | tiered\n"
+        "      --mode <MODE>          full (default) | sampled | tiered | coop\n"
         "                             full: hardware watchpoints, exact transitions.\n"
         "                             sampled: userspace ASH-style sampling, ~zero PG cost.\n"
         "                             tiered: sampler always-on; escalate to full\n"
         "                                     fidelity for bounded, budgeted windows.\n"
+        "                             coop: cooperative (PG extension) — not available in\n"
+        "                                   this build; ships in the extension track.\n"
         "      --sample-rate <HZ>     Sampling rate for sampled/tiered (1-1000, default 10)\n"
         "      --escalation-budget <S>  Tiered: full-fidelity seconds allowed per\n"
         "                             rolling hour (default 300). Escalate via the\n"
@@ -183,7 +185,8 @@ static enum pgwt_mode parse_mode(const char *s)
     if (strcmp(s, "full") == 0)     return PGWT_MODE_FULL;
     if (strcmp(s, "sampled") == 0)  return PGWT_MODE_SAMPLED;
     if (strcmp(s, "tiered") == 0)   return PGWT_MODE_TIERED;
-    fprintf(stderr, "ERROR: unknown mode '%s' (use: full, sampled, tiered)\n", s);
+    if (strcmp(s, "coop") == 0)     return PGWT_MODE_COOP;
+    fprintf(stderr, "ERROR: unknown mode '%s' (use: full, sampled, tiered, coop)\n", s);
     exit(1);
 }
 
@@ -416,11 +419,14 @@ int main(int argc, char **argv)
         return 1;
     }
 
-    /* Validate: --mode sampled/tiered is incompatible with --lightweight
+    /* Validate: any non-full mode is incompatible with --lightweight
      * (lightweight is a watchpoint-only BPF-accumulator mode). */
     if (d->mode != PGWT_MODE_FULL && d->lightweight_mode) {
+        const char *mname = d->mode == PGWT_MODE_SAMPLED ? "sampled"
+                          : d->mode == PGWT_MODE_TIERED  ? "tiered"
+                          : "coop";
         fprintf(stderr, "ERROR: --mode %s is incompatible with --lightweight\n",
-                d->mode == PGWT_MODE_SAMPLED ? "sampled" : "tiered");
+                mname);
         free(d);
         return 1;
     }

--- a/src/provider.h
+++ b/src/provider.h
@@ -80,9 +80,14 @@ enum pgwt_mode {
     PGWT_MODE_FULL = 0,    /* watchpoints only — today's default */
     PGWT_MODE_SAMPLED,     /* userspace sampler only, no watchpoints */
     PGWT_MODE_TIERED,      /* sampler always on; escalation lands in A4 */
+    PGWT_MODE_COOP,        /* cooperative (PG extension) — A6 interface freeze,
+                              implemented in the extension track. The stub
+                              recognizes the mode but refuses activation with
+                              a clean "not available in this build" message. */
 };
 
-/* The two real providers (A2). coop is A6. */
+/* The two real providers (A2). coop (A6) is an interface-frozen stub; its
+ * vtable lives in provider_coop.h. */
 extern const struct pgwt_capture_provider pgwt_provider_full;
 extern const struct pgwt_capture_provider pgwt_provider_sampled;
 

--- a/src/provider_coop.c
+++ b/src/provider_coop.c
@@ -1,0 +1,71 @@
+/* provider_coop.c — Cooperative capture provider (Track A, Phase A6)
+ *
+ * INTERFACE FREEZE ONLY — see provider_coop.h for the full frozen contract
+ * the extension track must satisfy. This file is a STUB: it registers a coop
+ * provider that advertises PGWT_FIDELITY_EXACT (the cooperative source reports
+ * every wait transition), but whose start() cleanly reports that the
+ * cooperative provider is not available in this build and refuses activation.
+ * No crash, clear message; the daemon aborts startup just as it would for any
+ * provider whose capture mechanism is unavailable.
+ *
+ * The extension track replaces these stub bodies with the real
+ * implementation (open the shared-memory ring the patched PG / extension
+ * fills, drain transitions in poll() into the SAME writer path the full tier
+ * uses — src/event_stream.c handle_event → src/event_writer.c). Nothing else
+ * in the daemon changes: provider selection, --mode coop parsing, and the
+ * vtable are already wired.
+ *
+ * Deliberately BPF-free (no skeleton include) so the stub and its unit test
+ * build without bpftool / in CI's server-only jobs, like sampler.c's core.
+ */
+#include "provider_coop.h"
+#include "daemon.h"
+
+#include <stdio.h>
+
+/* The single, stable not-available message. Kept as a symbol so the unit
+ * test can assert on it without duplicating the string. */
+const char pgwt_coop_unavailable_msg[] =
+    "cooperative provider not available in this build "
+    "(requires the pg_wait_tracer PostgreSQL extension / patched PG)";
+
+static int coop_start(struct pgwt_daemon *d)
+{
+    /* The cooperative source (patched PG / extension) is implemented in the
+     * separate extension track and is not present in this build. Report
+     * cleanly and refuse activation — the daemon turns the -1 into a clear
+     * "capture provider 'coop' failed to start" abort (src/daemon.c). */
+    fprintf(stderr, "ERROR: %s\n", pgwt_coop_unavailable_msg);
+    if (d && d->verbose)
+        fprintf(stderr,
+                "INFO: --mode coop is interface-only here (A6 freeze); the "
+                "cooperative tier ships in the extension track\n");
+    return -1;
+}
+
+static int coop_stop(struct pgwt_daemon *d)
+{
+    (void)d;
+    return 0;  /* never armed — nothing to disarm */
+}
+
+static int coop_poll(struct pgwt_daemon *d)
+{
+    (void)d;
+    return 0;  /* never armed — nothing to drain */
+}
+
+static void coop_metrics(struct pgwt_daemon *d, struct pgwt_metrics *m)
+{
+    (void)d;
+    (void)m;  /* no cooperative-tier counters until the extension lands */
+}
+
+const struct pgwt_capture_provider pgwt_provider_coop = {
+    .name         = "coop",
+    .fidelity     = PGWT_FIDELITY_EXACT,
+    .start        = coop_start,
+    .stop         = coop_stop,
+    .poll         = coop_poll,
+    .self_metrics = coop_metrics,
+};

--- a/src/provider_coop.h
+++ b/src/provider_coop.h
@@ -1,0 +1,90 @@
+/* provider_coop.h — Cooperative capture provider (Track A, Phase A6)
+ *
+ * ───────────────────────────────────────────────────────────────────────────
+ *  INTERFACE FREEZE ONLY. The cooperative tier is NOT implemented here.
+ * ───────────────────────────────────────────────────────────────────────────
+ *
+ * The cooperative ("coop") tier captures wait events with help from
+ * PostgreSQL itself — a patched PG or a loadable extension that hooks the
+ * wait-event start/stop path and reports transitions to the daemon, instead
+ * of the daemon observing PGPROC memory from the outside (watchpoints in the
+ * `full` tier, process_vm_readv sampling in the `sampled` tier).
+ *
+ * That implementation lives in a SEPARATE extension track, not in this repo.
+ * Phase A6's only deliverable is to FREEZE the provider contract so the
+ * extension can drop in later with zero churn in the daemon: this file plus
+ * provider_coop.c define the exact struct the extension must populate, and
+ * provider selection already recognizes `--mode coop`. Until the extension
+ * exists, the stub's start() cleanly reports "not available in this build"
+ * and refuses activation (no crash, clear message) — see provider_coop.c.
+ *
+ * ── THE FROZEN CONTRACT (what the extension track must satisfy) ────────────
+ *
+ * The cooperative provider is one more implementation of the single
+ * `struct pgwt_capture_provider` vtable (src/provider.h). It MUST:
+ *
+ *  1. SAME SCHEMA. Emit the SAME trace records as the other tiers — it does
+ *     NOT invent a new on-disk format. A wait transition becomes a v2
+ *     TRANSITIONS record (old_event → new_event with a real duration_ns),
+ *     byte-identical to what the `full` tier produces; the reader, replay,
+ *     pgwt-server and every compute view consume it unchanged. (If a future
+ *     coop source can only deliver point observations rather than intervals,
+ *     it must emit SAMPLES records and advertise SAMPLED instead — but the
+ *     intended cooperative source reports start/stop, i.e. intervals, so the
+ *     contract here is EXACT/TRANSITIONS.)
+ *
+ *  2. EXACT FIDELITY. Advertise `PGWT_FIDELITY_EXACT` — the extension reports
+ *     every transition, so coop windows satisfy the EXACT-required views
+ *     (histogram, transitions, lock chains, interference) exactly like the
+ *     `full` tier. compute.c keys view availability off this field alone; no
+ *     view needs to know whether EXACT data came from watchpoints or from
+ *     the extension.
+ *
+ *  3. THE WRITER PATH. Hand every event to the trace writer through the SAME
+ *     entry point the other tiers use — there is no second writer. Concretely,
+ *     poll() drains whatever the extension delivered (e.g. a shared-memory
+ *     ring the extension fills, or a ringbuf/socket the daemon reads) and, for
+ *     each transition, calls the daemon's per-event handler exactly as the
+ *     full tier's ringbuf callback does (see src/event_stream.c
+ *     `handle_event` → src/event_writer.c `pgwt_writer_*`). Backend identity
+ *     (pid → query_id, session metadata) comes from the SHARED registry
+ *     (src/backend.c), which the daemon keeps populated via the fork/exit
+ *     tracepoints + query_id uprobe in every mode — the coop provider does
+ *     NOT maintain its own backend table.
+ *
+ *  4. THE VTABLE. Implement all four entry points (src/provider.h):
+ *       - start(d):  arm cooperative capture (open the shm ring / register
+ *                    with the extension / verify the patched PG is present).
+ *                    Return 0 on success; -1 if the cooperative source is
+ *                    absent — the daemon prints a clear message and aborts
+ *                    startup, exactly as it would for any provider whose
+ *                    capture mechanism is unavailable. (This stub always
+ *                    takes the -1 path.)
+ *       - stop(d):   disarm (unregister, close the ring). Idempotent.
+ *       - poll(d):   drain delivered events into the writer (item 3). Called
+ *                    every daemon event-loop tick.
+ *       - self_metrics(d, m): fill tier-specific counters (e.g. transitions
+ *                    delivered, ring overruns) into struct pgwt_metrics for
+ *                    the control socket.
+ *
+ *  5. SHARED LIFECYCLE. Like `full` and `sampled`, the coop provider does NOT
+ *     own backend discovery. The daemon's registry/lifecycle machinery is
+ *     mode-independent; the provider only arms/drains its own capture path.
+ *
+ * Wiring already in place for the extension to slot into:
+ *   - enum pgwt_mode gains PGWT_MODE_COOP (src/provider.h).
+ *   - --mode coop parses to PGWT_MODE_COOP (src/pg_wait_tracer.c).
+ *   - pgwt_daemon_init() selects pgwt_provider_coop for that mode
+ *     (src/daemon.c). Today start() returns -1 → clean "not available".
+ * The extension track replaces the stub bodies in provider_coop.c with the
+ * real implementation; nothing else in the daemon needs to change.
+ */
+#ifndef PGWT_PROVIDER_COOP_H
+#define PGWT_PROVIDER_COOP_H
+
+#include "provider.h"
+
+/* The cooperative provider vtable (A6 stub; extension track fills it in). */
+extern const struct pgwt_capture_provider pgwt_provider_coop;
+
+#endif /* PGWT_PROVIDER_COOP_H */

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -6,8 +6,9 @@ CFLAGS    = -g -O2 -Wall -I../src -I../include
 BUILD     = ../build
 
 TESTS     = test_wait_event test_cmdline test_event_writer test_event_reader \
-            test_trace_v2 test_sampler test_anomaly test_bucket gen_test_traces \
-            gen_bench_traces test_concurrent_rw cross_validate dump_markers
+            test_trace_v2 test_sampler test_anomaly test_coop test_bucket \
+            gen_test_traces gen_bench_traces test_concurrent_rw cross_validate \
+            dump_markers
 
 .PHONY: all clean
 
@@ -47,6 +48,13 @@ test_sampler: test_sampler.c ../src/sampler.c
 # anomaly.c with -DPGWT_SERVER so only the pure rule core is built — no
 # skeleton, no escalation engine, runnable in CI's server-only jobs.
 test_anomaly: test_anomaly.c ../src/anomaly.c
+	$(CC) $(CFLAGS) -DPGWT_SERVER -o $@ $^
+
+# test_coop: cooperative provider stub (A6 interface freeze) — registers,
+# advertises EXACT fidelity, start() returns the clean "not available" status.
+# Compiles provider_coop.c with -DPGWT_SERVER so it needs no BPF skeleton — no
+# bpftool, runnable in CI's server-only jobs.
+test_coop: test_coop.c ../src/provider_coop.c
 	$(CC) $(CFLAGS) -DPGWT_SERVER -o $@ $^
 
 # Server-build objects for gen_test_traces

--- a/tests/run_all.sh
+++ b/tests/run_all.sh
@@ -78,6 +78,7 @@ run_test "test_bucket" "$SCRIPT_DIR/test_bucket"
 run_test "test_trace_v2" "$SCRIPT_DIR/test_trace_v2"
 run_test "test_sampler" "$SCRIPT_DIR/test_sampler"
 run_test "test_anomaly" "$SCRIPT_DIR/test_anomaly"
+run_test "test_coop" "$SCRIPT_DIR/test_coop"
 
 # Step 2.5: Synthetic data correctness tests (no root needed, needs pgwt-server)
 if [[ -x "$PROJECT_DIR/pgwt-server" ]] && [[ -x "$SCRIPT_DIR/gen_test_traces" ]]; then

--- a/tests/test_coop.c
+++ b/tests/test_coop.c
@@ -1,0 +1,98 @@
+/* test_coop.c — Unit tests for the cooperative provider stub (Phase A6)
+ *
+ * The cooperative tier is interface-frozen here, not implemented (it ships in
+ * the separate extension track). This test pins the FROZEN CONTRACT the
+ * extension must satisfy, and proves the stub refuses activation cleanly:
+ *
+ *   - the coop provider registers with name "coop";
+ *   - it advertises PGWT_FIDELITY_EXACT (cooperative source reports every
+ *     transition);
+ *   - the full vtable is present (start/stop/poll/self_metrics non-NULL);
+ *   - start() returns -1 (clean "not available in this build") with no crash;
+ *   - stop()/poll() succeed and self_metrics() is a safe no-op while unarmed.
+ *
+ * Built with -DPGWT_SERVER against provider_coop.c so it needs no BPF skeleton
+ * (buildable without bpftool, and in CI's server-only jobs), matching
+ * test_sampler / test_anomaly / test_trace_v2.
+ */
+#define _GNU_SOURCE
+#include "provider_coop.h"
+#include "daemon.h"
+
+#include <stdio.h>
+#include <string.h>
+
+static int tests_run = 0;
+static int tests_passed = 0;
+
+#define CHECK(cond, fmt, ...) do { \
+    tests_run++; \
+    if (cond) { tests_passed++; } \
+    else { printf("  FAIL: " fmt "\n", ##__VA_ARGS__); } \
+} while(0)
+
+/* The stub exports its single not-available message so we can assert on it. */
+extern const char pgwt_coop_unavailable_msg[];
+
+int main(void)
+{
+    printf("=== test_coop (A6 cooperative provider stub) ===\n");
+
+    const struct pgwt_capture_provider *p = &pgwt_provider_coop;
+
+    /* --- contract: identity + fidelity --- */
+    printf("--- frozen contract ---\n");
+    CHECK(p->name != NULL && strcmp(p->name, "coop") == 0,
+          "provider name should be \"coop\", got %s",
+          p->name ? p->name : "(null)");
+    CHECK(p->fidelity == PGWT_FIDELITY_EXACT,
+          "coop must advertise EXACT fidelity, got %d", (int)p->fidelity);
+
+    /* --- contract: full vtable present (extension must implement all four) --- */
+    CHECK(p->start != NULL, "start() must be implemented");
+    CHECK(p->stop != NULL, "stop() must be implemented");
+    CHECK(p->poll != NULL, "poll() must be implemented");
+    CHECK(p->self_metrics != NULL, "self_metrics() must be implemented");
+
+    /* --- behavior: start() refuses cleanly, no crash --- */
+    printf("--- clean not-available ---\n");
+    struct pgwt_daemon d;
+    memset(&d, 0, sizeof(d));
+    d.verbose = false;
+
+    int rc = p->start(&d);
+    CHECK(rc == -1, "start() must return -1 (not available), got %d", rc);
+
+    /* verbose path also must not crash */
+    d.verbose = true;
+    rc = p->start(&d);
+    CHECK(rc == -1, "start() (verbose) must return -1, got %d", rc);
+
+    /* the not-available message is present and mentions the extension */
+    CHECK(pgwt_coop_unavailable_msg[0] != '\0',
+          "not-available message must be non-empty");
+    CHECK(strstr(pgwt_coop_unavailable_msg, "not available") != NULL,
+          "message should say \"not available\": \"%s\"",
+          pgwt_coop_unavailable_msg);
+
+    /* --- behavior: stop/poll/metrics are safe no-ops while unarmed --- */
+    printf("--- safe no-ops while unarmed ---\n");
+    CHECK(p->stop(&d) == 0, "stop() must succeed (idempotent no-op)");
+    CHECK(p->poll(&d) == 0, "poll() must succeed (nothing to drain)");
+
+    struct pgwt_metrics m;
+    memset(&m, 0xab, sizeof(m));   /* poison; no-op metrics must not touch it */
+    struct pgwt_metrics before = m;
+    p->self_metrics(&d, &m);
+    CHECK(memcmp(&m, &before, sizeof(m)) == 0,
+          "self_metrics() must be a no-op (no coop counters yet)");
+
+    /* --- start()/stop()/poll() must tolerate a NULL daemon (defensive) --- */
+    printf("--- NULL-daemon tolerance ---\n");
+    CHECK(p->start(NULL) == -1, "start(NULL) must return -1 without crashing");
+    CHECK(p->stop(NULL) == 0,   "stop(NULL) must succeed without crashing");
+    CHECK(p->poll(NULL) == 0,   "poll(NULL) must succeed without crashing");
+
+    printf("=== %d/%d checks passed ===\n", tests_passed, tests_run);
+    return (tests_passed == tests_run) ? 0 : 1;
+}

--- a/tests/test_coop.c
+++ b/tests/test_coop.c
@@ -20,6 +20,7 @@
 #include "daemon.h"
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 static int tests_run = 0;
@@ -56,16 +57,18 @@ int main(void)
 
     /* --- behavior: start() refuses cleanly, no crash --- */
     printf("--- clean not-available ---\n");
-    struct pgwt_daemon d;
-    memset(&d, 0, sizeof(d));
-    d.verbose = false;
+    /* struct pgwt_daemon is large (embeds the snapshot ring etc.) — heap it. */
+    struct pgwt_daemon *dp = calloc(1, sizeof(*dp));
+    if (!dp) { printf("  FAIL: calloc daemon\n"); return 1; }
+    struct pgwt_daemon *d = dp;
+    d->verbose = false;
 
-    int rc = p->start(&d);
+    int rc = p->start(d);
     CHECK(rc == -1, "start() must return -1 (not available), got %d", rc);
 
     /* verbose path also must not crash */
-    d.verbose = true;
-    rc = p->start(&d);
+    d->verbose = true;
+    rc = p->start(d);
     CHECK(rc == -1, "start() (verbose) must return -1, got %d", rc);
 
     /* the not-available message is present and mentions the extension */
@@ -77,15 +80,17 @@ int main(void)
 
     /* --- behavior: stop/poll/metrics are safe no-ops while unarmed --- */
     printf("--- safe no-ops while unarmed ---\n");
-    CHECK(p->stop(&d) == 0, "stop() must succeed (idempotent no-op)");
-    CHECK(p->poll(&d) == 0, "poll() must succeed (nothing to drain)");
+    CHECK(p->stop(d) == 0, "stop() must succeed (idempotent no-op)");
+    CHECK(p->poll(d) == 0, "poll() must succeed (nothing to drain)");
 
     struct pgwt_metrics m;
     memset(&m, 0xab, sizeof(m));   /* poison; no-op metrics must not touch it */
     struct pgwt_metrics before = m;
-    p->self_metrics(&d, &m);
+    p->self_metrics(d, &m);
     CHECK(memcmp(&m, &before, sizeof(m)) == 0,
           "self_metrics() must be a no-op (no coop counters yet)");
+
+    free(dp);
 
     /* --- start()/stop()/poll() must tolerate a NULL daemon (defensive) --- */
     printf("--- NULL-daemon tolerance ---\n");


### PR DESCRIPTION
## Phase A6 — Cooperative provider stub (interface freeze only)

Freezes the cooperative (`coop`) capture-tier interface so the separate
**extension track** can drop in later with zero churn in the daemon. The
cooperative tier itself is **not** implemented here — A6 only fixes the contract.

### The stub
`src/provider_coop.{c,h}` — a `coop` provider implementing the
`struct pgwt_capture_provider` vtable and advertising `PGWT_FIDELITY_EXACT`.
Its `start()` cleanly reports *"cooperative provider not available in this
build"* and returns `-1`, so the daemon aborts startup with a clear message
(no crash). `stop()`/`poll()`/`self_metrics()` are safe no-ops while unarmed.

### The frozen contract (documented in `provider_coop.h`)
The extension's cooperative provider must:
1. **Same schema** — emit the same v2 trace records as the other tiers; a wait
   transition is a `TRANSITIONS` record byte-identical to the `full` tier's.
2. **EXACT fidelity** — advertise `PGWT_FIDELITY_EXACT`, so it satisfies the
   EXACT-required views (histogram, transitions, lock chains, interference)
   with no view-side change.
3. **Same writer path** — `poll()` drains the extension's delivery into the
   same path the full tier uses (`event_stream.c` `handle_event` →
   `event_writer.c`), taking backend identity from the **shared registry**
   (`backend.c`).
4. **Full vtable** — implement `start`/`stop`/`poll`/`self_metrics`.
5. **No backend discovery** — the mode-independent registry/lifecycle stays in
   the daemon; the provider only arms/drains its own capture path.

The extension track replaces the stub bodies in `provider_coop.c`; nothing else
in the daemon needs to change.

### Mode selection
`enum pgwt_mode` gains `PGWT_MODE_COOP`; `--mode coop` parses to it
(`pg_wait_tracer.c`) and `pgwt_daemon_init()` selects the stub (`daemon.c`).
Coop arms neither watchpoints nor the sampler (`pgwt_mode_uses_watchpoints` /
`_uses_sampler` in `daemon.h`). **No existing behavior changes** — default is
still `full`; `full`/`sampled`/`tiered` selection is untouched.

### Test
`tests/test_coop.c` — BPF-free unit test (built `-DPGWT_SERVER`, matching
test_sampler/test_anomaly): the coop provider registers, advertises EXACT,
exposes the full vtable, `start()` returns the clean not-available status,
no-op stop/poll/metrics, NULL-daemon tolerance (16/16). Wired into
`run_all.sh` C-unit + CI build-and-unit.

### Validation on the test box (Rocky 9, PG 18, full build)
- `make clean && make` links the daemon with the new provider.
- `tests/test_coop` 16/16.
- `--mode coop`: EXITED — `ERROR: cooperative provider not available in this
  build` → `FATAL: capture provider 'coop' failed to start` (clean, no crash).
- `--mode full` / `sampled` / `tiered`: all start normally, unaffected.