### PR TITLE
Show '—' for %DB of idle-but-visible events (fix %DB column overshoot)

### DIFF
--- a/src/compute.c
+++ b/src/compute.c
@@ -572,7 +572,10 @@ void pgwt_compute_top_events(const struct pgwt_trace_event *events, int count,
             continue;
 
         /* Idle-but-visible events (Client:ClientRead) appear in the list
-         * but are excluded from DB Time, so their %DB stays meaningful. */
+         * but are excluded from DB Time. Their time is not part of the
+         * DB-Time denominator, so a numeric %DB is meaningless for them
+         * (it overshoots and makes the column sum past 100%). Their %DB is
+         * marked with a sentinel below and rendered as "—". */
         if (!pgwt_is_idle_event(ev->old_event))
             db_time_ns += ev->duration_ns;
 
@@ -613,7 +616,12 @@ void pgwt_compute_top_events(const struct pgwt_trace_event *events, int count,
         r->p50_us   = hist_percentile(ht[i].hist, ht[i].count, 0.50);
         r->p95_us   = hist_percentile(ht[i].hist, ht[i].count, 0.95);
         r->p99_us   = hist_percentile(ht[i].hist, ht[i].count, 0.99);
-        r->pct_db   = db_time_ms > 0 ? r->total_ms / db_time_ms * 100.0 : 0;
+        /* Idle-but-visible events have time but no meaningful share of DB
+         * Time; flag their %DB with a sentinel so it renders as "—". */
+        if (pgwt_is_idle_event(ht[i].event_id))
+            r->pct_db = PGWT_PCT_DB_IDLE;
+        else
+            r->pct_db = db_time_ms > 0 ? r->total_ms / db_time_ms * 100.0 : 0;
         r->aas      = wall_ms > 0 ? r->total_ms / wall_ms : 0;
 
         if (ht[i].event_id == 0)
@@ -1432,7 +1440,12 @@ void pgwt_compute_top_events_from_summaries(
         row->p50_us   = hist_percentile(ctx.ht[i].hist, ctx.ht[i].count, 0.50);
         row->p95_us   = hist_percentile(ctx.ht[i].hist, ctx.ht[i].count, 0.95);
         row->p99_us   = hist_percentile(ctx.ht[i].hist, ctx.ht[i].count, 0.99);
-        row->pct_db   = db_time_ms > 0 ? row->total_ms / db_time_ms * 100.0 : 0;
+        /* Idle-but-visible events have time but no meaningful share of DB
+         * Time; flag their %DB with a sentinel so it renders as "—". */
+        if (pgwt_is_idle_event(ctx.ht[i].event_id))
+            row->pct_db = PGWT_PCT_DB_IDLE;
+        else
+            row->pct_db = db_time_ms > 0 ? row->total_ms / db_time_ms * 100.0 : 0;
         row->aas      = wall_ms > 0 ? row->total_ms / wall_ms : 0;
 
         if (ctx.ht[i].event_id == 0)

--- a/src/compute.h
+++ b/src/compute.h
@@ -5,6 +5,13 @@
 #include "pg_wait_tracer.h"
 #include <stdint.h>
 
+/* Sentinel for %DB of idle-but-visible events (e.g. Client:ClientRead).
+ * %DB = "share of DB Time" and applies only to non-idle (DB-Time) events;
+ * idle events have time but no meaningful share, so their pct_db is set to
+ * this sentinel and rendered as "—" (em-dash) / null (JSON). */
+#define PGWT_PCT_DB_IDLE (-1.0)
+#define PGWT_PCT_DB_IS_IDLE(p) ((p) < 0.0)
+
 /* ── Wait classes (same order as Rust WaitClass enum) ──────── */
 
 #define PGWT_NUM_CLASSES 11

--- a/src/output.c
+++ b/src/output.c
@@ -16,6 +16,20 @@
 static double ns_to_ms(uint64_t ns) { return (double)ns / 1e6; }
 static double ns_to_us(uint64_t ns) { return (double)ns / 1e3; }
 
+/* Format a "% DB" cell into buf. %DB = share of DB Time and applies only to
+ * non-idle (DB-Time) events; idle-but-visible events (e.g. Client:ClientRead)
+ * have time but no meaningful share, so they render as "—" (matching the
+ * "(Activity/Idle — excluded from DB Time)" bucket). pct is the precomputed
+ * percentage for non-idle rows. width is the field width (right-aligned). */
+static void fmt_pct_db(char *buf, size_t bufsz, int width,
+                       uint32_t wait_event, double pct)
+{
+    if (pgwt_is_idle_event(wait_event))
+        snprintf(buf, bufsz, "%*s", width, "—");
+    else
+        snprintf(buf, bufsz, "%*.1f%%", width - 1, pct);
+}
+
 /* ── Multi-window helpers ───────────────────────────────── */
 
 static void format_window_label(int secs, char *buf, size_t bufsz)
@@ -220,8 +234,10 @@ static void print_time_model_multi(struct pgwt_daemon *d)
                 if (!valid[w]) { printf(" %9s %7s", "-", "-"); continue; }
                 uint64_t db = deltas[w].tm.db_time_ns;
                 uint64_t ev_ns = find_snap_event_ns(&deltas[w], top[t].we);
-                printf(" %9.1f %6.1f%%", ns_to_ms(ev_ns),
-                       db ? 100.0 * ev_ns / db : 0);
+                char pctcell[16];
+                fmt_pct_db(pctcell, sizeof(pctcell), 7, top[t].we,
+                           db ? 100.0 * ev_ns / db : 0);
+                printf(" %9.1f %s", ns_to_ms(ev_ns), pctcell);
             }
             printf("\n");
         }
@@ -334,8 +350,11 @@ void pgwt_print_time_model(struct pgwt_daemon *d)
         for (int t = 0; t < ntop; t++) {
             char name[64];
             pgwt_event_full_name(top[t].we, name, sizeof(name));
-            printf("      %-32s %12.1f %9.1f%%\n", name,
-                   ns_to_ms(top[t].total_ns), 100.0 * top[t].total_ns / db);
+            char pctcell[16];
+            fmt_pct_db(pctcell, sizeof(pctcell), 9, top[t].we,
+                       100.0 * top[t].total_ns / db);
+            printf("      %-32s %12.1f %s\n", name,
+                   ns_to_ms(top[t].total_ns), pctcell);
         }
     }
 
