### PR TITLE
Fix PG13 query attribution: probe standard_ExecutorStart, not ExecutorStart

### DIFF
--- a/src/bpf/pg_wait_tracer.bpf.c
+++ b/src/bpf/pg_wait_tracer.bpf.c
@@ -38,11 +38,12 @@ volatile const u32 lightweight_mode = 0;   /* 0=full trace, 1=lightweight (no ri
 volatile const u32 skip_query_id = 0;      /* 1=skip query_id reads (saves 1 probe_read) */
 volatile const u64 debug_query_string_addr = 0; /* VA of debug_query_string global */
 
-/* PG13 query attribution (Route B1): ExecutorStart(QueryDesc*) uprobe walks
- * QueryDesc->plannedstmt->queryId (populated by pg_stat_statements' hook) into
- * the state_map query_id slot. 0 => disabled (the PG17+ pgstat_report_query_id
- * uprobe is used instead). Offsets are header-derived (postgresql13-devel). */
-volatile const u32 pg13_query_attr = 0;          /* 1 = ExecutorStart path active */
+/* PG13 query attribution (Route B1): standard_ExecutorStart(QueryDesc*) uprobe
+ * walks QueryDesc->plannedstmt->queryId (populated by pg_stat_statements' hook)
+ * into the state_map query_id slot. 0 => disabled (the PG17+
+ * pgstat_report_query_id uprobe is used instead). Offsets are header-derived
+ * (postgresql13-devel). */
+volatile const u32 pg13_query_attr = 0;          /* 1 = std_ExecutorStart path active */
 volatile const u32 pg13_qd_plannedstmt_off = 0;  /* offsetof(QueryDesc, plannedstmt) */
 volatile const u32 pg13_ps_queryid_off = 0;      /* offsetof(PlannedStmt, queryId) */
 volatile const u32 pg13_qd_sourcetext_off = 0;   /* offsetof(QueryDesc, sourceText) */
@@ -478,11 +479,16 @@ int on_report_query_id(struct pt_regs *ctx)
     return 0;
 }
 
