### PR TITLE
PG13 query attribution via pg_stat_statements (B1: ExecutorStart -> PlannedStmt.queryId)

### DIFF
--- a/src/bpf/pg_wait_tracer.bpf.c
+++ b/src/bpf/pg_wait_tracer.bpf.c
@@ -38,6 +38,15 @@ volatile const u32 lightweight_mode = 0;   /* 0=full trace, 1=lightweight (no ri
 volatile const u32 skip_query_id = 0;      /* 1=skip query_id reads (saves 1 probe_read) */
 volatile const u64 debug_query_string_addr = 0; /* VA of debug_query_string global */
 
+/* PG13 query attribution (Route B1): ExecutorStart(QueryDesc*) uprobe walks
+ * QueryDesc->plannedstmt->queryId (populated by pg_stat_statements' hook) into
+ * the state_map query_id slot. 0 => disabled (the PG17+ pgstat_report_query_id
+ * uprobe is used instead). Offsets are header-derived (postgresql13-devel). */
+volatile const u32 pg13_query_attr = 0;          /* 1 = ExecutorStart path active */
+volatile const u32 pg13_qd_plannedstmt_off = 0;  /* offsetof(QueryDesc, plannedstmt) */
+volatile const u32 pg13_ps_queryid_off = 0;      /* offsetof(PlannedStmt, queryId) */
+volatile const u32 pg13_qd_sourcetext_off = 0;   /* offsetof(QueryDesc, sourceText) */
+
 /* ── Maps ─────────────────────────────────────────────────── */
 
 /* Per-PID state: last event + timestamp for duration computation.
@@ -463,6 +472,80 @@ int on_report_query_id(struct pt_regs *ctx)
     }
 
     /* Mark as seen */