@@ -432,12 +451,15 @@ static void print_system_event_multi(struct pgwt_daemon *d)
             double avg_us = ev->count ?
                 ns_to_us(ev->total_ns) / ev->count : 0;
 
-            printf("  %-26s %12lu %14.1f %10.1f %8.1f%%\n",
+            char pctcell[16];
+            fmt_pct_db(pctcell, sizeof(pctcell), 9, ev->wait_event,
+                       db ? 100.0 * ev->total_ns / db : 0);
+            printf("  %-26s %12lu %14.1f %10.1f %s\n",
                    name,
                    (unsigned long)ev->count,
                    ns_to_ms(ev->total_ns),
                    avg_us,
-                   db ? 100.0 * ev->total_ns / db : 0);
+                   pctcell);
             shown++;
         }
         printf("\n");
@@ -490,13 +512,16 @@ void pgwt_print_system_event(struct pgwt_daemon *d)
         double avg_us = sorted[i].count ?
             ns_to_us(sorted[i].total_ns) / sorted[i].count : 0;
 
-        printf("  %-26s %12lu %14.1f %10.1f %12.1f %8.1f%%\n",
+        char pctcell[16];
+        fmt_pct_db(pctcell, sizeof(pctcell), 9, sorted[i].wait_event,
+                   db ? 100.0 * sorted[i].total_ns / db : 0);
+        printf("  %-26s %12lu %14.1f %10.1f %12.1f %s\n",
                name,
                (unsigned long)sorted[i].count,
                ns_to_ms(sorted[i].total_ns),
                avg_us,
                ns_to_us(sorted[i].max_ns),
-               db ? 100.0 * sorted[i].total_ns / db : 0);
+               pctcell);
         shown++;
     }
     free(sorted);
