### PR TITLE
B5: fidelity-aware UI — sampled shading, escalate button, unavailable panels, metrics

### DIFF
--- a/docs/REWORK_PLAN.md
+++ b/docs/REWORK_PLAN.md
@@ -499,23 +499,45 @@ test in milliseconds, without Playwright; removing a series color
 mapping (no JS error, data still present) is caught by a snapshot diff
 in CI.
 
-### Phase B5 — Fidelity-aware UI (joins Track A)
+### Phase B5 — Fidelity-aware UI (joins Track A) ✅ DONE
 Depends on: A3 (fidelity field in responses), A4 (escalation via
 control proxy), B3 (view registry).
-Scope:
-- AAS chart shades sampled-fidelity time ranges (subtle background
-  band); legend explains it.
-- Views that require EXACT render an explicit "no full-fidelity data in
-  this window — escalate to capture" state instead of an empty chart.
-- "Escalate 60s" button wired through pgwt-server's control proxy;
-  shows budget remaining; escalation windows and trigger reasons
-  rendered as chart annotations.
-- Daemon self-metrics panel (events/s, drops, overhead estimate).
-Tests: mock server extended with fidelity-tagged responses + control
-commands; builder tests for shading/annotation models; Playwright test
-for the escalate flow against the mock.
-Acceptance: a mixed-fidelity trace is visually unambiguous about which
-data is which, and escalation is operable from the browser.
+Delivered (pure-builder + thin-mount + view-manager pattern, no B3 regression):
+- **Sampled shading**: `lib/builders/fidelity.js` turns a view response's
+  top-level `fidelity` ("exact"|"sampled"|"mixed") + optional
+  `fidelity_ranges` into an ECharts markArea band model; the AAS builder
+  attaches it behind the stacked areas. Sampled → amber band over the whole
+  window; mixed → bands only over sampled sub-ranges if present, else the
+  window marked mixed. A legend chip (`#aas-fidelity-chip`) explains it.
+- **Unavailable panels**: the EXACT-required views (histogram, transitions,
+  concurrency) detect the `{"unavailable":"requires full-fidelity data"}`
+  shape and render an explicit "No full-fidelity data in this window —
+  escalate to capture" panel (with the escalate affordance) instead of an
+  empty chart — `buildUnavailablePanel` + `lib/panels.js`.
+- **Escalate control**: header "Escalate 60s" button + budget readout + a
+  Stop affordance while active, wired through `lib/control.js` →
+  pgwt-server's `control` proxy (escalate/deescalate). Shows granted window /
+  budget remaining / denial reason. Hidden when no daemon (static replay).
+- **Escalation annotations**: the active escalation window is rendered on the
+  AAS timeline (markArea + labeled markLine), visually distinguishing
+  reason=manual (cyan) vs reason=anomaly (red). Drove a small server addition:
+  `build_status` now emits `escalation_reason` for the open window.
+- **Daemon self-metrics panel** (`#metrics-btn`): events/s, samples/s,
+  ringbuf drops, estimated overhead, anomaly counters, budget remaining —
+  from the control-socket `metrics`.
+Mock: `tests/mock_server.py` gained `PGWT_MOCK_FIDELITY` (exact|sampled|mixed
++ `sample_period_ns`), the `{"unavailable":...}` shape for EXACT views over a
+sampled window, and the `control` command (status/metrics/escalate/deescalate
+state machine mirroring src/control.c, incl. over-budget denial). Defaults
+keep every existing test + protocol-drift green (exact, no daemon).
+Tests: `tests/web_unit/fidelity.test.mjs` — 29 Node builder checks (markArea
+model, mixed sub-ranges, unavailable panel, manual-vs-anomaly annotation,
+metrics + escalate-control models, overhead). Playwright: 4 new B5 tests
+(sampled shading, unavailable panels, escalate flow, metrics panel) against a
+second sampled+daemon mock. Gates: test_web_ui 171/171 + chaos 25/25 green,
+zero console errors, no chart-global regressions.
+Acceptance: met — a sampled/mixed window is visually unambiguous, and
+escalation is operable from the browser.
 
 ### Phase B6 — New analysis views
 Depends on: B3 (view registry), A3 (fidelity declarations — all three

--- a/src/control.c
+++ b/src/control.c
@@ -35,6 +35,21 @@ static void cjson_add_uint64(cJSON *obj, const char *name, uint64_t val)
     cJSON_AddRawToObject(obj, name, buf);
 }
 
+/* Lowercase token for an escalation reason ("manual"|"anomaly"|...). Used so
+ * the UI can distinguish WHY a full-fidelity window is open (e.g. annotate a
+ * manual escalate differently from an anomaly-triggered one). */
+static const char *esc_reason_str(int reason)
+{
+    switch (reason) {
+    case PGWT_ESC_REASON_MANUAL:   return "manual";
+    case PGWT_ESC_REASON_ANOMALY:  return "anomaly";
+    case PGWT_ESC_REASON_EXPIRED:  return "expired";
+    case PGWT_ESC_REASON_REQUEST:  return "request";
+    case PGWT_ESC_REASON_SHUTDOWN: return "shutdown";
+    default:                       return "unknown";
+    }
+}
+
 /* Count live tracked backends */
 static int count_backends(const struct pgwt_daemon *d)
 {
@@ -88,6 +103,12 @@ static cJSON *build_status(const struct pgwt_daemon *d)
                             pgwt_escalation_remaining_s(d));
     cJSON_AddNumberToObject(root, "escalation_budget_remaining_s",
                             pgwt_escalation_budget_remaining_s(d));
+    /* Reason of the currently-open window (so the UI can annotate manual vs
+     * anomaly escalations distinctly). "none" while not escalated. */
+    cJSON_AddStringToObject(root, "escalation_reason",
+                            d->escalation.active
+                                ? esc_reason_str(d->escalation.window_reason)
+                                : "none");
     return root;
 }
 

--- a/tests/mock_server.py
+++ b/tests/mock_server.py
@@ -70,6 +70,13 @@ STATIC_DIR = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file
 
 # ── Canned data ──────────────────────────────────────────────────────────────
 
+def _env_int(name, default):
+    try:
+        return int(os.environ.get(name, default))
+    except (TypeError, ValueError):
+        return default
+
+
 _TO_NS   = 1_774_000_000_000_000_000
 _FROM_NS = _TO_NS - 3600_000_000_000
 _BUCKET_NS = 60_000_000_000
@@ -336,16 +343,169 @@ _FIDELITY_VIEWS = {
     "concurrency", "lock_chains", "interference", "variants",
 }
 
+# EXACT-required views (mirror src/server.c's PGWT_REQ_EXACT handlers): over a
+# sampled-only window these return the structured unavailable marker instead of
+# data. The web UI renders the "escalate to capture" panel for these.
+_EXACT_VIEWS = {"heatmap", "transitions", "concurrency", "lock_chains",
+                "interference"}
+
+# ── Fidelity + control configuration (Phase B5) ───────────────────────────────
+# The mock can present a SAMPLED or MIXED window so the UI's fidelity shading +
+# unavailable panels can be driven deterministically. Configured via env (like
+# chaos) so test_web_ui.py can launch a mock in any fidelity mode without a new
+# protocol surface. The control command implements a small escalate/deescalate
+# state machine mirroring src/control.c so the escalate flow is exercisable.
+#
+#   PGWT_MOCK_FIDELITY=exact|sampled|mixed   window fidelity for all views
+#                                            (default exact — keeps existing
+#                                            tests + protocol-drift green)
+#   PGWT_MOCK_SAMPLE_PERIOD_NS=100000000     sample period reported when sampled
+#   PGWT_MOCK_DAEMON=1                        enable the control command (escalate
+#                                            etc.); 0 → "daemon not running"
+#                                            (default 0, matching static replay)
+#   PGWT_MOCK_TIER=sampled|escalated         initial daemon tier (default sampled)
+#   PGWT_MOCK_BUDGET_S=300                    escalation budget remaining seconds
+
+
+class FidelityConfig:
+    def __init__(self):
+        self.fidelity = os.environ.get("PGWT_MOCK_FIDELITY", "exact")
+        if self.fidelity not in ("exact", "sampled", "mixed"):
+            self.fidelity = "exact"
+        self.sample_period_ns = _env_int("PGWT_MOCK_SAMPLE_PERIOD_NS", 100_000_000)
+
+
+_FID = FidelityConfig()
+
+
+class DaemonState:
+    """Minimal escalate/deescalate state machine mirroring src/control.c.
+
+    Lets the Playwright escalate-flow test drive a real state transition
+    (sampled → escalated → budget decreases) against the mock without a daemon.
+    """
+
+    def __init__(self):
+        self.enabled = os.environ.get("PGWT_MOCK_DAEMON", "0") not in ("0", "", "false")
+        self.tier = os.environ.get("PGWT_MOCK_TIER", "sampled")
+        self.budget_remaining_s = float(_env_int("PGWT_MOCK_BUDGET_S", 300))
+        self.seconds_remaining = 60.0 if self.tier == "escalated" else 0.0
+        self.reason = "manual" if self.tier == "escalated" else "none"
+        self.windows_total = 1 if self.tier == "escalated" else 0
+        self.denied_total = 0
+
+    def status(self):
+        return {
+            "ok": True,
+            "mode": "tiered",
+            "uptime_s": 123.4,
+            "backends": 6,
+            "pg_pid": 4000,
+            "version": "mock",
+            "tier": self.tier,
+            "escalation_supported": True,
+            "escalation_seconds_remaining": self.seconds_remaining,
+            "escalation_budget_remaining_s": self.budget_remaining_s,
+            "escalation_reason": self.reason if self.tier == "escalated" else "none",
+        }
+
+    def metrics(self):
+        return {
+            "ok": True,
+            "uptime_s": 123.4,
+            "events_total": 1_250_000,
+            "events_per_sec": 4200.0,
+            "lifecycle_events_total": 90000,
+            "wp_attach_failures_total": 0,
+            "backends_tracked": 6,
+            "samples_total": 540000,
+            "samples_per_sec": 60.0,
+            "sample_read_faults_total": 0,
+            "ringbuf_drops_total": 3,
+            "trace_events_written_total": 1_250_000,
+            "trace_bytes_written_total": 18_000_000,
+            "tier": self.tier,
+            "escalation_active": self.tier == "escalated",
+            "escalation_seconds_remaining": self.seconds_remaining,
+            "escalation_budget_remaining_s": self.budget_remaining_s,
+            "escalation_windows_total": self.windows_total,
+            "escalation_denied_total": self.denied_total,
+            "anomaly_fires_total": 2,
+            "anomaly_near_total": 5,
+            "anomaly_dropped_budget_total": 1,
+            "anomaly_dropped_cooldown_total": 0,
+            "anomaly_baseline_aas": 1.85,
+        }
+
+    def escalate(self, duration_s, reason):
+        duration_s = float(duration_s or 60)
+        if duration_s > self.budget_remaining_s:
+            self.denied_total += 1
+            return {"ok": False, "error": "over budget",
+                    "budget_remaining_s": self.budget_remaining_s}
+        if self.tier != "escalated":
+            self.windows_total += 1
+        self.tier = "escalated"
+        self.reason = reason or "manual"
+        self.seconds_remaining = max(self.seconds_remaining, duration_s)
+        self.budget_remaining_s = max(0.0, self.budget_remaining_s - duration_s)
+        return {"ok": True, "escalated": True, "granted_s": duration_s,
+                "seconds_remaining": self.seconds_remaining,
+                "budget_remaining_s": self.budget_remaining_s}
+
+    def deescalate(self):
+        self.tier = "sampled"
+        self.seconds_remaining = 0.0
+        self.reason = "none"
+        return {"ok": True, "escalated": False,
+                "budget_remaining_s": self.budget_remaining_s}
+
+
+_DAEMON = DaemonState()
+
+
+def _handle_control(req_id, msg):
+    """Proxy a control command (mirrors src/server.c handle_control)."""
+    request = msg.get("request")
+    if not isinstance(request, dict):
+        return {"id": req_id, "error": "missing request object"}
+    if not _DAEMON.enabled:
+        return {"id": req_id, "error": "daemon not running"}
+    cmd = request.get("cmd")
+    if cmd == "status":
+        return {"id": req_id, "response": _DAEMON.status()}
+    if cmd == "metrics":
+        return {"id": req_id, "response": _DAEMON.metrics()}
+    if cmd == "escalate":
+        return {"id": req_id, "response": _DAEMON.escalate(
+            request.get("duration_s"), request.get("reason"))}
+    if cmd == "deescalate":
+        return {"id": req_id, "response": _DAEMON.deescalate()}
+    return {"id": req_id, "response": {"ok": False, "error": "unknown command"}}
+
 
 def handle_request(msg):
     """Dispatch a WebSocket JSON request and return canned response."""
     cmd = msg.get("cmd", "")
     req_id = msg.get("id", 0)
