### PR TITLE
Rocky 8 / RHEL 8 build support

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -2,10 +2,12 @@
 
 ## Supported Platforms
 
-- **Linux kernel** >= 5.8 (BPF ring buffer, CO-RE)
+- **Linux kernel** >= 5.8, **or** RHEL 8 / Rocky 8 (kernel 4.18 with Red Hat's
+  BPF ring buffer + BTF backports)
 - **Architecture**: x86_64, aarch64
 - **PostgreSQL**: 17, 18 (full support); 14–16 (limited — see Troubleshooting)
-- **Tested on**: Ubuntu 22.04/24.04, Rocky Linux 9, Oracle Linux 9, RHEL 9
+- **Tested on**: Ubuntu 22.04/24.04, Rocky Linux 9, Oracle Linux 9, RHEL 9,
+  Rocky Linux 8.10 / RHEL 8
 
 ## Prerequisites
 
@@ -30,6 +32,28 @@ sudo dnf install -y elfutils-libelf-devel zlib-devel lz4-devel
 # For DWARF-based st_query_id offset detection (optional, for query_event view)
 sudo dnf install -y elfutils    # provides readelf
 ```
+
+#### Rocky Linux 8 / RHEL 8 / AlmaLinux 8
+
+RHEL 8 ships `libbpf` 0.5.0 and an old `bpftool`, which predate the USDT
+support pg_wait_tracer needs. The Makefile detects this automatically and, on
+EL8 only, builds a pinned `libbpf` + `bpftool` from source into `build/`
+(requires network access at build time). EL9 and Ubuntu are unaffected.
+
+```bash
+# powertools is EL8's equivalent of EL9's CRB repo
+sudo dnf install -y dnf-plugins-core
+sudo dnf config-manager --set-enabled powertools
+
+# Core build tools + BPF toolchain + ELF/compression libs.
+# (git is required: the Makefile clones pinned libbpf/bpftool on EL8.)
+sudo dnf install -y gcc clang llvm make tar git \
+    elfutils-libelf-devel zlib-devel lz4-devel bpftool libbpf-devel
+```
+
+PGDG packages a **non-PIE** postgres binary on EL8 (PIE on EL9); pg_wait_tracer
+handles both. The kernel must still expose BTF (`/sys/kernel/btf/vmlinux`) —
+present by default on Rocky 8.10 / RHEL 8.
 
 #### Ubuntu 22.04 / 24.04 / Debian 12
 

--- a/Makefile
+++ b/Makefile
@@ -14,13 +14,70 @@ TARGET     = pg_wait_tracer
 
 ARCH       := $(shell uname -m | sed 's/x86_64/x86/' | sed 's/aarch64/arm64/')
 
+# ---------------------------------------------------------------------------
+# libbpf selection (Rocky 8 / RHEL 8 support)
+#
+# The BPF program and daemon use USDT support: the BPF-side header
+# <bpf/usdt.bpf.h> and the userspace function bpf_program__attach_usdt(),
+# both of which require libbpf >= 0.8. Ubuntu (CI), Rocky 9 / RHEL 9 (CRB)
+# all ship a recent enough libbpf, so the system one is used unchanged.
+#
+# Rocky 8 / RHEL 8 ships libbpf 0.5.0, which predates USDT entirely (no
+# usdt.bpf.h, no attach_usdt symbol). When the system libbpf is too old we
+# build a pinned libbpf from source into build/libbpf and link it statically.
+# This is detection-driven, so it is a no-op on every distro that already has
+# a usable libbpf — no Rocky 9 / Ubuntu / CI behaviour change.
+# ---------------------------------------------------------------------------
+LIBBPF_VERSION  ?= v1.4.7
+BPFTOOL_VERSION ?= v7.4.0
+
+# Probe: does the system libbpf expose bpf_program__attach_usdt AND usdt.bpf.h?
+# Delegated to a script so make's $(shell ...) never has to parse C source
+# (parentheses in main(void) confuse make's paren matching).
+SYSTEM_LIBBPF_HAS_USDT := $(shell CC='$(CC)' sh scripts/detect_libbpf_usdt.sh)
+
+ifeq ($(SYSTEM_LIBBPF_HAS_USDT),yes)
+  # System libbpf is recent enough — use it (Rocky 9, Ubuntu, CI: unchanged).
+  BPF_LIBBPF_INC =
+  LIBBPF_INC     =
+  LIBBPF_LIB     = -lbpf
+  LIBBPF_DEP     =
+  # System bpftool is fine when its libbpf matches the build's libbpf.
+  BPFTOOL_DEP    =
+else
+  # System libbpf lacks USDT (Rocky 8 / RHEL 8: libbpf 0.5.0). Build a pinned
+  # libbpf from source and link it statically.
+  BUNDLED_LIBBPF_DIR  = $(BUILD_DIR)/libbpf
+  BUNDLED_LIBBPF_SRC  = $(BUNDLED_LIBBPF_DIR)/src
+  BUNDLED_LIBBPF_INC  = $(BUNDLED_LIBBPF_DIR)/root/usr/include
+  BUNDLED_LIBBPF_A    = $(BUNDLED_LIBBPF_DIR)/root/usr/lib64/libbpf.a
+  # -I the bundled headers FIRST so usdt.bpf.h and the newer libbpf.h win.
+  BPF_LIBBPF_INC = -I$(BUNDLED_LIBBPF_INC)
+  LIBBPF_INC     = -I$(BUNDLED_LIBBPF_INC)
+  # Static libbpf pulls in libelf and zlib explicitly.
+  LIBBPF_LIB     = $(BUNDLED_LIBBPF_A) -lelf -lz
+  LIBBPF_DEP     = $(BUNDLED_LIBBPF_A)
+
+  # The BPF object is now compiled against the newer libbpf headers, so the
+  # system bpftool (RHEL 8 ships v4.18, libbpf 0.5.0) cannot finalize its BTF
+  # when generating the skeleton ("Error finalizing .BTF: -2"). Build a pinned
+  # bpftool from source and use it for all bpftool operations. (Same fallback
+  # CI already uses when the runner lacks a working bpftool.)
+  BUNDLED_BPFTOOL_DIR = $(BUILD_DIR)/bpftool
+  BUNDLED_BPFTOOL     = $(BUNDLED_BPFTOOL_DIR)/src/bpftool
+  BPFTOOL             = $(BUNDLED_BPFTOOL)
+  BPFTOOL_DEP         = $(BUNDLED_BPFTOOL)
+endif
+
 BPF_CFLAGS = -g -O2 -target bpf -D__TARGET_ARCH_$(ARCH) \
+             $(BPF_LIBBPF_INC) \
              -I$(INC_DIR) -I$(SRC_DIR) \
              -I/usr/include/$(shell uname -m)-linux-gnu
 
 CFLAGS     = -g -O2 -Wall -Wextra -Wno-unused-parameter \
+             $(LIBBPF_INC) \
              -I$(INC_DIR) -I$(SRC_DIR)
-LDFLAGS    = -lbpf -lelf -lz -llz4
+LDFLAGS    = $(LIBBPF_LIB) -lelf -lz -llz4
 
 USER_SRCS  = $(SRC_DIR)/pg_wait_tracer.c \
              $(SRC_DIR)/daemon.c \
@@ -96,8 +153,31 @@ bench:
 $(BUILD_DIR):
 	@mkdir -p $(BUILD_DIR)
 
+# Step 0 (Rocky 8 only): build a pinned libbpf + bpftool from source when the
+# system libbpf is too old for USDT. Only referenced when *_DEP is non-empty.
+ifneq ($(LIBBPF_DEP),)
+$(BUNDLED_LIBBPF_A): | $(BUILD_DIR)
+	@echo "  LIBBPF   system libbpf lacks USDT — building $(LIBBPF_VERSION) from source"
+	@rm -rf $(BUNDLED_LIBBPF_DIR)
+	@git clone -q --depth 1 --branch $(LIBBPF_VERSION) \
+		https://github.com/libbpf/libbpf.git $(BUNDLED_LIBBPF_DIR)
+	@$(MAKE) -s -C $(BUNDLED_LIBBPF_SRC) BUILD_STATIC_ONLY=1 \
+		PREFIX=/usr DESTDIR=$(abspath $(BUNDLED_LIBBPF_DIR))/root install install_uapi_headers
+	@echo "  LIBBPF   built $@"
+endif
+
+ifneq ($(BPFTOOL_DEP),)
+$(BUNDLED_BPFTOOL): | $(BUILD_DIR)
+	@echo "  BPFTOOL  system bpftool too old for this BPF object — building $(BPFTOOL_VERSION) from source"
+	@rm -rf $(BUNDLED_BPFTOOL_DIR)
+	@git clone -q --depth 1 --branch $(BPFTOOL_VERSION) --recurse-submodules \
+		https://github.com/libbpf/bpftool.git $(BUNDLED_BPFTOOL_DIR)
+	@$(MAKE) -s -C $(BUNDLED_BPFTOOL_DIR)/src
+	@echo "  BPFTOOL  built $@"
+endif
+
 # Step 1: Generate vmlinux.h from kernel BTF
-$(INC_DIR)/vmlinux.h:
+$(INC_DIR)/vmlinux.h: $(BPFTOOL_DEP)
 	@echo "  VMLINUX  $@"
 	@mkdir -p $(INC_DIR)
 	@$(BPFTOOL) btf dump file /sys/kernel/btf/vmlinux format c > $@
@@ -105,6 +185,7 @@ $(INC_DIR)/vmlinux.h:
 # Step 2: Compile BPF program
 $(BUILD_DIR)/pg_wait_tracer.bpf.o: $(BPF_DIR)/pg_wait_tracer.bpf.c \
                                     $(INC_DIR)/vmlinux.h \
+                                    $(LIBBPF_DEP) \
                                     $(SRC_DIR)/pg_wait_tracer.h | $(BUILD_DIR)
 	@echo "  BPF      $@"
 	@$(CLANG) $(BPF_CFLAGS) -c $< -o $@
@@ -117,6 +198,7 @@ $(INC_DIR)/pg_wait_tracer.skel.h: $(BUILD_DIR)/pg_wait_tracer.bpf.o
 
 # Step 4: Compile userspace C (all depend on skeleton + shared header)
 $(BUILD_DIR)/%.o: $(SRC_DIR)/%.c $(INC_DIR)/pg_wait_tracer.skel.h \
+                  $(LIBBPF_DEP) \
                   $(SRC_DIR)/pg_wait_tracer.h | $(BUILD_DIR)
 	@echo "  CC       $@"
 	@$(CC) $(CFLAGS) -c $< -o $@

--- a/scripts/detect_libbpf_usdt.sh
+++ b/scripts/detect_libbpf_usdt.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+# detect_libbpf_usdt.sh — print "yes" if the system libbpf is recent enough to
+# build pg_wait_tracer against, "no" otherwise.
+#
+# pg_wait_tracer needs USDT support, which arrived in libbpf 0.8:
+#   - the userspace function bpf_program__attach_usdt()
+#   - the BPF-side header <bpf/usdt.bpf.h>
+# Ubuntu (CI), Rocky 9 / RHEL 9 (CRB) ship a new enough libbpf and print "yes"
+# (no behaviour change). Rocky 8 / RHEL 8 ship libbpf 0.5.0 and print "no", so
+# the Makefile builds a pinned libbpf from source instead.
+#
+# The check is a real link probe: bpf_program__attach_usdt is only DECLARED in
+# libbpf >= 0.8, so the compile fails on 0.5.0 and we fall back.
+set -eu
+
+CC="${CC:-gcc}"
+HDR="${USDT_HEADER:-/usr/include/bpf/usdt.bpf.h}"
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+cat > "$tmpdir/probe.c" <<'EOF'
+#include <bpf/libbpf.h>
+int main(void) { return bpf_program__attach_usdt == 0; }
+EOF
+
+if "$CC" "$tmpdir/probe.c" -lbpf -o "$tmpdir/probe.out" >/dev/null 2>&1 \
+   && [ -r "$HDR" ]; then
+    echo yes
+else
+    echo no
+fi

--- a/src/discovery.c
+++ b/src/discovery.c
@@ -169,11 +169,25 @@ uint64_t pgwt_find_load_base(pid_t pid, const char *binary_basename)
     uint64_t base = 0;
     char line[512];
     while (fgets(line, sizeof(line), f)) {
-        if (strstr(line, binary_basename) && strstr(line, "r--p")) {
-            /* First r--p mapping of the binary is the load base */
-            base = strtoull(line, NULL, 16);
-            break;
-        }
+        if (!strstr(line, binary_basename))
+            continue;
+        /* The load base is the LOWEST-address mapping of the binary.
+         * /proc/<pid>/maps is sorted by start address, so the first mapping
+         * that names the binary is the load base — regardless of its
+         * permissions. We must NOT require a specific permission bit here:
+         *
+         *   - PIE / ET_DYN (Rocky 9, Ubuntu, Debian PGDG): the first mapping
+         *     is the read-only ELF-header page (r--p), so the old "first r--p"
+         *     match happened to be correct.
+         *   - non-PIE / ET_EXEC (Rocky 8 / RHEL 8 PGDG postgres): the first
+         *     mapping is the text segment (r-xp) and the r--p mapping is
+         *     rodata, far above the load base. Matching "first r--p" there
+         *     returned the rodata address, producing a wildly wrong symbol VA
+         *     (every wait_event read came back 0 → no events captured).
+         *
+         * Taking the first matching mapping is correct for both. */
+        base = strtoull(line, NULL, 16);
+        break;
     }
     fclose(f);
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -5,6 +5,11 @@ CC       ?= gcc
 CFLAGS    = -g -O2 -Wall -I../src -I../include
 BUILD     = ../build
 
+# libbpf link flags. Defaults to the system shared library; the top-level
+# Makefile overrides this (LIBBPF_LIB="path/to/libbpf.a -lelf -lz") on
+# Rocky 8 / RHEL 8 where the bundled static libbpf is used instead.
+LIBBPF_LIB ?= -lbpf
+
 TESTS     = test_wait_event test_cmdline test_event_writer test_event_reader \
             test_trace_v2 test_sampler test_anomaly test_coop test_bucket \
             gen_test_traces gen_bench_traces test_concurrent_rw cross_validate \
@@ -25,7 +30,7 @@ test_event_writer: test_event_writer.c $(BUILD)/event_writer.o
 
 test_event_reader: test_event_reader.c $(BUILD)/event_reader.o $(BUILD)/event_writer.o \
                    $(BUILD)/map_reader.o $(BUILD)/wait_event.o $(BUILD)/cJSON.o
-	$(CC) $(CFLAGS) -o $@ $^ -llz4 -lbpf -lelf -lz
+	$(CC) $(CFLAGS) -o $@ $^ -llz4 $(LIBBPF_LIB) -lelf -lz
 
 test_bucket: test_bucket.c
 	$(CC) $(CFLAGS) -o $@ $^
@@ -69,7 +74,7 @@ gen_bench_traces: gen_bench_traces.c $(SERVER_OBJS)
 
 test_concurrent_rw: test_concurrent_rw.c $(BUILD)/event_reader.o $(BUILD)/event_writer.o \
                     $(BUILD)/map_reader.o $(BUILD)/wait_event.o $(BUILD)/cJSON.o
-	$(CC) $(CFLAGS) -o $@ $^ -llz4 -lbpf -lelf -lz
+	$(CC) $(CFLAGS) -o $@ $^ -llz4 $(LIBBPF_LIB) -lelf -lz
 
 # cross_validate: A4 sampled-vs-exact comparison tool. Server build
 # (-DPGWT_SERVER) so it needs no BPF skeleton — runs anywhere the server


### PR DESCRIPTION
## Rocky 8 / RHEL 8 build and runtime support

Validated `pg_wait_tracer` on **Rocky Linux 8.10** (kernel 4.18.0-553, clang 21.1.8, PostgreSQL 18.4). Three Rocky-8-real issues were found and fixed. Every change is **detection-gated**, so Rocky 9 / Ubuntu / CI take exactly the same code paths as before.

### 1. Bundled libbpf when the system one lacks USDT
RHEL 8 ships **libbpf 0.5.0**, which predates USDT support: no `<bpf/usdt.bpf.h>` (the BPF program includes it) and no `bpf_program__attach_usdt()` (the daemon calls it). The build failed at the very first BPF compile.

A link probe (`scripts/detect_libbpf_usdt.sh`) detects whether the system libbpf is usable. Only when it is **not** (RHEL 8) does the Makefile clone + build a pinned **static libbpf v1.4.7** and link it in. Ubuntu/CI and Rocky 9 (CRB libbpf ≥ 1.x) probe `yes` and keep using the system libbpf unchanged.

### 2. Bundled bpftool when the system one is too old
Once the BPF object is compiled against the newer libbpf headers, RHEL 8's bpftool (v4.18, libbpf 0.5.0) cannot finalize its BTF during skeleton generation (`Error finalizing .BTF: -2`). Gated on the same condition, the Makefile builds a pinned **bpftool v7.4.0** from source and uses it for all bpftool steps. This mirrors the from-source bpftool fallback CI already uses.

### 3. Correct load-base detection for non-PIE binaries
PGDG ships a **PIE** postgres on EL9 but a **non-PIE (ET_EXEC)** postgres on EL8. `pgwt_find_load_base()` matched the first `r--p` mapping as the load base:
- **PIE** (EL9/Ubuntu): the first mapping is the read-only ELF-header page (`r--p`) — the old match happened to be correct.
- **non-PIE** (EL8): the first mapping is the `r-xp` text segment and `r--p` is *rodata* far above the load base. The old code returned the rodata address, making **every resolved symbol VA wrong** — so every `wait_event` read came back 0 and **no wait events were captured at all**.

The load base is simply the lowest-address mapping of the binary. Taking the first matching mapping regardless of permission bits is correct for both PIE and non-PIE.

### Why Rocky 9 is not regressed
- The libbpf/bpftool source builds only happen when the USDT link probe fails — Rocky 9's CRB libbpf and Ubuntu's `libbpf-dev` both pass it, so `LIBBPF_DEP`/`BPFTOOL_DEP` are empty and those Makefile rules are never reached. `LDFLAGS` and `BPFTOOL` are byte-for-byte the original values.
- The load-base fix is a strict generalization: for PIE the lowest mapping *is* the `r--p` header page, so the resolved base is identical to before.

### Evidence (Rocky 8.10)
- Toolchain: clang 21.1.8, system bpftool v4.18 / libbpf 0.5.0 → bundled libbpf v1.4.7 + bpftool v7.4.0.
- `make`: clean build of `pg_wait_tracer` + `pgwt-server`; `bpf_program__attach_usdt` statically linked.
- Capture confirmed in full tiered mode: `Timeout:PgSleep`, `IO:WalSync`, `IO:DataFileRead/Write`, `LWLock:WALWrite`, `Lock:transactionid`, and **`IO:AioIoCompletion`** (PG18 AIO, `io_method=worker`).