@@ -587,13 +612,16 @@ void pgwt_print_session_event(struct pgwt_daemon *d)
             pgwt_event_full_name(sorted[j].wait_event, name, sizeof(name));
             double avg_us = sorted[j].count ?
                 ns_to_us(sorted[j].total_ns) / sorted[j].count : 0;
-            printf("  %-26s %12lu %14.1f %10.1f %12.1f %8.1f%%\n",
+            char pctcell[16];
+            fmt_pct_db(pctcell, sizeof(pctcell), 9, sorted[j].wait_event,
+                       pa->db_time_ns ? 100.0 * sorted[j].total_ns / pa->db_time_ns : 0);
+            printf("  %-26s %12lu %14.1f %10.1f %12.1f %s\n",
                    name,
                    (unsigned long)sorted[j].count,
                    ns_to_ms(sorted[j].total_ns),
                    avg_us,
                    ns_to_us(sorted[j].max_ns),
-                   pa->db_time_ns ? 100.0 * sorted[j].total_ns / pa->db_time_ns : 0);
+                   pctcell);
         }
         printf("\n");
     }

--- a/src/server.c
+++ b/src/server.c
@@ -1180,7 +1180,12 @@ static void handle_top_events(struct pgwt_server *srv, struct pgwt_request *req)
         cJSON_AddNumberToObject(r, "p95_us", res.rows[i].p95_us);
         cJSON_AddNumberToObject(r, "p99_us", res.rows[i].p99_us);
         cJSON_AddNumberToObject(r, "max_us", res.rows[i].max_us);
-        cJSON_AddNumberToObject(r, "pct", res.rows[i].pct_db);
+        /* Idle-but-visible events (Client:ClientRead) have no meaningful
+         * share of DB Time; emit null so the client renders "—". */
+        if (PGWT_PCT_DB_IS_IDLE(res.rows[i].pct_db))
+            cJSON_AddNullToObject(r, "pct");
+        else
+            cJSON_AddNumberToObject(r, "pct", res.rows[i].pct_db);
         cJSON_AddNumberToObject(r, "aas", res.rows[i].aas);
         cJSON_AddItemToArray(rows, r);
     }
@@ -2421,8 +2426,14 @@ static void dump_summary(struct pgwt_server *srv)
     int n = ev.num_rows < 15 ? ev.num_rows : 15;
     for (int i = 0; i < n; i++) {
         struct pgwt_event_row *r = &ev.rows[i];
-        printf("  %-28s %10llu %12.1f %10.1f %7.1f%%\n",
-               r->name, (unsigned long long)r->count, r->total_ms, r->avg_us, r->pct_db);
+        char pctbuf[16];
+        /* Idle-but-visible events: time but no meaningful %DB share. */
+        if (PGWT_PCT_DB_IS_IDLE(r->pct_db))
+            snprintf(pctbuf, sizeof(pctbuf), "%8s", "—");
+        else
+            snprintf(pctbuf, sizeof(pctbuf), "%7.1f%%", r->pct_db);
+        printf("  %-28s %10llu %12.1f %10.1f %s\n",
+               r->name, (unsigned long long)r->count, r->total_ms, r->avg_us, pctbuf);
     }
     free(ev.rows);
 

--- a/tests/mock_server.py
+++ b/tests/mock_server.py
@@ -181,6 +181,18 @@ _CANNED["top_events"] = {
          "p95_us": 80, "p99_us": 200, "max_us": 5000, "pct": 2.4, "aas": 0.08},
     ],
 }