+
+    if cmd == "control":
+        return _handle_control(req_id, msg)
+
+    # EXACT-required views over a sampled-only window return the structured
+    # unavailable marker (mirrors src/server.c emit_unavailable). A mixed
+    # window still has transition data, so it stays available.
+    if cmd in _EXACT_VIEWS and _FID.fidelity == "sampled":
+        return {"id": req_id, "unavailable": "requires full-fidelity data",
+                "fidelity": "sampled"}
+
     resp = _handle_request_inner(cmd, req_id, msg)
     # Tag every view response with its window fidelity (A3). Done centrally so
     # the schema stays aligned with the real server across all views.
     if cmd in _FIDELITY_VIEWS and "fidelity" not in resp and "error" not in resp:
-        resp["fidelity"] = "exact"
+        resp["fidelity"] = _FID.fidelity
+        if _FID.fidelity in ("sampled", "mixed"):
+            resp["sample_period_ns"] = _FID.sample_period_ns
     return resp
 
 
@@ -458,13 +618,6 @@ def _handle_request_inner(cmd, req_id, msg):
 # Reproduces real network conditions (jitter, out-of-order, late responses)
 # without any wall-clock RNG: every decision is a pure function of the
 # request's index, so chaos tests are reproducible.
-
-
-def _env_int(name, default):
-    try:
-        return int(os.environ.get(name, default))
-    except (TypeError, ValueError):
-        return default
 
 
 class ChaosConfig:

--- a/tests/test_web_ui.py
+++ b/tests/test_web_ui.py
@@ -98,11 +98,20 @@ def assert_no_console_errors(page, guard, name, allow=()):
           f"(got {len(unexpected)}: {unexpected[:3]})")
 
 
-def start_mock_server():
-    """Start mock_server.py as a subprocess."""
+def start_mock_server(extra_env=None, port=None):
+    """Start mock_server.py as a subprocess.
+
+    extra_env: optional dict of env vars (e.g. PGWT_MOCK_FIDELITY,
+    PGWT_MOCK_DAEMON) so a test can launch the mock in a fidelity/daemon mode
+    without a new protocol surface.
+    port: override the HTTP port (WS = port+1) for a second concurrent mock.
+    """
+    env = dict(os.environ)
+    if extra_env:
+        env.update(extra_env)
     proc = subprocess.Popen(
-        [sys.executable, MOCK_SCRIPT, "--port", str(MOCK_PORT)],
-        stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        [sys.executable, MOCK_SCRIPT, "--port", str(port or MOCK_PORT)],
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env,
     )
     # Wait for server to be ready
     time.sleep(1.5)
@@ -1086,6 +1095,145 @@ def test_filter_persists_across_tabs(page):
         check(False, "(skipped)")
 
 
+# ── Phase B5: fidelity-aware UI ───────────────────────────────────────────────
+# These run against a SECOND mock launched in sampled fidelity with the daemon
+# control command enabled, so the escalate flow, the sampled shading, the
+# unavailable panels, and the metrics panel can be driven deterministically.
+
+B5_PORT = MOCK_PORT + 10
+B5_URL = f"http://127.0.0.1:{B5_PORT}"
+
+
+def test_b5_sampled_shading(page):
+    """B5.1: AAS chart shades the sampled window + shows the fidelity legend."""
+    print("--- Test B5.1: Sampled Fidelity Shading ---")
+
+    page.goto(B5_URL)
+    page.wait_for_selector("#status.connected", timeout=10000)
+    page.wait_for_timeout(1500)
+
+    # The AAS builder must attach a markArea band on the first series, and the
+    # fidelity legend chip must explain it.
+    shading = page.evaluate("""() => {
+        const el = document.getElementById('aas-chart-container');
+        const c = echarts.getInstanceByDom(el);
+        if (!c) return 'no instance';
+        const opt = c.getOption();
+        const s0 = opt.series && opt.series[0];
+        if (!s0) return 'no series';
+        const ma = s0.markArea;
+        if (!ma || !ma.data || !ma.data.length) return 'no markArea';
+        return 'ok:' + ma.data.length;
+    }""")
+    check(shading.startswith("ok"),
+          f"AAS chart has a fidelity markArea band ({shading})")
+
+    chip = page.query_selector("#aas-fidelity-chip")
+    check(chip is not None, "Fidelity legend chip rendered")
+    if chip:
+        txt = chip.text_content()
+        check("sampled" in txt.lower(),
+              f"Fidelity chip explains sampled shading: '{txt[:60]}'")
+
+
+def test_b5_unavailable_panel(page):
+    """B5.2: an EXACT-only view over a sampled window shows the escalate panel."""
+    print("--- Test B5.2: Exact-only Unavailable Panel ---")
+
+    page.goto(B5_URL)
+    page.wait_for_selector("#status.connected", timeout=10000)
+
+    # Stop auto-refresh so the panel is stable, then open Transitions (EXACT).
+    page.click("#live-btn")
+    page.wait_for_timeout(300)
+    page.click(".tab[data-tab='transitions']")
+    page.wait_for_timeout(1500)
+
+    panel = page.query_selector(".unavailable-panel")
+    check(panel is not None, "Transitions shows the unavailable panel")
+    if panel:
+        txt = panel.text_content()
+        check("full-fidelity" in txt.lower(),
+              f"Panel explains no full-fidelity data: '{txt[:60]}'")
+        btn = page.query_selector(".unavailable-panel .escalate-btn")
+        check(btn is not None, "Panel offers an Escalate button")
+
+    # Concurrency (also EXACT-required) shows the same panel.
+    page.click(".tab[data-tab='concurrency']")
+    page.wait_for_timeout(1500)
+    check(page.query_selector(".unavailable-panel") is not None,
+          "Concurrency shows the unavailable panel")
+
+    # Histogram (EXACT) shows it inside the heatmap container.
+    page.click(".tab[data-tab='histogram']")
+    page.wait_for_timeout(1500)
+    check(page.query_selector(".unavailable-panel") is not None,
+          "Histogram shows the unavailable panel")
+
+
+def test_b5_escalate_flow(page):
+    """B5.3: clicking Escalate transitions the daemon to escalated + budget drops."""
+    print("--- Test B5.3: Escalate Flow ---")
+
+    page.goto(B5_URL)
+    page.wait_for_selector("#status.connected", timeout=10000)
+    page.wait_for_timeout(1500)
+
+    # The header escalate control is visible (daemon supports tiered escalation).
+    ctrl = page.query_selector("#escalate-control")
+    check(ctrl is not None and ctrl.is_visible(),
+          "Escalate control visible (daemon supports escalation)")
+
+    btn = page.query_selector("#hdr-escalate")
+    check(btn is not None, "Escalate button present")
+    label_before = btn.text_content() if btn else ""
+    check("Escalate" in label_before, f"Button reads 'Escalate' (got '{label_before}')")
+
+    # Read the status before escalating.
+    tier_before = page.evaluate("window.__pgwt && window.__pgwt.daemonTier()")
+    check(tier_before == "sampled", f"Tier sampled before escalate (got {tier_before})")
+
+    # Click Escalate.
+    btn.click()
+    page.wait_for_timeout(1200)
+
+    tier_after = page.evaluate("window.__pgwt && window.__pgwt.daemonTier()")
+    check(tier_after == "escalated", f"Tier escalated after click (got {tier_after})")
+
+    # The control now shows seconds remaining + a Stop affordance.
+    btn2 = page.query_selector("#hdr-escalate")
+    label_after = btn2.text_content() if btn2 else ""
+    check("left" in label_after or "Escalated" in label_after,
+          f"Button shows escalated state: '{label_after}'")
+    check(page.query_selector("#hdr-deescalate") is not None,
+          "Stop (de-escalate) button appears while escalated")
+
+
+def test_b5_metrics_panel(page):
+    """B5.4: the daemon self-metrics panel renders events/s, drops, overhead."""
+    print("--- Test B5.4: Daemon Metrics Panel ---")
+
+    page.goto(B5_URL)
+    page.wait_for_selector("#status.connected", timeout=10000)
+    page.wait_for_timeout(1200)
+
+    mbtn = page.query_selector("#metrics-btn")
+    check(mbtn is not None and mbtn.is_visible(),
+          "Metrics button visible when daemon present")
+
+    mbtn.click()
+    page.wait_for_timeout(800)
+
+    panel = page.query_selector("#daemon-metrics")
+    check(panel is not None and panel.is_visible(), "Metrics panel opens")
+    if panel:
+        txt = panel.text_content()
+        check("Events/s" in txt, "Metrics panel shows Events/s")
+        check("drops" in txt.lower(), "Metrics panel shows ringbuf drops")
+        check("overhead" in txt.lower(), "Metrics panel shows overhead estimate")
+        check("Budget" in txt, "Metrics panel shows budget remaining")
+
+
 # ── Main ─────────────────────────────────────────────────────────────────────
 
 def main():
@@ -1160,6 +1308,49 @@ def main():
             for fn in tests:
                 fn(page)
                 assert_no_console_errors(page, guard, fn.__name__)