-/* ── Program 10: uprobe on ExecutorStart (PG13 query attribution) ──
+/* ── Program 10: uprobe on standard_ExecutorStart (PG13 query attribution) ──
  * PG13 has no in-core query_id and no pgstat_report_query_id. When
  * pg_stat_statements is loaded its post_parse_analyze hook populates
  * PlannedStmt.queryId (matching pg_stat_statements.queryid) before
- * ExecutorStart fires. arg0 = QueryDesc *queryDesc; walk
+ * the executor starts. We probe standard_ExecutorStart rather than the
+ * public ExecutorStart wrapper: with pgss loaded ExecutorStart_hook is set,
+ * so ExecutorStart is a trampoline that tail-jumps into the hook chain and an
+ * entry uprobe on it does not fire; standard_ExecutorStart is the real
+ * function, always reached at the bottom of the hook chain.
+ * arg0 = QueryDesc *queryDesc; walk
  *   queryDesc->plannedstmt (+pg13_qd_plannedstmt_off)
  *           ->queryId       (+pg13_ps_queryid_off, uint64)
  * and store it in the SAME state_map slot the PG17+ uprobe uses, so the

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -291,11 +291,22 @@ int pgwt_daemon_init(struct pgwt_daemon *d)
          *   PG14+ : pgstat_report_query_id (arg = query_id), bypassing shmem.
          *   PG13  : no in-core query_id / no pgstat_report_query_id. Instead,
          *           with pg_stat_statements loaded (use_pg13_query_attr),
-         *           uprobe ExecutorStart(QueryDesc*) and walk
+         *           uprobe standard_ExecutorStart(QueryDesc*) and walk
          *           queryDesc->plannedstmt->queryId. Feeds the SAME state_map
-         *           slot, so the sampler + watchpoint pipelines are unchanged. */
+         *           slot, so the sampler + watchpoint pipelines are unchanged.
+         *
+         *           We probe standard_ExecutorStart, NOT the public
+         *           ExecutorStart wrapper. With pg_stat_statements loaded,
+         *           ExecutorStart_hook is set, so the ExecutorStart wrapper is
+         *           a tiny trampoline that tail-jumps (jmp *hook) into the
+         *           hook chain; an entry uprobe placed on that trampoline does
+         *           not fire reliably (the tail-jump never returns through the
+         *           wrapper body). standard_ExecutorStart is the real function
+         *           and is always reached at the bottom of the hook chain
+         *           (pgss's hook calls it), by which point pgss has already
+         *           populated PlannedStmt.queryId. Same arg0 (QueryDesc*). */
         if (d->use_pg13_query_attr) {
-            uint64_t es_va = pgwt_find_symbol_offset(bin, "ExecutorStart");
+            uint64_t es_va = pgwt_find_symbol_offset(bin, "standard_ExecutorStart");
             uint64_t es_off = es_va > 0x400000 ? es_va - 0x400000 : es_va;
             if (es_off) {
                 LIBBPF_OPTS(bpf_uprobe_opts, uprobe_opts, .retprobe = false);
@@ -303,14 +314,14 @@ int pgwt_daemon_init(struct pgwt_daemon *d)
                     bpf_program__attach_uprobe_opts(d->skel->progs.on_executor_start,
                                                     -1, bin, es_off, &uprobe_opts);
                 if (d->verbose)
-                    fprintf(stderr, "INFO: ExecutorStart at offset 0x%lx "
+                    fprintf(stderr, "INFO: standard_ExecutorStart at offset 0x%lx "
                             "(PG13 query attribution via pg_stat_statements)\n",
                             (unsigned long)es_off);
                 if (!d->skel->links.on_executor_start)
-                    fprintf(stderr, "WARN: could not attach ExecutorStart uprobe "
-                            "(PG13 query attribution disabled)\n");
+                    fprintf(stderr, "WARN: could not attach standard_ExecutorStart "
+                            "uprobe (PG13 query attribution disabled)\n");
             } else {
-                fprintf(stderr, "WARN: symbol 'ExecutorStart' not found "
+                fprintf(stderr, "WARN: symbol 'standard_ExecutorStart' not found "
                         "(PG13 query attribution disabled)\n");
             }
         } else {

--- a/src/discovery.c
+++ b/src/discovery.c
@@ -859,8 +859,8 @@ int pgwt_discover(struct pgwt_daemon *d)
      * PG13 has no in-core query_id (st_query_id was added in PG14), so the
      * detection above returns 0. Instead, if pg_stat_statements is loaded its
      * post_parse_analyze hook populates PlannedStmt.queryId; we uprobe
-     * ExecutorStart and walk QueryDesc->plannedstmt->queryId into the same
-     * state_map slot. This is gated on pgss being loaded. */
+     * standard_ExecutorStart and walk QueryDesc->plannedstmt->queryId into the
+     * same state_map slot. This is gated on pgss being loaded. */
     if (d->use_myproc && d->pg_major_version == 13) {
         struct pgwt_pg13_query_offsets qo;
         int have_off = pgwt_detect_pg13_query_offsets(d->pg_major_version, &qo);
@@ -875,7 +875,7 @@ int pgwt_discover(struct pgwt_daemon *d)
             if (d->verbose)
                 fprintf(stderr,
                         "INFO: PG13 query attribution via pg_stat_statements "
-                        "(ExecutorStart uprobe; QueryDesc.plannedstmt=%d, "
+                        "(standard_ExecutorStart uprobe; QueryDesc.plannedstmt=%d, "
                         "PlannedStmt.queryId=%d, QueryDesc.sourceText=%d)\n",
                         d->pg13_qd_plannedstmt_off, d->pg13_ps_queryid_off,
                         d->pg13_qd_sourcetext_off);


### PR DESCRIPTION
## Problem

On PG13, query attribution (Route B1, the `pg_stat_statements` path added in PR #28) captured **zero** query_ids. `--view query_event` under active pgbench load always showed `(no query data yet — ensure compute_query_id = on/auto)` across every interval, even though `pg_stat_statements` held valid non-zero queryids for the running statements. Detection and attach all reported success (offsets resolved, pgss detected, uprobe attached), so the failure was silent. PG18 (PG17+ `pgstat_report_query_id` path) was unaffected.

## Root cause

The uprobe was attached to the public `ExecutorStart` symbol. When `pg_stat_statements` is loaded it sets `ExecutorStart_hook`, so on PG13 the `ExecutorStart` symbol is a tiny trampoline:

```
ExecutorStart:
    endbr64
    mov    ExecutorStart_hook, %rax
    test   %rax, %rax
    je     standard_ExecutorStart   ; hook NULL
    jmp    *%rax                     ; hook set -> tail-call
```

With the hook set, `ExecutorStart` tail-jumps into the hook chain and an entry uprobe placed on that trampoline never fires (the tail-jump never returns through the wrapper body).

Confirmed with `bpf_printk` + `trace_pipe` on the running PGDG PG13.23 build under heavy pgbench load:
- `on_executor_start` entry printk fired **0** times.
- The watchpoint printk fired **hundreds** of times in the same run (proving the printk plumbing and the rest of the pipeline work).
- Re-pointing the same probe at `standard_ExecutorStart` made it fire and read the exact queryids reported by `pg_stat_statements` (e.g. `SELECT abalance FROM pgbench_accounts` → `-5756345338735105643`).

Offsets, binary path and offset math were all verified correct and were **not** the cause.

## Fix

Attach the uprobe to `standard_ExecutorStart` instead of `ExecutorStart`. It:
- has the identical signature (`arg0 = QueryDesc *`),
- is always reached at the bottom of the hook chain (pgss's hook calls it),
- runs after pgss has populated `PlannedStmt.queryId`.

The BPF handler, struct offsets, offset math and state_map slot are all unchanged, so the full (watchpoint) and sampled pipelines pick up the query_id exactly as before. No change to the PG14+/PG17+ `pgstat_report_query_id` path.

## Verification (PGDG PG13.23 / PG18, AlmaLinux 9)

- **PG13 full mode**: `query_event` now shows query_ids matching `pg_stat_statements` under pgbench load (e.g. `-5756345338735105643`, `5982367233693820590`, `-4596197266514679381`, `-6481462898666369959`, `758819355974535140` — all present in `pg_stat_statements`).
- **PG18 full mode**: no regression — `query_event` still shows query_ids matching `pg_stat_statements`.
- **Unit tests**: `test_pg13_resolve` 19/19, plus the full C test suite green (`test_cmdline`, `test_wait_event`, `test_sampler`, `test_event_writer` 5060/5060, `test_event_reader`, `test_bucket`, `test_anomaly`, `test_coop`, `test_trace_v2`, `test_concurrent_rw`).

Note: sampled-mode `--view` not rendering live data is a separate, pre-existing sampler-accumulator issue (affects all views, including `system_event`, on this base) tracked/fixed on its own branch; the query_id uprobe attaches correctly in sampled mode and feeds the same state_map slot, so query_event will render in sampled mode once that fix lands.