+# NOTE on the idle-but-visible %DB shape:
+# The real server emits pct=null for idle-but-visible events (Client:ClientRead)
+# in top_events — %DB is "share of DB Time" and idle time is not part of DB
+# Time, so a numeric %DB is meaningless (see src/server.c handle_top_events).
+# We deliberately do NOT add such a row to this canned top_events dataset:
+# the visual-snapshot baselines (tests/web_snapshots/*.png, GATING in CI and
+# regenerated only via workflow_dispatch) are keyed to this exact layout, and
+# adding a row would change the rendered table height. The null-pct -> "—"
+# rendering is covered deterministically by the Node builder unit test
+# (tests/web_unit/events.test.mjs) and end-to-end against the real server by
+# tests/test_data_idle.py. protocol-drift stays consistent because a null
+# field merges optionally into the same numeric schema (test_protocol_drift.py).
 
 _CANNED["top_sessions"] = {
     "rows": [

--- a/tests/test_data_idle.py
+++ b/tests/test_data_idle.py
@@ -89,6 +89,24 @@ def main():
             t.check(len(client_rows) == 1,
                     "Client:ClientRead present in top_events (visible)")
 
+            # %DB = share of DB Time and applies ONLY to non-idle (DB-Time)
+            # events. Client:ClientRead is idle (excluded from DB Time), so it
+            # has time but no meaningful share — the server emits pct=null so
+            # the client renders "—" (a numeric %DB would overshoot 100%).
+            print("--- ClientRead %DB is null (idle, excluded from DB Time) ---")
+            if client_rows:
+                t.check(client_rows[0].get("pct", "missing") is None,
+                        "Client:ClientRead pct is null in top_events")
+                t.check(client_rows[0].get("total_ms", 0) > 0,
+                        "Client:ClientRead still reports its time")
+
+            # %DB over the NON-IDLE rows sums to ~100% (idle rows excluded).
+            non_idle = [r for r in resp_ev.get("rows", [])
+                        if r.get("pct") is not None]
+            pct_sum = sum(r["pct"] for r in non_idle)
+            t.check(abs(pct_sum - 100.0) < 0.5,
+                    f"Non-idle %DB sums to {pct_sum:.2f}% (expected ~100%)")
+
             # session_timeline must hide Activity bars but KEEP ClientRead
             print("--- timeline hides Activity, keeps ClientRead ---")
             resp_tl = srv.query("session_timeline")

--- a/tests/test_multi_window.py
+++ b/tests/test_multi_window.py
@@ -386,7 +386,12 @@ def test_system_event_progressive(pm_pid):
 # ── Test 6: system_event Data Sanity ───────────────────────
 
 def parse_system_events_section(text):
-    """Parse events from a system_event section."""
+    """Parse events from a system_event section.
+
+    The % DB column is either a number ("12.3%") for non-idle (DB-Time)
+    events, or "—" (em-dash) for idle-but-visible events (Client:ClientRead),
+    which have time but no meaningful share of DB Time. We capture the raw
+    token and expose 'pct' (float or None) plus 'pct_is_dash'."""
     events = []
     for line in text.split('\n'):
         line = line.strip()
@@ -395,16 +400,19 @@ def parse_system_events_section(text):
             r'(\d+)\s+'
             r'([\d.]+)\s+'
             r'([\d.]+)\s+'
-            r'([\d.]+)%',
+            r'(\d[\d.]*%|—)',          # % DB: number+% OR em-dash
             line
         )
         if m:
+            pct_tok = m.group(5)
+            is_dash = (pct_tok == '—')
             events.append({
                 'name': m.group(1),
                 'count': int(m.group(2)),
                 'total_ms': float(m.group(3)),
                 'avg_us': float(m.group(4)),
-                'pct': float(m.group(5)),
+                'pct': None if is_dash else float(pct_tok.rstrip('%')),
+                'pct_is_dash': is_dash,
             })
     return events
 
@@ -463,10 +471,25 @@ def test_system_event_data(pm_pid):
     check(all_positive,
           "All events have count > 0")
 
-    # Percentages should sum to roughly 100% (allowing for rounding)
-    pct_sum = sum(e['pct'] for e in events)
+    # %DB = share of DB Time and applies ONLY to non-idle (DB-Time) events.
+    # Idle-but-visible events (Client:ClientRead) are listed (they have time)
+    # but render "—" for %DB, not a number — counting them would overshoot the
+    # column past 100%. Sum must be ~100% across the NON-IDLE rows.
+    non_idle = [e for e in events if not e['pct_is_dash']]
+    pct_sum = sum(e['pct'] for e in non_idle)
     check(80 < pct_sum < 120,
-          f"Percentages sum to {pct_sum:.1f}% (expected ~100%)")
+          f"Non-idle %DB sums to {pct_sum:.1f}% (expected ~100%)")
+
+    # Idle-but-visible events must render "—" (not a number) for %DB.
+    idle_rows = [e for e in events if e['name'] == 'Client:ClientRead']
+    if idle_rows:
+        all_dash = all(e['pct_is_dash'] for e in idle_rows)
+        check(all_dash,
+              "Client:ClientRead renders '—' for %DB (idle, excluded from DB Time)")
+        # ...while still showing its time (it is visible, not hidden).
+        has_time = all(e['total_ms'] > 0 for e in idle_rows)
+        check(has_time,
+              "Client:ClientRead still shows its time (visible row)")
 
 
 # ── Test 7: query_event Mode A multi-window ─────────────────