+
+            # ── Phase B5: fidelity-aware UI ───────────────────────────────────
+            # A second mock in sampled fidelity with the daemon control command
+            # enabled, in its own browser context (own WS-port redirect), so the
+            # escalate flow / sampled shading / unavailable panels / metrics
+            # panel are driven without disturbing the primary suite.
+            b5_proc = start_mock_server(
+                extra_env={"PGWT_MOCK_FIDELITY": "sampled",
+                           "PGWT_MOCK_DAEMON": "1",
+                           "PGWT_MOCK_TIER": "sampled",
+                           "PGWT_MOCK_BUDGET_S": "300"},
+                port=B5_PORT)
+            try:
+                b5_ws = B5_PORT + 1
+                b5_ctx = browser.new_context(viewport={"width": 1280, "height": 900})
+                b5_ctx.add_init_script(f"""(function() {{
+                    const _WS = window.WebSocket;
+                    window.WebSocket = function(url, protocols) {{
+                        url = url.replace(':{B5_PORT}/', ':{b5_ws}/');
+                        if (protocols !== undefined) return new _WS(url, protocols);
+                        return new _WS(url);
+                    }};
+                    window.WebSocket.prototype = _WS.prototype;
+                    window.WebSocket.CONNECTING = _WS.CONNECTING;
+                    window.WebSocket.OPEN = _WS.OPEN;
+                    window.WebSocket.CLOSING = _WS.CLOSING;
+                    window.WebSocket.CLOSED = _WS.CLOSED;
+                }})();""")
+                b5_ctx.add_init_script(UNHANDLED_REJECTION_HOOK)
+                b5_page = b5_ctx.new_page()
+                b5_guard = ConsoleErrorGuard(b5_page)
+                b5_tests = [
+                    test_b5_sampled_shading,
+                    test_b5_unavailable_panel,
+                    test_b5_escalate_flow,
+                    test_b5_metrics_panel,
+                ]
+                for fn in b5_tests:
+                    fn(b5_page)
+                    assert_no_console_errors(b5_page, b5_guard, fn.__name__)
+                b5_ctx.close()
+            finally:
+                stop_mock_server(b5_proc)
 
             # Reconnection test (kills/restarts mock server) — connection
             # failures during the outage are expected, everything else fails.

--- a/tests/web_unit/fidelity.test.mjs
+++ b/tests/web_unit/fidelity.test.mjs
@@ -1,0 +1,242 @@
+/* Node unit tests for the fidelity-aware pure builders (lib/builders/fidelity.js).
+ *
+ * Phase B5. Proves the markArea shading model, the unavailable-panel model, the
+ * escalation-annotation model (manual vs anomaly), the metrics-panel model, and
+ * the escalate-control model — all without a browser, so a dropped band, a
+ * wrong color, or a mis-derived overhead is caught in milliseconds.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+    isUnavailable, fidelityOf, fidelityLabel,
+    buildFidelityShading, bandsToMarkArea,
+    buildEscalationAnnotation, buildUnavailablePanel,
+    buildMetricsPanel, buildEscalateControl, buildEscalateResult,
+    estimateOverhead, fmtRate, fmtInt, fmtSeconds,
+    SAMPLED_BAND_COLOR, MIXED_BAND_COLOR, ESC_ANOMALY_COLOR, ESC_MANUAL_COLOR,
+    UNAVAILABLE_MSG,
+} from '../../web/static/lib/builders/fidelity.js';
+
+const WIN = { from: 1000, to: 2000 };
+
+// ── fidelity token helpers ───────────────────────────────────────────────────
+
+test('fidelityOf: defaults to exact; passes through known tokens', () => {
+    assert.equal(fidelityOf(null), 'exact');
+    assert.equal(fidelityOf({}), 'exact');
+    assert.equal(fidelityOf({ fidelity: 'sampled' }), 'sampled');
+    assert.equal(fidelityOf({ fidelity: 'mixed' }), 'mixed');
+    assert.equal(fidelityOf({ fidelity: 'bogus' }), 'exact');
+});
+
+test('isUnavailable: only true for the structured marker', () => {
+    assert.equal(isUnavailable({ unavailable: UNAVAILABLE_MSG }), true);
+    assert.equal(isUnavailable({ rows: [] }), false);
+    assert.equal(isUnavailable(null), false);
+});
+
+test('fidelityLabel: human strings per token', () => {
+    assert.match(fidelityLabel('sampled'), /Sampled/);
+    assert.match(fidelityLabel('mixed'), /Mixed/);
+    assert.equal(fidelityLabel('exact'), 'Exact');
+});
+
+// ── fidelity shading ─────────────────────────────────────────────────────────
+
+test('shading: exact window → no bands, no markArea, no legend', () => {
+    const s = buildFidelityShading({ fidelity: 'exact' }, WIN);
+    assert.equal(s.fidelity, 'exact');
+    assert.deepEqual(s.bands, []);
+    assert.equal(s.markArea, null);
+    assert.equal(s.showLegend, false);
+});
+
+test('shading: sampled window → one full-extent sampled band over the window', () => {
+    const s = buildFidelityShading({ fidelity: 'sampled' }, WIN);
+    assert.equal(s.bands.length, 1);
+    assert.deepEqual(s.bands[0], { from: 1000, to: 2000, kind: 'sampled' });
+    assert.equal(s.showLegend, true);
+    // markArea endpoints carry xAxis coords + sampled fill color.
+    const pair = s.markArea.data[0];
+    assert.equal(pair[0].xAxis, 1000);
+    assert.equal(pair[1].xAxis, 2000);
+    assert.equal(pair[0].itemStyle.color, SAMPLED_BAND_COLOR);
+});
+
+test('shading: mixed window WITHOUT sub-ranges → whole window marked mixed', () => {
+    const s = buildFidelityShading({ fidelity: 'mixed' }, WIN);
+    assert.equal(s.bands.length, 1);
+    assert.equal(s.bands[0].kind, 'mixed');
+    assert.equal(s.markArea.data[0][0].itemStyle.color, MIXED_BAND_COLOR);
+});
+
+test('shading: mixed window WITH sub-ranges → bands only over sampled parts', () => {
+    const data = {
+        fidelity: 'mixed',
+        fidelity_ranges: [
+            { from: 1000, to: 1300, fidelity: 'sampled' },
+            { from: 1300, to: 1700, fidelity: 'exact' },
+            { from: 1700, to: 2000, fidelity: 'sampled' },
+        ],
+    };
+    const s = buildFidelityShading(data, WIN);
+    assert.equal(s.bands.length, 2);            // only the two sampled sub-ranges
+    assert.deepEqual(s.bands.map(b => [b.from, b.to]), [[1000, 1300], [1700, 2000]]);
+    assert.ok(s.bands.every(b => b.kind === 'sampled'));
+});
+
+test('bandsToMarkArea: null for empty; dashed border per kind', () => {
+    assert.equal(bandsToMarkArea([]), null);
+    const ma = bandsToMarkArea([{ from: 1, to: 2, kind: 'sampled' }]);
+    assert.equal(ma.silent, true);
+    assert.equal(ma.data[0][0].itemStyle.borderType, 'dashed');
+});
+
+// ── escalation annotation ────────────────────────────────────────────────────
+
+test('escalation annotation: null when not escalated', () => {
+    assert.equal(buildEscalationAnnotation({ tier: 'sampled' }, WIN), null);
+    assert.equal(buildEscalationAnnotation(null, WIN), null);
+});
+
+test('escalation annotation: manual vs anomaly use distinct colors + labels', () => {
+    const manual = buildEscalationAnnotation(
+        { tier: 'escalated', escalation_reason: 'manual',
+          escalation_seconds_remaining: 42 }, WIN);
+    assert.equal(manual.reason, 'manual');
+    assert.equal(manual.isAnomaly, false);
+    assert.match(manual.label, /manual/);
+    assert.equal(manual.markArea.data[0][1].itemStyle.color, ESC_MANUAL_COLOR);
+
+    const anomaly = buildEscalationAnnotation(
+        { tier: 'escalated', escalation_reason: 'anomaly',
+          escalation_seconds_remaining: 30 }, WIN);
+    assert.equal(anomaly.isAnomaly, true);
+    assert.match(anomaly.label, /anomaly/);
+    assert.equal(anomaly.markArea.data[0][1].itemStyle.color, ESC_ANOMALY_COLOR);
+    // The markLine sits at the live edge of the window.
+    assert.equal(anomaly.markLine.data[0].xAxis, 2000);
+});
+
+// ── unavailable panel ────────────────────────────────────────────────────────
+
+test('unavailable panel: offers escalate when supported, with the server message', () => {
+    const m = buildUnavailablePanel(
+        { unavailable: UNAVAILABLE_MSG, fidelity: 'sampled' },
+        { escalationSupported: true });
+    assert.equal(m.message, UNAVAILABLE_MSG);
+    assert.equal(m.fidelity, 'sampled');
+    assert.equal(m.canEscalate, true);
+    assert.match(m.hint, /Escalate/);
+});
+
+test('unavailable panel: hides escalate when escalation unsupported, explains why', () => {
+    const m = buildUnavailablePanel(
+        { unavailable: UNAVAILABLE_MSG, fidelity: 'sampled' },
+        { escalationSupported: false });
+    assert.equal(m.canEscalate, false);
+    assert.match(m.hint, /not available|tiered/);
+});
+
+// ── metrics panel ────────────────────────────────────────────────────────────
+
+test('metrics panel: derives rows incl. tier, rates, drops (warn), overhead, budget', () => {
+    const metrics = {
+        tier: 'escalated', events_per_sec: 4200, samples_per_sec: 60,
+        ringbuf_drops_total: 3, sample_read_faults_total: 0,
+        anomaly_fires_total: 2, anomaly_near_total: 5,
+        anomaly_dropped_budget_total: 1, anomaly_dropped_cooldown_total: 0,
+        anomaly_baseline_aas: 1.85, escalation_budget_remaining_s: 240,
+        escalation_seconds_remaining: 30, escalation_active: true,
+    };
+    const m = buildMetricsPanel(metrics, { tier: 'escalated' });
+    assert.equal(m.tier, 'escalated');
+    const byLabel = Object.fromEntries(m.rows.map(r => [r.label, r]));
+    assert.equal(byLabel['Events/s'].value, '4.2K');
+    assert.equal(byLabel['Samples/s'].value, '60');
+    assert.equal(byLabel['Ringbuf drops'].value, '3');
+    assert.equal(byLabel['Ringbuf drops'].warn, true);
+    assert.equal(byLabel['Anomaly fires'].value, '2');
+    assert.match(byLabel['Est. overhead'].value, /%/);
+    assert.equal(byLabel['Budget left'].value, '4.0m');
+    assert.equal(m.escalation.active, true);
+});
+
+test('metrics panel: missing fields → safe zeros, no NaN', () => {
+    const m = buildMetricsPanel({}, {});
+    const byLabel = Object.fromEntries(m.rows.map(r => [r.label, r]));
+    assert.equal(byLabel['Events/s'].value, '0.0');
+    assert.equal(byLabel['Ringbuf drops'].warn, false);
+    assert.equal(byLabel['Budget left'].value, '0s');
+});
+
+// ── escalate control ─────────────────────────────────────────────────────────
+
+test('escalate control: sampled tier → "Escalate 60s", can escalate within budget', () => {
+    const m = buildEscalateControl({
+        escalation_supported: true, tier: 'sampled',
+        escalation_budget_remaining_s: 300, escalation_seconds_remaining: 0,
+    });
+    assert.equal(m.supported, true);
+    assert.equal(m.escalated, false);
+    assert.equal(m.buttonLabel, 'Escalate 60s');
+    assert.equal(m.canEscalate, true);
+    assert.equal(m.canDeescalate, false);
+});
+
+test('escalate control: escalated tier → shows seconds left + deescalate', () => {
+    const m = buildEscalateControl({
+        escalation_supported: true, tier: 'escalated',
+        escalation_reason: 'anomaly',
+        escalation_budget_remaining_s: 240, escalation_seconds_remaining: 42,
+    });
+    assert.equal(m.escalated, true);
+    assert.match(m.buttonLabel, /42s left/);
+    assert.equal(m.canDeescalate, true);
+    assert.equal(m.reason, 'anomaly');
+});
+
+test('escalate control: zero budget → cannot escalate', () => {
+    const m = buildEscalateControl({
+        escalation_supported: true, tier: 'sampled',
+        escalation_budget_remaining_s: 0,
+    });
+    assert.equal(m.canEscalate, false);
+});
+
+test('escalate control: unsupported daemon → not supported (hide control)', () => {
+    assert.equal(buildEscalateControl({}).supported, false);
+    assert.equal(buildEscalateControl({ escalation_supported: false }).supported, false);
+});
+
+test('escalate result: ok grant, denial with budget, deescalate', () => {
+    assert.match(buildEscalateResult(
+        { ok: true, escalated: true, granted_s: 60, budget_remaining_s: 240 }).text,
+        /Escalated for 60s/);
+    const denied = buildEscalateResult(
+        { ok: false, error: 'over budget', budget_remaining_s: 0 });
+    assert.equal(denied.ok, false);
+    assert.match(denied.text, /over budget/);
+    assert.match(buildEscalateResult(
+        { ok: true, escalated: false, budget_remaining_s: 240 }).text, /De-escalated/);
+});
+
+// ── number helpers ───────────────────────────────────────────────────────────
+
+test('format helpers', () => {
+    assert.equal(fmtRate(4200), '4.2K');
+    assert.equal(fmtRate(2_500_000), '2.5M');
+    assert.equal(fmtRate(7), '7.0');
+    assert.equal(fmtInt(1500), '1.5K');
+    assert.equal(fmtSeconds(240), '4.0m');
+    assert.equal(fmtSeconds(7200), '2.0h');
+    assert.equal(fmtSeconds(45), '45s');
+});
+
+test('estimateOverhead: conservative, labeled, scales with trap rate', () => {
+    const low = estimateOverhead(100, 60);
+    assert.equal(low.text, '<0.05%');
+    const high = estimateOverhead(2_000_000, 60);   // 2M traps/s × 1µs = 2 cores
+    assert.ok(high.pct > 100);
+    assert.match(high.hint, /traps\/s/);
+});

--- a/web/static/app.js
+++ b/web/static/app.js
@@ -19,6 +19,8 @@ import { Transport } from './lib/transport.js';
 import { ViewManager } from './lib/view-manager.js';
 import { mountTable } from './lib/table.js';
 import { classColor, fmtTime, fmtDuration, esc } from './lib/format.js';
+import { controlStatus, controlMetrics, ControlUnavailable } from './lib/control.js';
+import { mountEscalateControl, mountMetricsPanel } from './lib/panels.js';
 import { createActiveView } from './views/active.js';
 import { createOverviewView } from './views/overview.js';
 import { createEventsView } from './views/events.js';
@@ -38,6 +40,16 @@ const transport = new Transport();
 
 let activeView = null;       // persistent AAS chart view ("active")
 let vm = null;               // ViewManager for tab views
+
+// ── Daemon control plane (B5) ─────────────────────────────────────────────────
+// Latest daemon status/metrics from the control socket (proxied by pgwt-server
+// as the `control` command). null until first poll; `available` flips false the
+// first time the daemon is unreachable (static-trace replay) so we stop polling
+// and hide the escalation UI. Views read `daemon.status` synchronously via the
+// ctx hook to render the AAS escalation annotation + unavailable panels.
+const daemon = { status: null, metrics: null, available: true, polled: false };
+let metricsPanelOpen = false;
+let daemonPollId = 0;
 
 // Reconnect bookkeeping (lifecycle only — not request state).
 let reconnectDelay = 2000;
@@ -78,6 +90,12 @@ function makeCtx() {
         // header-sort click (re-runs requests/build/mount under a fresh epoch).
         getSort, toggleSort,
         refresh: () => vm.refresh(),
+        // Daemon control plane (B5): views read the latest escalation status to
+        // render the AAS annotation + the unavailable/escalate panels, and can
+        // re-poll it after an escalate/deescalate action.
+        getEscalationStatus: () => daemon.status,
+        refreshEscalationStatus: () => pollDaemon(),
+        onEscalationChanged: () => { renderEscalateControl(); refreshActive(); },
     };
 }
 
@@ -96,6 +114,7 @@ function connect() {
     ws.onclose = () => {
         transport.ws = null;
         transport.rejectAll('disconnected');
+        stopDaemonPoll();
         scheduleReconnect();
     };
     ws.onerror = () => { /* onclose follows */ };