+    u8 one = 1;
+    bpf_map_update_elem(&seen_query_ids, &query_id, &one, BPF_ANY);
+
+    return 0;
+}
+
+/* ── Program 10: uprobe on ExecutorStart (PG13 query attribution) ──
+ * PG13 has no in-core query_id and no pgstat_report_query_id. When
+ * pg_stat_statements is loaded its post_parse_analyze hook populates
+ * PlannedStmt.queryId (matching pg_stat_statements.queryid) before
+ * ExecutorStart fires. arg0 = QueryDesc *queryDesc; walk
+ *   queryDesc->plannedstmt (+pg13_qd_plannedstmt_off)
+ *           ->queryId       (+pg13_ps_queryid_off, uint64)
+ * and store it in the SAME state_map slot the PG17+ uprobe uses, so the
+ * watchpoint (full tier) and sampler (sampled tier) pick it up unchanged.
+ * One uprobe per query, not per event. Query text comes from
+ * queryDesc->sourceText (a const char*), captured once per query_id. */
+
+SEC("uprobe")
+int on_executor_start(struct pt_regs *ctx)
+{
+    if (!pg13_query_attr)
+        return 0;
+
+    u64 query_desc = PT_REGS_PARM1(ctx);
+    if (!query_desc)
+        return 0;
+
+    /* queryDesc->plannedstmt */
+    u64 planned = 0;
+    bpf_probe_read_user(&planned, sizeof(planned),
+                        (void *)(query_desc + pg13_qd_plannedstmt_off));
+    if (!planned)
+        return 0;
+
+    /* plannedstmt->queryId (uint64). With pgss loaded this is set; without it
+     * the field is 0, so we leave the slot untouched (query attribution stays
+     * "unavailable" rather than reporting a bogus 0 id). */
+    u64 query_id = 0;
+    bpf_probe_read_user(&query_id, sizeof(query_id),
+                        (void *)(planned + pg13_ps_queryid_off));
+    if (!query_id)
+        return 0;
+
+    u32 pid = bpf_get_current_pid_tgid() >> 32;
+    struct pgwt_pid_state *st = bpf_map_lookup_elem(&state_map, &pid);
+    if (st)
+        st->last_query_id = query_id;
+
+    /* Capture query text on first occurrence of this query_id, from
+     * queryDesc->sourceText. Emitted via lifecycle_rb (metadata, not trace
+     * data) — same consumer as the PG17+ debug_query_string path. */
+    if (lightweight_mode || skip_query_id || !pg13_qd_sourcetext_off)
+        return 0;
+
+    if (bpf_map_lookup_elem(&seen_query_ids, &query_id))
+        return 0;  /* already captured text for this query_id */
+
+    u64 src_ptr = 0;
+    bpf_probe_read_user(&src_ptr, sizeof(src_ptr),
+                        (void *)(query_desc + pg13_qd_sourcetext_off));
+    if (!src_ptr)
+        return 0;
+
+    struct pgwt_query_text_event *evt;
+    evt = bpf_ringbuf_reserve(&lifecycle_rb, sizeof(*evt), 0);
+    if (evt) {
+        evt->type = PGWT_LIFECYCLE_QUERY_TEXT;
+        evt->pid = pid;
+        evt->query_id = query_id;
+        bpf_probe_read_user_str(evt->text, sizeof(evt->text), (void *)src_ptr);
+        bpf_ringbuf_submit(evt, 0);
+    }
+
     u8 one = 1;
     bpf_map_update_elem(&seen_query_ids, &query_id, &one, BPF_ANY);
 

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -240,6 +240,14 @@ int pgwt_daemon_init(struct pgwt_daemon *d)
     d->skel->rodata->lightweight_mode = d->lightweight_mode;
     d->skel->rodata->skip_query_id = d->skip_query_id;
 
+    /* PG13 query attribution (Route B1): the ExecutorStart uprobe walks
+     * QueryDesc->plannedstmt->queryId into the state_map. Enabled only when
+     * pg_stat_statements is loaded (use_pg13_query_attr). */
+    d->skel->rodata->pg13_query_attr = d->use_pg13_query_attr ? 1 : 0;
+    d->skel->rodata->pg13_qd_plannedstmt_off = (uint32_t)d->pg13_qd_plannedstmt_off;
+    d->skel->rodata->pg13_ps_queryid_off = (uint32_t)d->pg13_ps_queryid_off;
+    d->skel->rodata->pg13_qd_sourcetext_off = (uint32_t)d->pg13_qd_sourcetext_off;
+
     /* Resolve debug_query_string address for BPF query text capture */
     if (d->pg_binary_saved) {
         uint64_t dqs_addr = pgwt_find_symbol_offset(d->pg_binary_saved,
@@ -278,19 +286,45 @@ int pgwt_daemon_init(struct pgwt_daemon *d)
     if (!d->lightweight_mode && !d->skip_usdt && d->pg_binary_saved) {
         const char *bin = d->pg_binary_saved;
 
-        /* Uprobe on pgstat_report_query_id FIRST — must be active before
-         * USDT probes fire, so EXEC_START always has a correct query_id.
-         * Captures query_id from function argument, bypassing shared memory. */
-        uint64_t qid_func_va = pgwt_find_symbol_offset(bin, "pgstat_report_query_id");
-        uint64_t qid_func_off = qid_func_va > 0x400000 ? qid_func_va - 0x400000 : qid_func_va;
-        if (qid_func_off) {
-            LIBBPF_OPTS(bpf_uprobe_opts, uprobe_opts, .retprobe = false);
-            d->skel->links.on_report_query_id =
-                bpf_program__attach_uprobe_opts(d->skel->progs.on_report_query_id,
-                                                -1, bin, qid_func_off, &uprobe_opts);
-            if (d->verbose)
-                fprintf(stderr, "INFO: pgstat_report_query_id at offset 0x%lx\n",
-                        (unsigned long)qid_func_off);
+        /* Query-id capture uprobe. Must be active before USDT probes fire so
+         * EXEC_START always has a correct query_id. Two variants:
+         *   PG14+ : pgstat_report_query_id (arg = query_id), bypassing shmem.
+         *   PG13  : no in-core query_id / no pgstat_report_query_id. Instead,
+         *           with pg_stat_statements loaded (use_pg13_query_attr),
+         *           uprobe ExecutorStart(QueryDesc*) and walk
+         *           queryDesc->plannedstmt->queryId. Feeds the SAME state_map
+         *           slot, so the sampler + watchpoint pipelines are unchanged. */
+        if (d->use_pg13_query_attr) {
+            uint64_t es_va = pgwt_find_symbol_offset(bin, "ExecutorStart");
+            uint64_t es_off = es_va > 0x400000 ? es_va - 0x400000 : es_va;
+            if (es_off) {
+                LIBBPF_OPTS(bpf_uprobe_opts, uprobe_opts, .retprobe = false);
+                d->skel->links.on_executor_start =
+                    bpf_program__attach_uprobe_opts(d->skel->progs.on_executor_start,
+                                                    -1, bin, es_off, &uprobe_opts);
+                if (d->verbose)
+                    fprintf(stderr, "INFO: ExecutorStart at offset 0x%lx "
+                            "(PG13 query attribution via pg_stat_statements)\n",
+                            (unsigned long)es_off);
+                if (!d->skel->links.on_executor_start)
+                    fprintf(stderr, "WARN: could not attach ExecutorStart uprobe "
+                            "(PG13 query attribution disabled)\n");
+            } else {
+                fprintf(stderr, "WARN: symbol 'ExecutorStart' not found "
+                        "(PG13 query attribution disabled)\n");
+            }
+        } else {
+            uint64_t qid_func_va = pgwt_find_symbol_offset(bin, "pgstat_report_query_id");
+            uint64_t qid_func_off = qid_func_va > 0x400000 ? qid_func_va - 0x400000 : qid_func_va;
+            if (qid_func_off) {
+                LIBBPF_OPTS(bpf_uprobe_opts, uprobe_opts, .retprobe = false);
+                d->skel->links.on_report_query_id =
+                    bpf_program__attach_uprobe_opts(d->skel->progs.on_report_query_id,
+                                                    -1, bin, qid_func_off, &uprobe_opts);
+                if (d->verbose)
+                    fprintf(stderr, "INFO: pgstat_report_query_id at offset 0x%lx\n",
+                            (unsigned long)qid_func_off);
+            }
         }
 
         /* USDT marker probes write into event_ringbuf, which only the FULL
@@ -316,12 +350,15 @@ int pgwt_daemon_init(struct pgwt_daemon *d)
                                          -1, bin,
                                          "postgresql", "query__plan__done", NULL);
 
+            bool qid_attached = d->use_pg13_query_attr
+                ? (d->skel->links.on_executor_start != NULL)
+                : (d->skel->links.on_report_query_id != NULL);
             if (d->skel->links.on_exec_start && d->skel->links.on_exec_done
-                && d->skel->links.on_report_query_id)
+                && qid_attached)
                 fprintf(stderr, "INFO: attached USDT + query_id uprobe\n");
             else
                 fprintf(stderr, "WARN: could not attach query probes (lifecycle tracking disabled)\n");
-        } else if (d->skel->links.on_report_query_id) {
+        } else if (d->skel->links.on_report_query_id || d->skel->links.on_executor_start) {
             fprintf(stderr, "INFO: attached query_id uprobe (sampled mode)\n");
         }
     }

--- a/src/daemon.h
+++ b/src/daemon.h
@@ -107,6 +107,18 @@ struct pgwt_daemon {
     int         pg_major_version;   /* 14, 15, 16, 17, or 18 */
     int         st_query_id_offset; /* 0 = not available */
     int         st_activity_offset; /* st_activity_raw in PgBackendStatus, 0 = N/A */
+
+    /* PG13 query attribution (Route B1 via pg_stat_statements). PG13 has no
+     * in-core query_id; when pgss is loaded its post_parse_analyze hook
+     * populates PlannedStmt.queryId (matching pg_stat_statements.queryid). We
+     * uprobe ExecutorStart(QueryDesc*) and walk QueryDesc->plannedstmt->queryId
+     * into the SAME state_map query_id slot the PG17+ path uses, so both tiers
+     * work unchanged. Active only when use_pg13_query_attr is true. */
+    bool        pgss_loaded;            /* pg_stat_statements in postmaster maps */
+    bool        use_pg13_query_attr;    /* PG13 + pgss: use ExecutorStart uprobe */
+    int         pg13_qd_plannedstmt_off; /* offsetof(QueryDesc, plannedstmt) */
+    int         pg13_ps_queryid_off;     /* offsetof(PlannedStmt, queryId) */
+    int         pg13_qd_sourcetext_off;  /* offsetof(QueryDesc, sourceText) */
     enum pgwt_format format;         /* output format (TUI/TEXT/JSON/CSV) */
     int         count;               /* max intervals, 0 = unlimited */
     int         tick;                /* current interval number */

--- a/src/discovery.c
+++ b/src/discovery.c
@@ -246,6 +246,60 @@ int pgwt_detect_pgproc_wait_offset(int pg_major)
     }
 }
 
+int pgwt_detect_pg13_query_offsets(int pg_major,
+                                   struct pgwt_pg13_query_offsets *out)
+{
+    if (!out)
+        return 0;
+    out->querydesc_plannedstmt = 0;
+    out->plannedstmt_queryid   = 0;
+    out->querydesc_sourcetext  = 0;
+
+    struct utsname un;
+    if (uname(&un) != 0)
+        return 0;
+    if (strcmp(un.machine, "x86_64") != 0)
+        return 0;   /* offsets are layout-/ABI-specific; only x86_64 known */
+
+    switch (pg_major) {
+    /* Header-derived via an offsetof() probe against postgresql13-devel
+     * (13.23, x86_64), confirmed against the running binary:
+     *   offsetof(QueryDesc, plannedstmt) = 8
+     *   offsetof(PlannedStmt, queryId)   = 8   (uint64)
+     *   offsetof(QueryDesc, sourceText)  = 16  (const char *)
+     * The BPF uprobe validates the walked queryId against pgss at runtime,
+     * so a wrong offset shows up as zero/garbage ids rather than a crash. */
+    case 13:
+        out->querydesc_plannedstmt = 8;
+        out->plannedstmt_queryid   = 8;
+        out->querydesc_sourcetext  = 16;
+        return 1;
+    default:
+        return 0;
+    }
+}
+
+int pgwt_detect_pgss_loaded(pid_t postmaster_pid)
+{
+    char path[64];
+    snprintf(path, sizeof(path), "/proc/%d/maps", postmaster_pid);
+
+    FILE *f = fopen(path, "r");
+    if (!f)
+        return -1;
+
+    int found = 0;
+    char line[512];
+    while (fgets(line, sizeof(line), f)) {
+        if (strstr(line, "pg_stat_statements")) {
+            found = 1;
+            break;
+        }
+    }
+    fclose(f);
+    return found;
+}
+
 uint64_t pgwt_resolve_wait_addr_via_myproc(pid_t pid, uint64_t my_proc_global_addr,
                                            int pgproc_wait_offset)
 {
@@ -779,36 +833,85 @@ int pgwt_discover(struct pgwt_daemon *d)
                     (unsigned long)ptr_val);
     }
 
-    /* Discover MyBEEntry address (for query_id attribution) */
+    /* Discover MyBEEntry address (for query_id attribution via PgBackendStatus,
+     * the PG14+ path). On PG13 the query_id comes from QueryDesc->plannedstmt
+     * (Route B1, resolved below), NOT from MyBEEntry — and PG13 does not export
+     * MyBEEntry in .dynsym anyway — so a missing MyBEEntry is not fatal there. */
     d->my_be_entry_addr = pgwt_resolve_symbol(binary, "MyBEEntry",
                                                pm_pid, base);
     if (d->my_be_entry_addr == 0) {
-        if (d->view == PGWT_VIEW_QUERY_EVENT) {
+        if (d->view == PGWT_VIEW_QUERY_EVENT && d->pg_major_version != 13) {
             fprintf(stderr, "FATAL: symbol 'MyBEEntry' not found — query_event view unavailable\n");
             return -1;
         }
         if (d->verbose)
-            fprintf(stderr, "WARN: symbol 'MyBEEntry' not found — query_event view disabled\n");
+            fprintf(stderr, "WARN: symbol 'MyBEEntry' not found — "
+                    "PgBackendStatus query-id path disabled\n");
     } else if (d->verbose) {
         fprintf(stderr, "INFO: MyBEEntry VA: 0x%lx\n",
                 (unsigned long)d->my_be_entry_addr);
     }
 
-    /* Detect st_query_id offset */
+    /* Detect st_query_id offset (PG14+ in-core query_id path) */
     d->st_query_id_offset = pgwt_detect_query_id_offset(binary, d->pg_major_version);
+
+    /* PG13 query attribution — Route B1 (pg_stat_statements-based).
+     * PG13 has no in-core query_id (st_query_id was added in PG14), so the
+     * detection above returns 0. Instead, if pg_stat_statements is loaded its
+     * post_parse_analyze hook populates PlannedStmt.queryId; we uprobe
+     * ExecutorStart and walk QueryDesc->plannedstmt->queryId into the same
+     * state_map slot. This is gated on pgss being loaded. */
+    if (d->use_myproc && d->pg_major_version == 13) {
+        struct pgwt_pg13_query_offsets qo;
+        int have_off = pgwt_detect_pg13_query_offsets(d->pg_major_version, &qo);
+        int pgss = pgwt_detect_pgss_loaded(pm_pid);
+        d->pgss_loaded = (pgss == 1);
+
+        if (have_off && d->pgss_loaded) {
+            d->use_pg13_query_attr      = true;
+            d->pg13_qd_plannedstmt_off  = qo.querydesc_plannedstmt;
+            d->pg13_ps_queryid_off      = qo.plannedstmt_queryid;
+            d->pg13_qd_sourcetext_off   = qo.querydesc_sourcetext;
+            if (d->verbose)
+                fprintf(stderr,
+                        "INFO: PG13 query attribution via pg_stat_statements "
+                        "(ExecutorStart uprobe; QueryDesc.plannedstmt=%d, "
+                        "PlannedStmt.queryId=%d, QueryDesc.sourceText=%d)\n",
+                        d->pg13_qd_plannedstmt_off, d->pg13_ps_queryid_off,
+                        d->pg13_qd_sourcetext_off);
+        } else if (d->view == PGWT_VIEW_QUERY_EVENT) {
+            if (!have_off)
+                fprintf(stderr,
+                        "FATAL: query_event unavailable on PG13 — no known "
+                        "query-attribution offsets for this architecture\n");
+            else
+                fprintf(stderr,
+                        "FATAL: query_event unavailable on PG13 — requires "
+                        "pg_stat_statements (not loaded in this instance).\n"
+                        "  Add pg_stat_statements to shared_preload_libraries "
+                        "and restart PostgreSQL.\n");
+            return -1;
+        } else if (d->verbose) {
+            fprintf(stderr,
+                    "INFO: PG13 query attribution unavailable (requires "
+                    "pg_stat_statements%s) — query views disabled\n",
+                    have_off ? "; not loaded" : "; unknown offsets");
+        }
+    }
+
     if (d->st_query_id_offset > 0) {
         if (d->verbose)
             fprintf(stderr, "INFO: st_query_id offset: %d (PG%d)\n",
                     d->st_query_id_offset, d->pg_major_version);
-    } else {
-        if (d->view == PGWT_VIEW_QUERY_EVENT) {
+    } else if (!d->use_pg13_query_attr) {
+        if (d->view == PGWT_VIEW_QUERY_EVENT && d->pg_major_version != 13) {
             fprintf(stderr, "FATAL: st_query_id offset not found for PG%d — "
                     "query_event view unavailable\n"
                     "  Hint: install postgresql-%d-dbgsym for DWARF-based detection\n",
                     d->pg_major_version, d->pg_major_version);
             return -1;
         }
-        if (d->verbose)
+        if (d->verbose && d->pg_major_version != 13)
             fprintf(stderr, "INFO: st_query_id offset not available — "
                     "query_event view disabled\n");
     }

--- a/src/discovery.h
+++ b/src/discovery.h
@@ -37,6 +37,31 @@ int pgwt_detect_pg_version(const char *pg_binary);
  * Returns offset in bytes, or 0 if unavailable. */
 int pgwt_detect_query_id_offset(const char *pg_binary, int pg_major);
 
+/* PG13 query-attribution offsets (Route B1 via pg_stat_statements).
+ * PG13 has no in-core query_id; when pg_stat_statements is loaded its
+ * post_parse_analyze hook populates the core PlannedStmt.queryId field, which
+ * matches pg_stat_statements.queryid. We uprobe ExecutorStart(QueryDesc*) and
+ * walk QueryDesc->plannedstmt->queryId; QueryDesc->sourceText gives the text.
+ * Offsets are header-derived (postgresql13-devel, x86_64) since PG13 is EOL
+ * and has no debuginfo anywhere. All fields 0 => not available. */
+struct pgwt_pg13_query_offsets {
+    int querydesc_plannedstmt;  /* offsetof(QueryDesc, plannedstmt) */
+    int plannedstmt_queryid;    /* offsetof(PlannedStmt, queryId)   */
+    int querydesc_sourcetext;   /* offsetof(QueryDesc, sourceText)  */
+};
+
+/* Fill header-derived PG13 query-attribution offsets for the given major
+ * version on x86_64. Returns 1 if a known layout was filled, 0 otherwise
+ * (caller leaves query attribution disabled). */
+int pgwt_detect_pg13_query_offsets(int pg_major,
+                                   struct pgwt_pg13_query_offsets *out);
+
+/* Detect whether pg_stat_statements is loaded into the running postmaster.
+ * Scans /proc/<postmaster_pid>/maps for pg_stat_statements.so — no DB
+ * connection or auth needed, works regardless of port. Returns 1 if loaded,
+ * 0 if not, -1 if the maps file could not be read. */
+int pgwt_detect_pgss_loaded(pid_t postmaster_pid);
+
 /* offsetof(PGPROC, wait_event_info) for a given PG major version on x86_64.
  * Used on PG<17, where the daemon resolves the MyProc (PGPROC*) global and
  * adds this offset to reach each backend's wait_event_info. Header-derived

--- a/tests/test_pg13_resolve.c
+++ b/tests/test_pg13_resolve.c
@@ -57,6 +57,36 @@ int main(void)
     /* Unreadable address -> -1 (transient read error, not a hard reject). */
     CHECK(pgwt_validate_wait_addr(self, 0x1) == -1, "unreadable addr -> -1");
 
+    /* ── PG13 query-attribution offsets (Route B1) ──────────────────
+     * Header-derived from postgresql13-devel (x86_64), confirmed via an
+     * offsetof() probe against 13.23: QueryDesc.plannedstmt=8,
+     * PlannedStmt.queryId=8, QueryDesc.sourceText=16. The BPF uprobe walks
+     * QueryDesc->plannedstmt->queryId; sourceText gives the query text. */
+    struct pgwt_pg13_query_offsets qo;
+    int have13 = pgwt_detect_pg13_query_offsets(13, &qo);
+#if defined(__x86_64__)
+    CHECK(have13 == 1, "PG13 query offsets available on x86_64");
+    CHECK(qo.querydesc_plannedstmt == 8, "QueryDesc.plannedstmt == 8");
+    CHECK(qo.plannedstmt_queryid   == 8, "PlannedStmt.queryId == 8");
+    CHECK(qo.querydesc_sourcetext  == 16, "QueryDesc.sourceText == 16");
+#else
+    CHECK(have13 == 0, "non-x86_64: PG13 query offsets unavailable");
+#endif
+    /* Unknown/unsupported version: no offsets, all zeroed, fail safe. */
+    struct pgwt_pg13_query_offsets qo99;
+    CHECK(pgwt_detect_pg13_query_offsets(99, &qo99) == 0, "unknown version -> 0");
+    CHECK(qo99.querydesc_plannedstmt == 0 && qo99.plannedstmt_queryid == 0
+          && qo99.querydesc_sourcetext == 0, "unknown version offsets zeroed");
+    CHECK(pgwt_detect_pg13_query_offsets(13, NULL) == 0, "NULL out -> 0 (no crash)");
+
+    /* ── pgss detection (gating) ────────────────────────────────────
+     * This test process does NOT load pg_stat_statements, so detection on
+     * our own pid must report "not loaded" (0). A bad pid -> -1 (read error).
+     * The "loaded" case is covered by the live PG13 validation, where the
+     * postmaster's maps contain pg_stat_statements.so. */
+    CHECK(pgwt_detect_pgss_loaded(self) == 0, "pgss not loaded in this process -> 0");
+    CHECK(pgwt_detect_pgss_loaded(0x7fffffff) == -1, "unreadable maps -> -1");
+
     printf("\n%d/%d tests passed\n", ok, run);
     return (ok == run) ? 0 : 1;
 }


### PR DESCRIPTION
## Summary

PR 2 of PG13 support (Track D / Phase D3(c)). PR 1 (PG13 wait **capture** — MyProc resolution + name tables) is on master; this PR makes **query attribution** work on PG13 so the `query_event` view, per-query AAS, and query drill-downs work in **both tiers** (full + sampled).

PG13 has no in-core `query_id` (`st_query_id` arrived in PG14). Route **B1**: when `pg_stat_statements` is loaded, its `post_parse_analyze` hook populates the core `PlannedStmt.queryId` field, and that value **matches `pg_stat_statements.queryid`** (validated in the D3(c) feasibility probe at `ExecutorStart` entry).

## Uprobe + offset design

- **Uprobe `ExecutorStart`** (arg0 = `QueryDesc *`). Walk
  `queryDesc->plannedstmt` (`+8`) `->queryId` (`+8`, uint64) and store it in the **same `state_map` query_id slot** the PG17+ `pgstat_report_query_id` uprobe uses. **One uprobe per query, not per event.**
- **Query text** comes from `queryDesc->sourceText` (`+16`, `const char*`), captured once per query_id (existing `seen_query_ids` dedup) and emitted on `lifecycle_rb` — the same consumer as the PG17+ `debug_query_string` path.
- **Offsets are header-derived** from `postgresql13-devel` (13.23, x86_64) via an `offsetof()` probe — `QueryDesc.plannedstmt=8`, `PlannedStmt.queryId=8`, `QueryDesc.sourceText=16`. PG13 is EOL with **no debuginfo anywhere**, so headers (not DWARF) are the authoritative source. `ExecutorStart` is resolved at runtime from `.dynsym` (survives stripping). A zero `queryId` leaves the slot untouched (no bogus 0). Unit-tested offset table with fail-safe defaults.

## Feeds the existing pipeline (both tiers, unchanged)

The uprobe writes into `state_map[pid].last_query_id`. The **full tier** watchpoint reads it per event; the **sampled tier** sampler reads it at 10 Hz (`lookup_query_id`) and attaches it to each SAMPLES record (`pgwt_sampler_build_batch`). No per-tier code change — both tiers pick up the cached id automatically.

## pgss gating / unavailable path

Active only on **PG13 (MyProc path) AND `pg_stat_statements` loaded**. Detection scans `/proc/<postmaster>/maps` for `pg_stat_statements.so` (no DB/auth needed). Graceful degradation:
- pgss present → B1 path active.
- pgss absent + `--view query_event` → **clean FATAL** naming the requirement (replaces PR1's blanket PG<14 query-disabled WARN) — not a silent empty.
- pgss absent + other views → verbose INFO, no crash.
- `MyBEEntry` (not exported in PG13's `.dynsym`, and unused by B1) is no longer fatal on PG13.

PG17+ path is **unchanged** (native `query_id`).

## Live evidence (PG13.23 + pgss, port 5433)

Query_ids captured by the tracer **match `pg_stat_statements.queryid`** in **both tiers** (validated via recorded trace + `pgwt-server top_queries`):

```
===== TIER: --mode full =====
  INFO: PG13 query attribution via pg_stat_statements (ExecutorStart uprobe;
        QueryDesc.plannedstmt=8, PlannedStmt.queryId=8, QueryDesc.sourceText=16)
  OVERLAP (tracer ∩ pgss): 5 ids
    580257896393702283   INSERT INTO pgbench_history (...)
    3970434753414870764  UPDATE pgbench_branches SET bbalance = ...
    4929713118402706566  UPDATE pgbench_tellers SET tbalance = ...
    7695062737022374142  UPDATE pgbench_accounts SET abalance = ...
  RESULT: PASS (full tier)

===== TIER: --mode sampled =====
  INFO: attached query_id uprobe (sampled mode)
  OVERLAP (tracer ∩ pgss): 3 ids   RESULT: PASS (sampled tier)
==== SUMMARY: full=PASS sampled=PASS ====
```

Live full-mode `query_event` view on PG13 also shows the CPU query_id `1726910080662187274`, matching pgss's `select count(*) from generate_series($1,$2) g`. Per-query wait profiles + text appear.

## PG18 no-regression (native query_id, port 5432)

- `test_query_event` — **15/15 PASS**
- `test_accuracy` — **11/11 PASS**
- `test_control` — **16/16 PASS**

## Tests

`test_pg13_resolve` extended (already in `tests/Makefile`, `run_all.sh`, and CI's C-unit list): offset table (8/8/16 on x86_64; unknown version → 0/zeroed; NULL → no crash) and pgss detection (no-pgss process → 0; bad maps → -1). **19/19 pass.**

## Documented gap

Utility statements (CHECKPOINT/VACUUM/DDL) go through `ProcessUtility`, not `ExecutorStart`, so they are not attributed — same gap as other PG versions; an optional `ProcessUtility` uprobe can close it later.