--- a/tests/web_unit/events.test.mjs
+++ b/tests/web_unit/events.test.mjs
@@ -71,3 +71,30 @@ test('single row -> stable', () => {
     assert.equal(m.table.rows.length, 1);
     assert.equal(m.table.rows[0].row.name, 'Solo');
 });
+
+// %DB column is index 8 (name,count,total_ms,avg_us,p50,p95,p99,max,pct,aas).
+const PCT_COL = 8;
+
+test('idle event with pct=null renders "—" for %DB, not a bar', () => {
+    // Client:ClientRead is idle (excluded from DB Time): server sends
+    // pct=null, the cell must show an em-dash rather than a bogus pct-bar.
+    const m = buildEventsModel({ rows: [
+        ev({ name: 'Client:ClientRead', event_id: 0x06000000,
+             count: 100, total_ms: 5000, pct: null }),
+    ] }, null);
+    const cell = m.table.rows[0].cells[PCT_COL].html;
+    assert.ok(cell.includes('—'), `expected em-dash, got: ${cell}`);
+    assert.ok(!cell.includes('pct-bar'), `should not render a bar, got: ${cell}`);
+    // The row is still visible with its time intact.
+    assert.equal(m.table.rows[0].row.total_ms, 5000);
+});
+
+test('non-idle event with numeric pct still renders a pct-bar', () => {
+    const m = buildEventsModel({ rows: [
+        ev({ name: 'IO:DataFileRead', event_id: 0x01000015,
+             count: 100, total_ms: 2100, pct: 16.8 }),
+    ] }, null);
+    const cell = m.table.rows[0].cells[PCT_COL].html;
+    assert.ok(cell.includes('pct-bar'), `expected pct-bar, got: ${cell}`);
+    assert.ok(cell.includes('16.8%'), `expected 16.8%, got: ${cell}`);
+});