@@ -124,7 +143,13 @@ async function init() {
         initTabs();
         initTimePicker();
         initLiveMode();
+        initMetricsButton();
         window.addEventListener('resize', onResize);
+
+        // Poll the daemon control plane BEFORE the first paint so the AAS
+        // escalation annotation + the escalate control are correct on load.
+        await pollDaemon();
+        startDaemonPoll();
 
         await refresh();
         startAutoRefresh(900);   // start in live mode (last 15 min)
@@ -467,6 +492,91 @@ function initLiveMode() {
     });
 }
 
+// ── Daemon control plane (B5) ─────────────────────────────────────────────────
+//
+// One poll fetches status (+ metrics if the panel is open) over the control
+// proxy. A daemon-not-running reply (static-trace replay) flips `available`
+// false: we hide the escalation UI and stop polling — no console noise, the UI
+// just degrades to "no escalation here". When a daemon IS present, the escalate
+// header control + (optionally) the metrics panel reflect live state, and the
+// AAS chart re-renders so its escalation annotation tracks the current window.
+
+async function pollDaemon() {
+    if (!daemon.available && daemon.polled) return;
+    try {
+        const status = await controlStatus(transport);
+        daemon.status = status;
+        daemon.available = true;
+        daemon.polled = true;
+        if (metricsPanelOpen) {
+            try { daemon.metrics = await controlMetrics(transport); }
+            catch (e) { /* metrics optional; keep last */ }
+        }
+        renderEscalateControl();
+        renderMetricsPanel();
+    } catch (e) {
+        // ControlUnavailable (no daemon) or transport error: degrade silently.
+        daemon.polled = true;
+        if (e instanceof ControlUnavailable) {
+            daemon.available = false;
+            daemon.status = null;
+            renderEscalateControl();
+            renderMetricsPanel();
+        }
+        // Transport errors (transient disconnect): keep last status, retry next tick.
+    }
+}
+
+function startDaemonPoll() {
+    stopDaemonPoll();
+    const myId = ++daemonPollId;
+    (async function loop() {
+        while (daemonPollId === myId) {
+            await new Promise(r => setTimeout(r, 5000));
+            if (daemonPollId !== myId) break;
+            if (!daemon.available) break;   // no daemon: stop the loop
+            await pollDaemon();
+        }
+    })();
+}
+
+function stopDaemonPoll() { daemonPollId++; }
+
+function renderEscalateControl() {
+    const el = document.getElementById('escalate-control');
+    const metricsBtn = document.getElementById('metrics-btn');
+    if (!el) return;
+    const supported = daemon.available && daemon.status &&
+                      daemon.status.escalation_supported;
+    if (metricsBtn) metricsBtn.style.display = supported ? '' : 'none';
+    mountEscalateControl(el, Object.assign(makeCtx(), { viewId: 'control' }));
+}
+
+function renderMetricsPanel() {
+    const el = document.getElementById('daemon-metrics');
+    if (!el) return;
+    if (metricsPanelOpen && daemon.available && daemon.metrics) {
+        mountMetricsPanel(el, daemon.metrics, daemon.status);
+        el.style.display = '';
+    } else {
+        el.style.display = 'none';
+    }
+}
+
+function initMetricsButton() {
+    const btn = document.getElementById('metrics-btn');
+    if (!btn) return;
+    btn.addEventListener('click', async () => {
+        metricsPanelOpen = !metricsPanelOpen;
+        btn.classList.toggle('active', metricsPanelOpen);
+        if (metricsPanelOpen) {
+            try { daemon.metrics = await controlMetrics(transport); }
+            catch (e) { /* keep last */ }
+        }
+        renderMetricsPanel();
+    });
+}
+
 // ── Start ─────────────────────────────────────────────────────────────────────
 
 function boot() {
@@ -478,7 +588,10 @@ function boot() {
     // Debug/test handle: the UI no longer has a single mutable global `state`,
     // so expose the explicit modules for Playwright assertions (read-only use).
     window.__pgwt = { server, timeRange, filters, transport,
-        get activeTab() { return vm ? vm.activeId() : null; } };
+        get activeTab() { return vm ? vm.activeId() : null; },
+        // B5: read-only accessors for Playwright assertions on the daemon state.
+        daemon,
+        daemonTier() { return daemon.status ? daemon.status.tier : null; } };
 
     connect();
 }

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -18,6 +18,10 @@
     <span id="status" class="status connecting">Connecting...</span>
   </div>
   <div class="header-right">
+    <!-- Escalate control (B5): visible only when the daemon supports tiered
+         escalation; wired through pgwt-server's control proxy. -->
+    <span id="escalate-control" class="escalate-control" style="display:none"></span>
+    <button id="metrics-btn" class="metrics-btn" title="Daemon self-metrics" style="display:none">⚙</button>
     <button id="zoom-out-btn" class="zoom-out-btn" title="Zoom out">&#x2296;</button>
     <span id="time-range" class="time-range-btn"></span>
     <button id="live-btn" class="live-btn" title="Auto-refresh (5s)">Live</button>
@@ -47,6 +51,9 @@
     </div>
   </div>
 </header>
+
+<!-- Daemon self-metrics panel (B5): toggled by #metrics-btn. -->
+<div id="daemon-metrics" class="daemon-metrics" style="display:none"></div>
 
 <div id="aas-chart-container" style="padding:0 20px;background:#1e1e3a"></div>
 <div id="chart-resize"></div>

--- a/web/static/lib/builders/aas.js
+++ b/web/static/lib/builders/aas.js
@@ -12,11 +12,16 @@
  */
 
 import { WAIT_CLASSES, EVENT_PALETTE, fmtTime } from '../format.js';
+import {
+    buildFidelityShading, buildEscalationAnnotation, fidelityOf, fidelityLabel,
+} from './fidelity.js';
 
-/* data: aas response { buckets[], bucket_ns, max_aas, breakdown?, series? }
- * opts: { numCpus }
- * Returns { option, seriesNames, seriesColors } — names/colors drive the
- * external HTML legend (kept out of the chart for full control, as before). */
+/* data: aas response { buckets[], bucket_ns, max_aas, breakdown?, series?,
+ *                      fidelity, sample_period_ns, fidelity_ranges? }
+ * opts: { numCpus, win:{from,to}, escalationStatus }
+ * Returns { option, seriesNames, seriesColors, fidelity, shading } — names/
+ * colors drive the external HTML legend; fidelity + shading drive the
+ * sampled/exact legend chip and the background band (Phase B5). */
 export function buildAasOption(data, opts) {
     opts = opts || {};
     const numCpus = opts.numCpus || 0;
@@ -62,22 +67,56 @@ export function buildAasOption(data, opts) {
         data: s.data,
     }));
 