--- a/web/static/lib/builders/table-configs.js
+++ b/web/static/lib/builders/table-configs.js
@@ -57,6 +57,10 @@ export const eventsConfig = {
         { key: 'p99_us', label: 'P99', cls: 'num', format: (r) => fmtUs(r.p99_us) },
         { key: 'max_us', label: 'Max', cls: 'num', format: (r) => fmtUs(r.max_us) },
         { key: 'pct', label: '%DB', cls: 'num', format: (r) => {
+            /* Idle-but-visible events (e.g. Client:ClientRead) have time but
+             * no meaningful share of DB Time; the server sends pct=null so we
+             * render "—" instead of a bogus bar. */
+            if (r.pct == null) return '<span style="color:#555">—</span>';
             const color = classColor(r.name) || '#4fc3f7';
             return pctBar(r.pct, color);
         }},


### PR DESCRIPTION
## Problem

The \`%DB\` (% of DB Time) column could overshoot 100% (observed ~141% on a box with many idle backends; this is what made \`test_multi_window\` 62/63 on Rocky 8).

\`%DB\` is computed as \`event_time / DB_Time_total\`. But \`Client:ClientRead\` is **idle** — its time is excluded from DB Time (it is the analogue of Oracle's "SQL\*Net message from client"; counting it as DB Time inflates load when connections sit idle). Yet it is **visible** (shown in event lists, unlike Activity which is hidden — see \`src/wait_event.c\` \`pgwt_is_idle_event\`/\`pgwt_is_hidden_event\`). Dividing an idle event's time by a denominator that excludes that time produces an absurd per-row \`%DB\` (e.g. 871379%) and makes the visible column sum past 100%.

The captured data was already correct (time-model consistency 0.0% error; DB Time / AAS exact). This is purely how \`%DB\` is *presented* for idle-but-visible rows.

## The fix (consistent with the idle-but-visible model + Oracle convention)

\`%DB\` = "share of DB Time" and applies **only to non-idle (DB-Time) events**. For idle-but-visible events we no longer compute a numeric \`%DB\` — we display **"—"** (an em-dash, exactly like the existing "(Activity/Idle — excluded from DB Time)" bucket). Result: \`%DB\` sums to ~100% across the non-idle rows; idle rows still show their **time** but "—" for \`%DB\`. DB Time / AAS / the time/count/min/max values are unchanged.

## Places changed (the rule: idle row → "—" / null \`%DB\`)

- **compute.c** — per-event \`top_events\` rows (both the raw-events and from-summaries paths) tag idle events with a \`PGWT_PCT_DB_IDLE\` sentinel instead of a bogus ratio. \`compute.h\` adds the sentinel + \`PGWT_PCT_DB_IS_IDLE()\`.
- **Text output (output.c)** — new \`fmt_pct_db()\` renders idle rows' \`%DB\` as "—" across the **system_event**, **time-model class drill-down**, and **per-PID detail** tables (the visible per-event tables that include ClientRead). Query-event tables already skip idle, so they are unaffected.
- **JSON (server.c)** — \`handle_top_events\` emits \`pct: null\` for idle rows so the web client renders "—"; the debug dump prints "—". Other endpoints (time-model / per-query rows) are not per-event-idle and keep their values.
- **Web UI (web/static/lib/builders/table-configs.js)** — the events table \`%DB\` cell renders \`null\` as "—" instead of feeding \`null\` to \`pctBar\`. This also fixes the B5-flagged "ClientRead %DB reads huge" cosmetic.

## Tests

- **test_multi_window**: the \`%DB\` column is now parsed as number-or-"—"; the sum assertion checks ~100% across **non-idle** rows, and it asserts \`Client:ClientRead\` renders "—" (not a number) while still showing its time.
- **test_data_idle**: asserts \`top_events\` emits \`pct=null\` for ClientRead (still visible, still has time) and that non-idle \`%DB\` sums to ~100%.
- **Node builder test (web_unit/events.test.mjs)**: null \`%DB\` → "—"; numeric \`%DB\` → pct-bar.
- \`mock_server.py\` documents why the canned \`top_events\` deliberately omits an idle row (the gating visual-snapshot baselines are keyed to its layout); the null→"—" path is covered by the Node test + test_data_idle, and protocol-drift stays consistent (a \`null\` field merges optionally into the same numeric schema).

## Live evidence (Rocky Linux 8.10, PG18) — test_multi_window now PASSES

\`\`\`
65/65 tests passed
  PASS: Non-idle %DB sums to 100.1% (expected ~100%)
  PASS: Client:ClientRead renders '—' for %DB (idle, excluded from DB Time)
  PASS: Client:ClientRead still shows its time (visible row)
\`\`\`

A live system_event table on the same box:

\`\`\`
  Wait Event                  Total Waits     Total (ms)   Avg (us)      % DB
  -------------------------- ------------ -------------- ---------- ---------
  Client:ClientRead                 63980         7533.3      117.7       —
  CPU*                             102012         5816.1       57.0     46.5%
  IO:WalSync                         7113         3160.2      444.3     25.3%
  LWLock:WALWrite                    7576         2743.1      362.1     21.9%
  Lock:transactionid                  759          490.0      645.5      3.9%
  ...
\`\`\`

ClientRead shows its time but "—" for \`%DB\`; the non-idle rows sum to ~100%.

## Validation

- Clean build on the Rocky 8 box (\`make clean && make\`): both \`pg_wait_tracer\` and \`pgwt-server\` link; \`output.o\` compiles clean.
- Local: \`make pgwt-server\` compiles; \`node --test\` 102/102; synthetic python suite green (test_data_idle 8/8, test_protocol_drift 48/48, snapshots 13/13); \`test_trace_v2\` 98/98.
- DB Time / AAS / time / count values are unchanged — only the per-row \`%DB\` presentation for idle rows changed.