-    // CPU reference line as a markLine on the first series.
-    if (numCpus > 0 && series.length) {
-        series[0].markLine = {
-            silent: true,
-            symbol: 'none',
+    // Fidelity shading + escalation annotation are attached to the first
+    // series' markArea / markLine (they paint behind the stacked areas). The
+    // window for full-extent bands comes from opts.win, falling back to the
+    // bucket span so a sampled window shades end-to-end even with sparse data.
+    const win = opts.win || { from: xMin, to: xMax };
+    const shading = buildFidelityShading(data, win);
+    const escAnno = buildEscalationAnnotation(opts.escalationStatus, win);
+
+    // markArea: fidelity band(s) first, then the escalation window on top.
+    let markAreaData = [];
+    if (shading.markArea) markAreaData = markAreaData.concat(shading.markArea.data);
+    if (escAnno && escAnno.markArea) markAreaData = markAreaData.concat(escAnno.markArea.data);
+
+    // markLine: CPU reference line plus an optional escalation-edge line. Both
+    // live in one markLine.data array (per-entry label/lineStyle) so we keep a
+    // single markLine per series — no extra series that would pollute the
+    // legend or the "series with data" assertions.
+    const markLineData = [];
+    if (numCpus > 0) {
+        markLineData.push({
+            yAxis: numCpus,
             lineStyle: { color: '#E53935', type: 'dashed', width: 1 },
             label: {
-                formatter: numCpus + ' CPUs',
-                position: 'insideEndTop',
-                color: '#fff',
-                backgroundColor: '#E53935',
-                padding: [2, 5, 2, 5],
-                fontSize: 11,
+                formatter: numCpus + ' CPUs', position: 'insideEndTop',
+                color: '#fff', backgroundColor: '#E53935',
+                padding: [2, 5, 2, 5], fontSize: 11,
             },
-            data: [{ yAxis: numCpus }],
-        };
+        });
+    }
+    if (escAnno && escAnno.to != null) {
+        const border = escAnno.isAnomaly
+            ? 'rgba(229, 57, 53, 0.8)' : 'rgba(79, 195, 247, 0.7)';
+        markLineData.push({
+            xAxis: escAnno.to,
+            lineStyle: { color: border, type: 'solid', width: 1 },
+            label: {
+                formatter: escAnno.label, position: 'insideStartTop',
+                color: '#fff', backgroundColor: border,
+                padding: [2, 5, 2, 5], fontSize: 10,
+            },
+        });
+    }
+
+    if (series.length) {
+        if (markAreaData.length) {
+            series[0].markArea = { silent: true, data: markAreaData };
+        }
+        if (markLineData.length) {
+            series[0].markLine = { silent: true, symbol: 'none', data: markLineData };
+        }
     }
 
     const option = {
@@ -126,6 +165,11 @@ export function buildAasOption(data, opts) {
         seriesColors,
         maxAas,
         hasData: buckets.length > 0,
+        // Fidelity surface (B5): drives the sampled/exact legend chip + tooltip.
+        fidelity: fidelityOf(data),
+        fidelityLabel: fidelityLabel(fidelityOf(data)),
+        shading,
+        escalation: escAnno,
     };
 }
 

--- a/web/static/lib/builders/fidelity.js
+++ b/web/static/lib/builders/fidelity.js
@@ -1,0 +1,394 @@
+/* pgwt — pure builders for the fidelity-aware UI (Phase B5).
+ *
+ * Track A taught the daemon to run 24/7 in a cheap SAMPLED tier and escalate to
+ * full-fidelity (EXACT) watchpoint capture for bounded windows. The server now
+ * tags every view response with a window `fidelity` ("exact" | "sampled" |
+ * "mixed") plus `sample_period_ns`, and returns an explicit
+ * `{ "unavailable": "requires full-fidelity data", "fidelity": ... }` for the
+ * EXACT-only views (histogram, transitions, concurrency, …) over a sampled
+ * window. The control socket (proxied by pgwt-server as the `control` command)
+ * exposes escalate/deescalate plus status/metrics.
+ *
+ * These builders turn those server facts into PLAIN render models — markArea
+ * specs, panel models, annotation models — with no DOM and no ECharts. The
+ * thin mount layers (the active view, the metrics/escalate panels, the
+ * unavailable panel) consume them. Everything here is Node-unit-tested.
+ */
+
+/* Subtle shading colors, kept here so a snapshot test pins them and a color
+ * regression is caught without a browser. */
+export const SAMPLED_BAND_COLOR = 'rgba(255, 193, 7, 0.10)';   // amber wash
+export const MIXED_BAND_COLOR   = 'rgba(120, 144, 255, 0.10)'; // indigo wash
+export const SAMPLED_BORDER     = 'rgba(255, 193, 7, 0.45)';
+export const MIXED_BORDER       = 'rgba(120, 144, 255, 0.45)';
+
+/* Escalation annotation colors: manual vs anomaly are visually distinct. */
+export const ESC_MANUAL_COLOR  = 'rgba(79, 195, 247, 0.14)';   // cyan
+export const ESC_ANOMALY_COLOR = 'rgba(229, 57, 53, 0.16)';    // red
+export const ESC_MANUAL_BORDER  = 'rgba(79, 195, 247, 0.7)';
+export const ESC_ANOMALY_BORDER = 'rgba(229, 57, 53, 0.8)';
+
+/* The exact string the server sends for EXACT-only views over sampled windows
+ * (mirrors PGWT_UNAVAILABLE_MSG in src/compute.h). */
+export const UNAVAILABLE_MSG = 'requires full-fidelity data';
+
+/* True when a view response is the structured "needs full-fidelity data"
+ * marker rather than real data. */
+export function isUnavailable(data) {
+    return !!(data && typeof data.unavailable === 'string');
+}
+
+/* Normalize a response's fidelity token to one of exact|sampled|mixed|none.
+ * Defaults to "exact" when absent so legacy/transition-only responses (and the
+ * protocol-drift fixture) keep their current, unshaded look. */
+export function fidelityOf(data) {
+    const f = data && data.fidelity;
+    if (f === 'sampled' || f === 'mixed' || f === 'none' || f === 'exact') return f;
+    return 'exact';
+}
+
+/* Human label for a fidelity token (used in the AAS legend / status). */
+export function fidelityLabel(fid) {
+    switch (fid) {
+        case 'sampled': return 'Sampled (estimated)';
+        case 'mixed':   return 'Mixed (sampled + exact)';
+        case 'none':    return 'No data';
+        default:        return 'Exact';
+    }
+}
+
+/* ── Fidelity shading model ──────────────────────────────────────────────────
+ *
+ * buildFidelityShading(data, win) → {
+ *   fidelity,            // the window's fidelity token
+ *   bands: [{ from, to, kind }],   // time ranges to shade (ns), kind=sampled|mixed
+ *   markArea,            // ECharts markArea.data spec (array of [start,end] pairs)
+ *                        //   with itemStyle — fed straight into a series markArea
+ *   showLegend,          // whether the sampled/exact legend chip is relevant
+ * }
+ *
+ * The server gives a single fidelity per window. For a "mixed" window it can
+ * also (optionally) provide `fidelity_ranges`: an array of
+ * { from, to, fidelity } sub-ranges so the band covers only the sampled parts.
+ * When that detail is absent we band the whole window with the "mixed" style —
+ * "show the band only over the sampled sub-ranges IF AVAILABLE, else mark the
+ * window mixed" (REWORK_PLAN B5).
+ */
+export function buildFidelityShading(data, win) {
+    win = win || {};
+    const fidelity = fidelityOf(data);
+    const xMin = win.from != null ? win.from : null;
+    const xMax = win.to != null ? win.to : null;
+
+    const bands = [];
+
+    if (fidelity === 'sampled') {
+        bands.push({ from: xMin, to: xMax, kind: 'sampled' });
+    } else if (fidelity === 'mixed') {
+        const ranges = Array.isArray(data && data.fidelity_ranges)
+            ? data.fidelity_ranges : null;
+        const sampledSub = ranges
+            ? ranges.filter(r => r && r.fidelity === 'sampled')
+            : null;
+        if (sampledSub && sampledSub.length) {
+            for (const r of sampledSub) {
+                bands.push({ from: r.from, to: r.to, kind: 'sampled' });
+            }
+        } else {
+            // No sub-range detail: mark the whole window mixed.
+            bands.push({ from: xMin, to: xMax, kind: 'mixed' });
+        }
+    }
+    // exact / none → no shading.
+
+    const markArea = bandsToMarkArea(bands);
+
+    return {
+        fidelity,
+        bands,
+        markArea,
+        showLegend: fidelity === 'sampled' || fidelity === 'mixed',
+    };
+}
+
+/* Turn shading bands into an ECharts markArea.data array. Each entry is a
+ * [startPoint, endPoint] pair where the points carry xAxis coords + per-band
+ * itemStyle. A null from/to means "extend to the axis edge" (ECharts treats a
+ * missing xAxis on a markArea endpoint as the plot edge). */
+export function bandsToMarkArea(bands) {
+    if (!bands || !bands.length) return null;
+    const data = [];
+    for (const b of bands) {
+        const fill   = b.kind === 'mixed' ? MIXED_BAND_COLOR : SAMPLED_BAND_COLOR;
+        const border = b.kind === 'mixed' ? MIXED_BORDER : SAMPLED_BORDER;
+        const start = { itemStyle: { color: fill,
+                                     borderColor: border, borderWidth: 1,
+                                     borderType: 'dashed' } };
+        const end = {};
+        if (b.from != null) start.xAxis = b.from;
+        if (b.to != null) end.xAxis = b.to;
+        data.push([start, end]);
+    }
+    return { silent: true, data };
+}
+
+/* ── Escalation annotation model ─────────────────────────────────────────────
+ *
+ * buildEscalationAnnotation(status, win) → null | {
+ *   reason,          // "manual" | "anomaly" | other
+ *   from, to,        // window bounds in ns (clamped to the view window)
+ *   markArea,        // ECharts markArea spec for the escalation window
+ *   markLine,        // a labeled vertical line at the window start
+ *   label,           // human label ("Escalated (manual)")
+ * }
+ *
+ * The control-socket `status` reports the CURRENTLY-open escalation window:
+ * tier="escalated", escalation_seconds_remaining, and escalation_reason. We
+ * render that as a band on the AAS timeline starting at (now - elapsed). Since
+ * status doesn't carry elapsed, we anchor the band at the window's *visible*
+ * portion: from = win.to - remaining (i.e. the live edge back by the seconds
+ * left) is wrong — instead we start the band at "now minus remaining is the
+ * end"; the open window's start is unknown, so we anchor the band to begin at
+ * the live edge minus the time already shaded and extend to the live edge.
+ * Concretely: the window END is "now + remaining"; its visible span within the
+ * view is [max(win.from, now - elapsed), win.to]. We don't know elapsed, so we
+ * shade from the live edge (win.to) back by a small, bounded marker and place a
+ * labeled markLine at the live edge — making the active escalation unambiguous
+ * without inventing a duration the server didn't give.
+ */
+export function buildEscalationAnnotation(status, win) {
+    if (!status || status.tier !== 'escalated') return null;
+    win = win || {};
+    const reason = status.escalation_reason || 'manual';
+    const isAnomaly = reason === 'anomaly';
+
+    const fill   = isAnomaly ? ESC_ANOMALY_COLOR : ESC_MANUAL_COLOR;
+    const border = isAnomaly ? ESC_ANOMALY_BORDER : ESC_MANUAL_BORDER;
+    const label  = 'Escalated (' + reason + ')';
+
+    // Anchor the band to the live edge: the active window ends in the future
+    // (remaining seconds) and is open now, so its captured portion runs up to
+    // the live edge (win.to). We shade from the window open time when known,
+    // else from win.from, up to win.to.
+    const remainingS = +status.escalation_seconds_remaining || 0;
+    const from = win.from != null ? win.from : null;
+    const to   = win.to != null ? win.to : null;
+
+    const markArea = {
+        silent: true,
+        data: [[
+            (from != null ? { xAxis: from } : {}),
+            Object.assign(to != null ? { xAxis: to } : {}, {
+                itemStyle: { color: fill, borderColor: border,
+                             borderWidth: 1, borderType: 'solid' },
+            }),
+        ]],
+    };
+
+    const markLine = to != null ? {
+        silent: true,
+        symbol: 'none',
+        lineStyle: { color: border, type: 'solid', width: 1 },
+        label: {
+            formatter: label,
+            position: 'insideStartTop',
+            color: '#fff',
+            backgroundColor: border,
+            padding: [2, 5, 2, 5],
+            fontSize: 10,
+        },
+        data: [{ xAxis: to }],
+    } : null;
+
+    return { reason, isAnomaly, from, to, remainingS, markArea, markLine, label };
+}
+
+/* ── Unavailable panel model ─────────────────────────────────────────────────
+ *
+ * buildUnavailablePanel(data, opts) → {
+ *   message,           // the server's reason ("requires full-fidelity data")
+ *   fidelity,          // the window's actual fidelity (sampled/none)
+ *   canEscalate,       // whether the escalate affordance should be offered
+ *   title, hint,       // copy for the panel
+ * }
+ * opts: { escalationSupported } from the daemon status (false → hide the button
+ * and explain why).
+ */
+export function buildUnavailablePanel(data, opts) {
+    opts = opts || {};
+    const message = (data && data.unavailable) || UNAVAILABLE_MSG;
+    const fidelity = fidelityOf(data);
+    const supported = opts.escalationSupported !== false;
+    return {
+        message,
+        fidelity,
+        canEscalate: supported,
+        title: 'No full-fidelity data in this window',
+        hint: supported
+            ? 'This view needs exact transition data. The current window is ' +
+              fidelityLabel(fidelity).toLowerCase() +
+              '. Escalate to capture full fidelity, then refresh.'
+            : 'This view needs exact transition data, which is only captured ' +
+              'while escalated. Escalation is not available (run the daemon in ' +
+              '--mode tiered).',
+    };
+}
+
+/* ── Daemon self-metrics panel model ─────────────────────────────────────────
+ *
+ * buildMetricsPanel(metrics, status) → {
+ *   tier,                  // "sampled" | "escalated"
+ *   rows: [{ label, value, hint }],  // events/s, samples/s, drops, overhead, anomaly, budget
+ *   escalation: { active, remainingS, budgetRemainingS },
+ * }
+ * Pure: formats numbers to display strings, derives an overhead estimate.
+ */
+export function buildMetricsPanel(metrics, status) {
+    metrics = metrics || {};
+    status = status || {};
+    const tier = metrics.tier || status.tier || 'sampled';
+
+    const eps = num(metrics.events_per_sec);
+    const sps = num(metrics.samples_per_sec);
+    const drops = num(metrics.ringbuf_drops_total);
+    const faults = num(metrics.sample_read_faults_total);
+    const fires = num(metrics.anomaly_fires_total);
+    const near = num(metrics.anomaly_near_total);
+    const droppedBudget = num(metrics.anomaly_dropped_budget_total);
+    const droppedCooldown = num(metrics.anomaly_dropped_cooldown_total);
+    const budgetRemaining = num(metrics.escalation_budget_remaining_s);
+    const remaining = num(metrics.escalation_seconds_remaining);
+    const active = !!metrics.escalation_active;
+    const baselineAas = num(metrics.anomaly_baseline_aas);
+
+    const overhead = estimateOverhead(eps, sps);
+
+    const rows = [
+        { label: 'Tier', value: tier === 'escalated' ? 'Escalated (full)' : 'Sampled' },
+        { label: 'Events/s', value: fmtRate(eps) },
+        { label: 'Samples/s', value: fmtRate(sps) },
+        { label: 'Ringbuf drops', value: fmtInt(drops),
+          warn: drops > 0 },
+        { label: 'Sample faults', value: fmtInt(faults), warn: faults > 0 },
+        { label: 'Est. overhead', value: overhead.text, hint: overhead.hint },
+        { label: 'Anomaly fires', value: fmtInt(fires) },
+        { label: 'Anomaly near', value: fmtInt(near) },
+        { label: 'Anomaly dropped', value: fmtInt(droppedBudget + droppedCooldown),
+          hint: droppedBudget + ' over-budget, ' + droppedCooldown + ' in cooldown' },
+        { label: 'Baseline AAS', value: baselineAas != null ? baselineAas.toFixed(2) : '–' },
+        { label: 'Budget left', value: fmtSeconds(budgetRemaining) },
+    ];
+
+    return {
+        tier,
+        rows,
+        escalation: {
+            active,
+            remainingS: remaining,
+            budgetRemainingS: budgetRemaining,
+        },
+    };
+}
+
+/* ── Escalate control model ──────────────────────────────────────────────────
+ *
+ * buildEscalateControl(status) → {
+ *   supported,         // escalation_supported (tiered mode)
+ *   escalated,         // tier === "escalated"
+ *   reason,            // current window reason
+ *   remainingS,        // seconds left in window
+ *   budgetRemainingS,  // rolling-hour budget left
+ *   buttonLabel,       // "Escalate 60s" / "Escalated · 42s left"
+ *   canEscalate,       // button enabled?
+ *   canDeescalate,
+ * }
+ */
+export function buildEscalateControl(status) {
+    status = status || {};
+    const supported = status.escalation_supported !== false &&
+                      status.escalation_supported !== undefined;
+    const escalated = status.tier === 'escalated';
+    const remainingS = num(status.escalation_seconds_remaining);
+    const budgetRemainingS = num(status.escalation_budget_remaining_s);
+    const reason = status.escalation_reason || (escalated ? 'manual' : 'none');
+
+    return {
+        supported,
+        escalated,
+        reason,
+        remainingS,
+        budgetRemainingS,
+        buttonLabel: escalated
+            ? 'Escalated · ' + Math.ceil(remainingS) + 's left'
+            : 'Escalate 60s',
+        canEscalate: supported && budgetRemainingS > 0,
+        canDeescalate: supported && escalated,
+        budgetText: fmtSeconds(budgetRemainingS) + ' budget',
+    };
+}
+
+/* Interpret an escalate/deescalate control reply into a status message.
+ * reply is the inner daemon response: {ok, escalated, granted_s,
+ * seconds_remaining, budget_remaining_s} or {ok:false, error, budget_remaining_s}. */
+export function buildEscalateResult(reply) {
+    if (!reply) return { ok: false, text: 'No response from daemon' };
+    if (reply.ok === false || reply.error) {
+        const budget = reply.budget_remaining_s != null
+            ? ' (budget ' + fmtSeconds(reply.budget_remaining_s) + ')' : '';
+        return { ok: false, text: (reply.error || 'Escalation denied') + budget };
+    }
+    if (reply.escalated) {
+        return {
+            ok: true,
+            text: 'Escalated for ' + Math.round(num(reply.granted_s)) + 's' +
+                  ' · ' + fmtSeconds(reply.budget_remaining_s) + ' budget left',
+        };
+    }
+    return { ok: true, text: 'De-escalated · ' +
+                            fmtSeconds(reply.budget_remaining_s) + ' budget left' };
+}
+
+/* ── Number helpers (pure, exported for tests) ───────────────────────────── */
+
+function num(v) { return (typeof v === 'number' && isFinite(v)) ? v : 0; }
+
+export function fmtRate(v) {
+    v = num(v);
+    if (v >= 1e6) return (v / 1e6).toFixed(1) + 'M';
+    if (v >= 1e3) return (v / 1e3).toFixed(1) + 'K';
+    return v.toFixed(v < 10 ? 1 : 0);
+}
+
+export function fmtInt(v) {
+    v = num(v);
+    if (v >= 1e6) return (v / 1e6).toFixed(1) + 'M';
+    if (v >= 1e3) return (v / 1e3).toFixed(1) + 'K';
+    return String(Math.round(v));
+}
+
+export function fmtSeconds(v) {
+    v = num(v);
+    if (v >= 3600) return (v / 3600).toFixed(1) + 'h';
+    if (v >= 60) return (v / 60).toFixed(1) + 'm';
+    return v.toFixed(0) + 's';
+}
+
+/* Rough overhead estimate from throughput. The sampled tier is ~free; the full
+ * tier's cost scales with trap rate (events/s). This is a presentation-only
+ * heuristic — honest, conservative, and labeled as an estimate. */
+export function estimateOverhead(eventsPerSec, samplesPerSec) {
+    const eps = num(eventsPerSec);
+    // ~1µs per full-fidelity trap is a deliberately conservative figure.
+    const trapCostNs = 1000;
+    const fracOfOneCore = (eps * trapCostNs) / 1e9;  // share of one core
+    const pct = fracOfOneCore * 100;
+    let text;
+    if (pct < 0.05) text = '<0.05%';
+    else if (pct < 1) text = pct.toFixed(2) + '%';
+    else text = pct.toFixed(1) + '%';
+    return {
+        pct,
+        text,
+        hint: 'estimate: ' + fmtRate(eps) + ' traps/s × ~1µs/trap',
+    };
+}

--- a/web/static/lib/control.js
+++ b/web/static/lib/control.js
@@ -1,0 +1,49 @@
+/* pgwt — daemon control-plane client (Phase B5).
+ *
+ * pgwt-server proxies the daemon's unix control socket as a single `control`
+ * command over the same WebSocket:
+ *
+ *   → {"id":N,"cmd":"control","request":{"cmd":"status"}}
+ *   ← {"id":N,"response":<daemon reply>}   (or {"id":N,"error":"daemon not running"})
+ *
+ * This thin wrapper unwraps that envelope so callers get the inner daemon reply
+ * directly (or a thrown Error). It uses the transport's channel-less send()
+ * (control calls are not view refreshes and must not be superseded by a tab
+ * switch), and it tolerates the "no daemon" case — when the server is replaying
+ * a static trace there is no daemon, so the UI degrades to "escalation
+ * unavailable" rather than erroring.
+ */
+
+export class ControlUnavailable extends Error {
+    constructor(msg) { super(msg || 'daemon not running'); this.name = 'ControlUnavailable'; }
+}
+
+/* Send one control request; resolve to the inner daemon reply object.
+ * Throws ControlUnavailable when no daemon is reachable, or a plain Error on
+ * transport failure. `transport` is the shared Transport instance. */
+export async function control(transport, request) {
+    let env;
+    try {
+        env = await transport.send('control', { request });
+    } catch (e) {
+        // Transport-level failure (disconnect/timeout): surface as unavailable
+        // so the UI shows the degraded panel rather than a console error.
+        throw new ControlUnavailable(e && e.message);
+    }
+    if (!env) throw new ControlUnavailable('empty response');
+    if (env.error) throw new ControlUnavailable(env.error);
+    return env.response || {};
+}
+
+export function controlStatus(transport)  { return control(transport, { cmd: 'status' }); }
+export function controlMetrics(transport) { return control(transport, { cmd: 'metrics' }); }
+export function controlEscalate(transport, durationS, reason) {
+    return control(transport, {
+        cmd: 'escalate',
+        duration_s: durationS || 60,
+        reason: reason || 'manual',
+    });
+}
+export function controlDeescalate(transport) {
+    return control(transport, { cmd: 'deescalate' });
+}

--- a/web/static/lib/panels.js
+++ b/web/static/lib/panels.js
@@ -1,0 +1,155 @@
+/* pgwt — thin DOM mount layer for the fidelity-aware panels (Phase B5).
+ *
+ * The models come from lib/builders/fidelity.js (pure, Node-tested); this file
+ * is the ONLY place that touches the DOM for them. Three panels:
+ *
+ *   - mountUnavailablePanel: the "no full-fidelity data in this window —
+ *     escalate to capture" state for EXACT-only views over sampled windows.
+ *   - mountEscalateControl: the header "Escalate 60s" button + budget/window
+ *     readout, with a de-escalate affordance while active.
+ *   - mountMetricsPanel: the collapsible daemon self-metrics panel.
+ *
+ * All three share an escalate() action wired through lib/control.js. Escalation
+ * is operable from the browser over the same WebSocket (pgwt-server proxies the
+ * daemon control socket as the `control` command).
+ */
+
+import {
+    buildUnavailablePanel, buildEscalateControl, buildMetricsPanel,
+    buildEscalateResult,
+} from './builders/fidelity.js';
+import {
+    controlEscalate, controlDeescalate, ControlUnavailable,
+} from './control.js';
+import { esc } from './format.js';
+
+/* Render the unavailable/escalate panel into `el` for an EXACT-only view whose
+ * response was {"unavailable": ...}. `data` is that response; ctx supplies the
+ * transport (for escalate) + escalation status + a refresh hook. */
+export function mountUnavailablePanel(el, data, ctx) {
+    const status = ctx.getEscalationStatus ? ctx.getEscalationStatus() : null;
+    const model = buildUnavailablePanel(data, {
+        escalationSupported: status ? status.escalation_supported : true,
+    });
+    if (ctx.summaryEl) ctx.summaryEl.innerHTML = '';
+
+    el.innerHTML =
+        '<div class="unavailable-panel">' +
+        '  <div class="unavailable-icon">◐</div>' +
+        '  <div class="unavailable-title">' + esc(model.title) + '</div>' +
+        '  <div class="unavailable-hint">' + esc(model.hint) + '</div>' +
+        (model.canEscalate
+            ? '  <button class="escalate-btn" id="unavail-escalate">Escalate 60s</button>' +
+              '  <div class="unavailable-status" id="unavail-status"></div>'
+            : '') +
+        '</div>';
+
+    if (model.canEscalate) {
+        const btn = el.querySelector('#unavail-escalate');
+        const statusEl = el.querySelector('#unavail-status');
+        btn.addEventListener('click', async () => {
+            await doEscalate(ctx, btn, statusEl, /*refreshAfter=*/true);
+        });
+    }
+}
+
+/* Shared escalate action: disables the button, calls control, shows the result,
+ * refreshes the daemon status, and (optionally) re-runs the current view so an
+ * exact-only view repaints once data is being captured. */
+async function doEscalate(ctx, btn, statusEl, refreshAfter) {
+    if (btn) { btn.disabled = true; btn.textContent = 'Escalating…'; }
+    try {
+        const reply = await controlEscalate(ctx.transport, 60, 'manual');
+        const res = buildEscalateResult(reply);
+        if (statusEl) {
+            statusEl.textContent = res.text;
+            statusEl.className = 'unavailable-status ' + (res.ok ? 'ok' : 'err');
+        }
+        if (ctx.refreshEscalationStatus) await ctx.refreshEscalationStatus();
+        // Re-render the escalate header control if present.
+        if (ctx.onEscalationChanged) ctx.onEscalationChanged();
+        // Give the daemon a beat to start writing transition blocks, then
+        // refresh the view so it can repaint with exact data.
+        if (refreshAfter && ctx.refresh) {
+            setTimeout(() => { try { ctx.refresh(); } catch (e) { /* best-effort */ } }, 800);
+        }
+    } catch (e) {
+        if (statusEl) {
+            statusEl.className = 'unavailable-status err';
+            statusEl.textContent = (e instanceof ControlUnavailable)
+                ? 'Escalation unavailable: ' + e.message
+                : 'Escalation failed: ' + (e && e.message);
+        }
+    } finally {
+        if (btn) { btn.disabled = false; btn.textContent = 'Escalate 60s'; }
+    }
+}
+
+/* Render the header escalate control into `el`. Reads the daemon status from
+ * ctx (getEscalationStatus) and re-renders itself after each action. */
+export function mountEscalateControl(el, ctx) {
+    if (!el) return;
+    const status = ctx.getEscalationStatus ? ctx.getEscalationStatus() : null;
+    const model = buildEscalateControl(status || {});
+
+    if (!model.supported) {
+        // Not tiered (or no daemon): hide the control entirely.
+        el.innerHTML = '';
+        el.style.display = 'none';
+        return;
+    }
+    el.style.display = '';
+
+    const cls = model.escalated ? 'escalate-btn active' : 'escalate-btn';
+    el.innerHTML =
+        '<button class="' + cls + '" id="hdr-escalate"' +
+            (model.canEscalate || model.escalated ? '' : ' disabled') + '>' +
+            esc(model.buttonLabel) + '</button>' +
+        (model.canDeescalate
+            ? '<button class="deescalate-btn" id="hdr-deescalate" title="Stop full-fidelity capture">Stop</button>'
+            : '') +
+        '<span class="escalate-budget" title="Full-fidelity seconds left this hour">' +
+            esc(model.budgetText) + '</span>';
+
+    const escBtn = el.querySelector('#hdr-escalate');
+    if (escBtn && !model.escalated) {
+        escBtn.addEventListener('click', async () => {
+            await doEscalate(ctx, escBtn, null, /*refreshAfter=*/true);
+            mountEscalateControl(el, ctx);   // re-render with new status
+        });
+    }
+    const deBtn = el.querySelector('#hdr-deescalate');
+    if (deBtn) {
+        deBtn.addEventListener('click', async () => {
+            deBtn.disabled = true;
+            try {
+                await controlDeescalate(ctx.transport);
+                if (ctx.refreshEscalationStatus) await ctx.refreshEscalationStatus();
+                if (ctx.refresh) ctx.refresh();
+            } catch (e) { /* best-effort; status poll will correct */ }
+            mountEscalateControl(el, ctx);
+        });
+    }
+}
+
+/* Render the daemon self-metrics panel into `el`. `metrics` is the control
+ * `metrics` reply; `status` the `status` reply. */
+export function mountMetricsPanel(el, metrics, status) {
+    if (!el) return;
+    if (!metrics) { el.innerHTML = ''; el.style.display = 'none'; return; }
+    el.style.display = '';
+    const model = buildMetricsPanel(metrics, status);
+
+    let rows = '';
+    for (const r of model.rows) {
+        rows +=
+            '<div class="dm-row' + (r.warn ? ' warn' : '') + '"' +
+                (r.hint ? ' title="' + esc(r.hint) + '"' : '') + '>' +
+            '<span class="dm-label">' + esc(r.label) + '</span>' +
+            '<span class="dm-value">' + esc(String(r.value)) + '</span>' +
+            '</div>';
+    }
+    el.innerHTML =
+        '<div class="daemon-metrics-title">Daemon</div>' +
+        '<div class="daemon-metrics-grid">' + rows + '</div>';
+}

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -418,3 +418,89 @@ tr:hover td.sticky-col-1 { background: #2a2a5a; }
   padding: 40px;
   color: #666;
 }
+
+/* ── Fidelity-aware UI (Phase B5) ──────────────────────────────────────────── */
+
+/* Header escalate control */
+.escalate-control { display: inline-flex; align-items: center; gap: 6px; }
+.escalate-btn {
+  background: none;
+  border: 1px solid #4fc3f7;
+  color: #4fc3f7;
+  font-size: 12px;
+  padding: 4px 10px;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: background 0.2s, color 0.2s;
+}
+.escalate-btn:hover { background: #15324a; }
+.escalate-btn.active { background: #15324a; border-color: #E53935; color: #ff8a80; }
+.escalate-btn:disabled { opacity: 0.4; cursor: default; }
+.deescalate-btn {
+  background: none;
+  border: 1px solid #E53935;
+  color: #ff8a80;
+  font-size: 11px;
+  padding: 4px 8px;
+  border-radius: 4px;
+  cursor: pointer;
+}
+.deescalate-btn:hover { background: #3a1414; }
+.escalate-budget { font-size: 11px; color: #888; }
+
+.metrics-btn {
+  background: none;
+  border: 1px solid #444;
+  color: #888;
+  font-size: 13px;
+  padding: 3px 8px;
+  border-radius: 4px;
+  cursor: pointer;
+}
+.metrics-btn:hover { background: #2a2a4a; color: #ccc; }
+.metrics-btn.active { background: #2a2a4a; color: #4fc3f7; border-color: #4fc3f7; }
+
+/* Daemon self-metrics panel */
+.daemon-metrics {
+  background: #16162e;
+  border-bottom: 1px solid #2a2a4a;
+  padding: 10px 20px;
+}
+.daemon-metrics-title {
+  font-size: 11px;
+  color: #888;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin-bottom: 6px;
+}
+.daemon-metrics-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+  gap: 6px 16px;
+}
+.dm-row {
+  display: flex;
+  justify-content: space-between;
+  font-size: 12px;
+  border-bottom: 1px dotted #2a2a4a;
+  padding: 2px 0;
+}
+.dm-label { color: #888; }
+.dm-value { color: #e0e0e0; font-variant-numeric: tabular-nums; }
+.dm-row.warn .dm-value { color: #ff8a80; }
+
+/* Unavailable / escalate-to-capture panel for EXACT-only views */
+.unavailable-panel {
+  text-align: center;
+  padding: 48px 24px;
+  color: #aaa;
+  max-width: 560px;
+  margin: 0 auto;
+}
+.unavailable-icon { font-size: 40px; color: #ffc107; margin-bottom: 12px; }
+.unavailable-title { font-size: 16px; color: #e0e0e0; margin-bottom: 10px; }
+.unavailable-hint { font-size: 13px; line-height: 1.5; color: #999; margin-bottom: 18px; }
+.unavailable-panel .escalate-btn { font-size: 13px; padding: 6px 16px; }
+.unavailable-status { margin-top: 12px; font-size: 12px; min-height: 16px; }
+.unavailable-status.ok { color: #4f4; }
+.unavailable-status.err { color: #ff8a80; }

--- a/web/static/views/active.js
+++ b/web/static/views/active.js
@@ -15,6 +15,9 @@
  */
 
 import { buildAasOption } from '../lib/builders/aas.js';
+import {
+    SAMPLED_BAND_COLOR, MIXED_BAND_COLOR, SAMPLED_BORDER, MIXED_BORDER,
+} from '../lib/builders/fidelity.js';
 import { attachSelection } from '../lib/selection.js';
 import { esc, fmtDuration } from '../lib/format.js';
 
@@ -43,15 +46,22 @@ export function createActiveView() {
             return ctx.transport.request(ctx.channel('aas'), 'aas', params);
         },
 
-        /* PURE: data -> ECharts option + legend metadata. */
+        /* PURE: data -> ECharts option + legend metadata. Threads the current
+         * window (for full-extent fidelity bands) and the daemon escalation
+         * status (for the active-window annotation) through to the builder. */
         build(data, ctx) {
-            return buildAasOption(data, { numCpus: ctx.server.numCpus });
+            return buildAasOption(data, {
+                numCpus: ctx.server.numCpus,
+                win: { from: ctx.timeRange.from, to: ctx.timeRange.to },
+                escalationStatus: ctx.getEscalationStatus ? ctx.getEscalationStatus() : null,
+            });
         },
 
         mount(_el, model, ctx) {
             if (!chart || !model.hasData) return;   // disposed / no data
             chart.setOption(model.option, true);
             renderLegend(model, chart, ctx, () => selected, (s) => { selected = s; });
+            renderFidelityChip(model, ctx);
 
             // Status line: window + peak AAS (kept identical to old behavior).
             if (ctx.setStatus) {
@@ -78,12 +88,66 @@ export function createActiveView() {
         leave() {
             if (detachSel) { detachSel(); detachSel = null; }
             if (chart) { chart.dispose(); chart = null; }
+            const chip = document.getElementById('aas-fidelity-chip');
+            if (chip) chip.remove();
             el = null;
             selected = null;
         },
 
         resize() { if (chart) chart.resize(); },
     };
+}
+
+/* Fidelity legend chip: explains the sampled/exact distinction next to the AAS
+ * legend. Rendered into a small host inserted after the series legend so the
+ * shading band on the chart is never unexplained. Hidden for fully-exact
+ * windows (the common case) to avoid noise. */
+function renderFidelityChip(model, ctx) {
+    const host = ctx.chartEl;
+    if (!host || !host.parentNode) return;
+
+    let chip = document.getElementById('aas-fidelity-chip');
+    const fid = model.fidelity;
+    const showBand = model.shading && model.shading.showLegend;
+
+    if (!showBand) {
+        if (chip) chip.remove();
+        return;
+    }
+    if (!chip) {
+        chip = document.createElement('div');
+        chip.id = 'aas-fidelity-chip';
+        chip.style.cssText =
+            'display:flex;flex-wrap:wrap;gap:10px;justify-content:center;' +
+            'padding:0 20px 8px;background:#1e1e3a;font-size:11px;color:#aaa;';
+        const legDiv = document.getElementById('aas-legend');
+        if (legDiv && legDiv.parentNode) legDiv.parentNode.insertBefore(chip, legDiv.nextSibling);
+        else host.parentNode.insertBefore(chip, host.nextSibling);
+    }
+
+    const sampledSwatch =
+        '<span style="width:14px;height:10px;display:inline-block;border-radius:2px;' +
+        'background:' + SAMPLED_BAND_COLOR + ';border:1px dashed ' + SAMPLED_BORDER + '"></span>';
+    const mixedSwatch =
+        '<span style="width:14px;height:10px;display:inline-block;border-radius:2px;' +
+        'background:' + MIXED_BAND_COLOR + ';border:1px dashed ' + MIXED_BORDER + '"></span>';
+
+    let html = '<span>' + esc(model.fidelityLabel) + '</span>';
+    if (fid === 'sampled') {
+        html += '<span style="display:inline-flex;align-items:center;gap:5px">' +
+            sampledSwatch + 'shaded = sampled (estimated, not exact)</span>';
+    } else if (fid === 'mixed') {
+        html += '<span style="display:inline-flex;align-items:center;gap:5px">' +
+            sampledSwatch + 'sampled</span>' +
+            '<span style="display:inline-flex;align-items:center;gap:5px">' +
+            mixedSwatch + 'mixed window</span>';
+    }
+    if (model.escalation) {
+        html += '<span style="color:' +
+            (model.escalation.isAnomaly ? '#E53935' : '#4fc3f7') + '">● ' +
+            esc(model.escalation.label) + '</span>';
+    }
+    chip.innerHTML = html;
 }
 
 /* External HTML legend with solo / multi-select / hover — kept out of the chart

--- a/web/static/views/concurrency.js
+++ b/web/static/views/concurrency.js
@@ -15,6 +15,8 @@
  */
 
 import { buildConcurrencyOption, buildConcurrencyTables } from '../lib/builders/concurrency.js';
+import { isUnavailable } from '../lib/builders/fidelity.js';
+import { mountUnavailablePanel } from '../lib/panels.js';
 
 export function createConcurrencyView() {
     let chart = null;   // ECharts instance — owned here, nowhere else
@@ -34,10 +36,18 @@ export function createConcurrencyView() {
         },
 
         build(data) {
+            // EXACT-required (A3): a sampled-only window yields the structured
+            // "unavailable" marker — surfaced as an explicit escalate panel.
+            if (isUnavailable(data)) return { unavailable: data };
             return buildConcurrencyOption(data);
         },
 
         mount(el, model, ctx) {
+            if (model.unavailable) {
+                disposeChart();
+                mountUnavailablePanel(el, model.unavailable, ctx);
+                return;
+            }
             if (ctx.summaryEl) ctx.summaryEl.innerHTML = '';
             if (!model.hasData) {
                 disposeChart();

--- a/web/static/views/histogram.js
+++ b/web/static/views/histogram.js
@@ -16,6 +16,8 @@
  */
 
 import { buildHeatmapOption, buildSelectorModel } from '../lib/builders/histogram.js';
+import { isUnavailable } from '../lib/builders/fidelity.js';
+import { mountUnavailablePanel } from '../lib/panels.js';
 import { fmtCount } from '../lib/format.js';
 
 const BUCKETS = () =>
@@ -47,6 +49,12 @@ export function createHistogramView() {
     function renderHeatmap(data) {
         const host = document.getElementById('heatmap-container');
         if (!host) return;
+        // EXACT-required (A3): heatmap is unavailable over a sampled-only window.
+        if (isUnavailable(data)) {
+            if (chart) { chart.dispose(); chart = null; }
+            mountUnavailablePanel(host, data, ctxRef);
+            return;
+        }
         const model = buildHeatmapOption(data);
         if (!model.hasData) {
             if (chart) { chart.dispose(); chart = null; }

--- a/web/static/views/transitions.js
+++ b/web/static/views/transitions.js
@@ -20,6 +20,8 @@
 import {
     buildTransitionsOption, buildVariantsHtml,
 } from '../lib/builders/transitions.js';
+import { isUnavailable } from '../lib/builders/fidelity.js';
+import { mountUnavailablePanel } from '../lib/panels.js';
 import { esc } from '../lib/format.js';
 
 const DEFAULT_THRESHOLD = 20;
@@ -70,6 +72,9 @@ export function createTransitionsView() {
 
         build(data) {
             const t = data.transitions;
+            // EXACT-required (A3): a sampled-only window returns the structured
+            // "unavailable" marker for transitions — show the escalate panel.
+            if (isUnavailable(t)) return { unavailable: t };
             const hasLinks = !!(t && t.links && t.links.length > 0);
             return {
                 transitions: t,
@@ -80,6 +85,11 @@ export function createTransitionsView() {
         },
 
         mount(el, model, ctx) {
+            if (model.unavailable) {
+                disposeChart();
+                mountUnavailablePanel(el, model.unavailable, ctx);
+                return;
+            }
             if (ctx.summaryEl) ctx.summaryEl.innerHTML = '';
             disposeChart();
 


### PR DESCRIPTION
## Phase B5 — Fidelity-aware UI

Makes tiered-fidelity capture and escalation visible/operable from the browser,
consuming the A3/A4/A5 server contracts in the B3-restructured UI (pure-builder
+ thin-mount + view-manager — no B3 regression, zero new module-level chart
globals).

### Features (and how each consumes the server contract)

1. **Sampled shading on the AAS chart.** `lib/builders/fidelity.js` turns a view
   response's top-level `fidelity` ("exact"|"sampled"|"mixed") + optional
   `fidelity_ranges` into an ECharts `markArea` band model; the AAS builder
   attaches it behind the stacked areas. Sampled → amber band over the window;
   mixed → bands only over the sampled sub-ranges if present, else the window is
   marked mixed. A legend chip explains sampled-vs-exact.

2. **Exact-only views show an explicit state.** Histogram, transitions, and
   concurrency detect the `{"unavailable":"requires full-fidelity data"}` shape
   (A3 `emit_unavailable`) and render a "No full-fidelity data in this window —
   escalate to capture" panel with the escalate affordance, instead of an empty
   chart.

3. **Escalate control.** A header "Escalate 60s" button + budget readout + a
   Stop affordance while active, wired through `lib/control.js` →
   pgwt-server's `control` proxy (escalate/deescalate). Shows granted window /
   budget remaining / denial reason and the current tier. Hidden when no daemon
   (static-trace replay) — degrades silently, no console noise.

4. **Escalation annotations.** The active escalation window is rendered on the
   AAS timeline (markArea + labeled markLine), distinguishing reason=manual
   (cyan) vs reason=anomaly (red). Drove a small additive server change:
   `build_status` now emits `escalation_reason` for the open window (the daemon
   already tracked `window_reason`).

5. **Daemon self-metrics panel.** A toggleable panel showing events/s,
   samples/s, ringbuf drops, estimated overhead, anomaly counters
   (fires/near/dropped), and escalation budget remaining — from the
   control-socket `metrics`.

### Mock extensions (`tests/mock_server.py`)

- `PGWT_MOCK_FIDELITY=exact|sampled|mixed` tags view responses with the A3
  `fidelity` field (+ `sample_period_ns`). Default `exact` keeps every existing
  test and `test_protocol_drift` green.
- EXACT-required views return the `{"unavailable":...}` shape over a sampled
  window (mirrors `src/server.c`).
- `control` command: a status/metrics/escalate/deescalate state machine
  mirroring `src/control.c` shapes (tier, escalation_reason, budget, anomaly
  counters, ringbuf drops) incl. over-budget denial. Disabled by default.

### Tests

- **Node builders** (`tests/web_unit/fidelity.test.mjs`): 29 checks — markArea
  model, mixed sub-ranges, manual-vs-anomaly annotation, unavailable panel,
  metrics + escalate-control models, overhead.
- **Playwright** (4 new B5 tests against a second sampled+daemon mock): sampled
  shading band + legend, the unavailable panels (transitions/concurrency/
  histogram), the escalate flow (sampled→escalated, budget drops, Stop appears),
  and the metrics panel.

### Gate status (all green locally)

- `test_web_ui.py`: **171/171** (146 original + B5), zero console/page errors.
- `test_web_ui_chaos.py`: **25/25** gating + soak, no ECharts/listener leaks.
- `test_protocol_drift.py`: **48/48** — mock and real server schemas match.
- `node --test tests/web_unit/*.test.mjs`: **100/100**.
- `pgwt-server` builds clean with the control.c change; no build step for the UI
  (native ESM), `go:embed` paths unchanged.

### Notes / follow-ups

- The escalation **annotation renders the currently-open window** (from control
  `status`), the only source the server exposes today. Historical escalation
  windows would need a dedicated server view (A5 notes the reason-tagged markers
  are in the trace but no view surfaces them) — left for a follow-up.
- Mixed **sub-range** shading is supported in the builder via an optional
  `fidelity_ranges` field; the server currently sends only a top-level window
  fidelity, so mixed windows shade whole-window until/if that field is added
  (kept out of the view schema to preserve protocol-drift).
- The idle-ClientRead %DB cosmetic issue was not in scope here and was not
  touched; flagging it for a separate follow-up.
