### PR TITLE
T0: real-PG CI capture smoke + test-gate hardening (TST-1..8)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,13 @@ jobs:
     # if present, --mode full is asserted as hard as tiered; if absent, the
     # full-mode section is skipped LOUDLY in the job summary while the
     # tiered/sampled assertions (the shipped default) remain the hard gate.
+    # Matrix: PG 13 / 17 / 18 are the SUPPORTED versions (README+INSTALL)
+    # and get the full capture assertions. PG 16 is NOT yet supported
+    # (PG<17 needs a header-derived offsetof(PGPROC, wait_event_info) and
+    # only PG13's is validated — Track D owns 14-16): its cell asserts the
+    # fail-safe contract instead — the tracer must REFUSE loudly, never
+    # trace garbage (verified empirically: it exits with a FATAL). When
+    # Track D lands, flip the cell to the full assertions.
     name: capture-smoke (PG ${{ matrix.pg }})
     runs-on: ubuntu-latest
     strategy:
@@ -175,8 +182,14 @@ jobs:
       - name: Run capture smoke (tiered hard; full if watchpoints available)
         run: |
           V=${{ matrix.pg }}
+          # PG16 = unsupported version: assert the loud-refusal contract.
+          FLAGS=""
+          [ "$V" = "16" ] && FLAGS="--expect-unsupported"
+          # sudo strips the environment: pass PATH (psql/pgbench) and
+          # GITHUB_STEP_SUMMARY (the loud watchpoint-skip note) through.
           sudo env "PATH=/usr/lib/postgresql/$V/bin:$PATH" \
-            tests/ci_smoke.sh --pg-version "$V"
+            "GITHUB_STEP_SUMMARY=$GITHUB_STEP_SUMMARY" \
+            tests/ci_smoke.sh --pg-version "$V" $FLAGS
 
   web-ui:
     name: web-ui

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,17 +62,11 @@ jobs:
         run: make -C tests
 
       - name: Run C unit tests
-        run: |
-          tests/test_wait_event
-          tests/test_cmdline
-          tests/test_bucket
-          tests/test_event_writer
-          tests/test_event_reader
-          tests/test_trace_v2
-          tests/test_sampler
-          tests/test_anomaly
-          tests/test_coop
-          tests/test_pg13_resolve
+        # The test list lives in tests/unit_tests.list — the single source of
+        # truth shared with tests/run_all.sh (TST-3: the two hand-maintained
+        # lists had drifted; test_event_writer/test_event_reader were missing
+        # from run_all and test_concurrent_rw ran nowhere).
+        run: make -C tests check
 
       - name: Run synthetic data tests
         run: |
@@ -88,6 +82,101 @@ jobs:
         # transport / selection modules are Node-testable without a browser.
         # A builder off-by-one fails here in milliseconds, no Playwright needed.
         run: node --test 'tests/web_unit/*.test.mjs'
+
+  capture-smoke:
+    # Phase T0 (Trust Milestone, TST-1/2): run the REAL capture path against
+    # a real PostgreSQL on the runner. Every field escape to date (#8, #24,
+    # #30, #31) lived in the capture/discovery slice that the other jobs
+    # never execute; this job's entire purpose is to go red when capture
+    # silently records nothing.
+    #
+    # Watchpoints (perf hardware breakpoints) may be unavailable on hosted
+    # runners' hypervisor — tests/ci_smoke.sh probes for them empirically:
+    # if present, --mode full is asserted as hard as tiered; if absent, the
+    # full-mode section is skipped LOUDLY in the job summary while the
+    # tiered/sampled assertions (the shipped default) remain the hard gate.
+    name: capture-smoke (PG ${{ matrix.pg }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        pg: [13, 16, 17, 18]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang llvm libbpf-dev libelf-dev \
+            zlib1g-dev liblz4-dev linux-tools-common
+          # Same bpftool fallback as build-and-unit: the runner's HWE azure
+          # kernel may ship linux-tools without a bpftool binary.
+          if bpftool version >/dev/null 2>&1; then
+            BPFTOOL=$(command -v bpftool)
+          else
+            git clone --depth 1 --branch v7.5.0 --recurse-submodules \
+              https://github.com/libbpf/bpftool.git /tmp/bpftool
+            make -C /tmp/bpftool/src -j"$(nproc)"
+            BPFTOOL=/tmp/bpftool/src/bpftool
+          fi
+          "$BPFTOOL" version
+          echo "BPFTOOL=$BPFTOOL" >> "$GITHUB_ENV"
+          test -r /sys/kernel/btf/vmlinux
+
+      - name: Install PostgreSQL ${{ matrix.pg }} (PGDG apt)
+        run: |
+          set -x
+          V=${{ matrix.pg }}
+          # Stop and drop any preinstalled clusters so ours owns port 5432.
+          sudo systemctl stop postgresql || true
+          sudo apt-get install -y postgresql-common
+          pg_lsclusters -h | awk '{print $1, $2}' | while read -r ver name; do
+            sudo pg_dropcluster --stop "$ver" "$name" || true
+          done
+          sudo /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -y
+          # PG13 is EOL: when the live PGDG repo no longer carries it, fall
+          # back to the PGDG apt archive (same signing key).
+          if ! apt-cache show "postgresql-$V" >/dev/null 2>&1; then
+            echo "postgresql-$V not in the live PGDG repo — adding apt-archive"
+            echo "deb https://apt-archive.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" \
+              | sudo tee /etc/apt/sources.list.d/pgdg-archive.list
+            sudo apt-get update
+          fi
+          sudo apt-get install -y "postgresql-$V" "postgresql-contrib-$V"
+
+      - name: Configure + start PostgreSQL ${{ matrix.pg }}
+        run: |
+          set -ex
+          V=${{ matrix.pg }}
+          # The postgresql-$V package auto-creates cluster "main" unless one
+          # already existed (e.g. the preinstalled PG16 we dropped above).
+          if ! pg_lsclusters -h | awk -v v="$V" '$1 == v && $2 == "main"' | grep -q .; then
+            sudo pg_createcluster "$V" main
+          fi
+          sudo pg_conftool "$V" main set port 5432
+          # pg_stat_statements everywhere:
+          #  - PG13: REQUIRED for query attribution (no in-core query_id;
+          #    the tracer walks PlannedStmt.queryId that pgss populates).
+          #  - PG14+: compute_query_id=on so st_query_id is populated.
+          sudo pg_conftool "$V" main set shared_preload_libraries pg_stat_statements
+          if [ "$V" -ge 14 ]; then
+            sudo pg_conftool "$V" main set compute_query_id on
+          fi
+          # Tests connect as "psql -U postgres" from root: trust local auth.
+          sudo sed -i -E 's/(peer|scram-sha-256|md5)$/trust/' \
+            "/etc/postgresql/$V/main/pg_hba.conf"
+          sudo pg_ctlcluster "$V" main start
+          psql -U postgres -d postgres -c "CREATE EXTENSION IF NOT EXISTS pg_stat_statements"
+          psql -U postgres -d postgres -tAc "SELECT version()"
+
+      - name: Build (BPF tracer + pgwt-server)
+        run: make
+
+      - name: Run capture smoke (tiered hard; full if watchpoints available)
+        run: |
+          V=${{ matrix.pg }}
+          sudo env "PATH=/usr/lib/postgresql/$V/bin:$PATH" \
+            tests/ci_smoke.sh --pg-version "$V"
 
   web-ui:
     name: web-ui

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,9 @@ tests/test_trace_v2
 tests/test_sampler
 tests/test_anomaly
 tests/test_coop
+tests/test_pg13_resolve
+tests/test_discovery_pie
+tests/test_discovery_nopie
 tests/dump_markers
 tests/gen_test_traces
 tests/gen_bench_traces

--- a/src/discovery.c
+++ b/src/discovery.c
@@ -155,14 +155,16 @@ uint64_t pgwt_resolve_symbol(const char *binary, const char *symbol,
     return sym_val - elf_base + load_base;
 }
 
-uint64_t pgwt_find_load_base(pid_t pid, const char *binary_basename)
+/* Parse a maps file (the /proc/<pid>/maps format) and return the load base
+ * for the given binary basename. Split out from pgwt_find_load_base so unit
+ * tests can drive it with committed fixture files (tests/test_discovery.c —
+ * the #24 regression class: EL8 non-PIE vs EL9/Ubuntu PIE layouts). */
+uint64_t pgwt_find_load_base_in_maps(const char *maps_path,
+                                     const char *binary_basename)
 {
-    char path[64];
-    snprintf(path, sizeof(path), "/proc/%d/maps", pid);
-
-    FILE *f = fopen(path, "r");
+    FILE *f = fopen(maps_path, "r");
     if (!f) {
-        fprintf(stderr, "Cannot open %s: %s\n", path, strerror(errno));
+        fprintf(stderr, "Cannot open %s: %s\n", maps_path, strerror(errno));
         return 0;
     }
 
@@ -192,9 +194,16 @@ uint64_t pgwt_find_load_base(pid_t pid, const char *binary_basename)
     fclose(f);
 
     if (base == 0)
-        fprintf(stderr, "Load base for '%s' not found in /proc/%d/maps\n",
-                binary_basename, pid);
+        fprintf(stderr, "Load base for '%s' not found in %s\n",
+                binary_basename, maps_path);
     return base;
+}
+
+uint64_t pgwt_find_load_base(pid_t pid, const char *binary_basename)
+{
+    char path[64];
+    snprintf(path, sizeof(path), "/proc/%d/maps", pid);
+    return pgwt_find_load_base_in_maps(path, binary_basename);
 }
 
 uint64_t pgwt_read_pointer(pid_t pid, uint64_t addr)

--- a/src/discovery.c
+++ b/src/discovery.c
@@ -782,13 +782,19 @@ int pgwt_discover(struct pgwt_daemon *d)
             if (d->verbose)
                 fprintf(stderr, "INFO: loaded dynamic event names from PG%d\n",
                         d->pg_major_version);
-            /* Write sidecar for pgwt-server to use later */
-            if (d->trace_dir)
-                pgwt_write_names_json(d->trace_dir);
         } else if (d->verbose) {
             fprintf(stderr, "INFO: dynamic event name query failed, using hardcoded tables\n");
         }
     }
+
+    /* Write the name sidecar for pgwt-server whenever we record a trace —
+     * ALWAYS, not only when dynamic names loaded. The sidecar must carry
+     * the mapping the trace is written with (dynamic on PG17+, the
+     * version-selected hardcoded tables otherwise); without it a PG13
+     * trace was silently decoded with PG18 tables by pgwt-server (the #8
+     * mislabeling class — caught by the CI capture-smoke PG13 cell). */
+    if (d->trace_dir)
+        pgwt_write_names_json(d->trace_dir);
 
     /* Extract basename for /proc/pid/maps matching */
     const char *base = strrchr(binary, '/');

--- a/src/discovery.h
+++ b/src/discovery.h
@@ -19,6 +19,13 @@ uint64_t pgwt_find_symbol_offset(const char *binary, const char *symbol);
 /* Find the load base address of the binary in the target process. */
 uint64_t pgwt_find_load_base(pid_t pid, const char *binary_basename);
 
+/* Same, but against an explicit maps file (the /proc/<pid>/maps format).
+ * pgwt_find_load_base() is a thin wrapper over this; the split exists so
+ * unit tests can drive the parser with committed fixture files
+ * (tests/test_discovery.c — the #24 load-base regression class). */
+uint64_t pgwt_find_load_base_in_maps(const char *maps_path,
+                                     const char *binary_basename);
+
 /* Resolve a symbol to its runtime virtual address in the target process.
  * Handles both PIE (ET_DYN) and non-PIE (ET_EXEC) binaries correctly. */
 uint64_t pgwt_resolve_symbol(const char *binary, const char *symbol,

--- a/src/wait_event.c
+++ b/src/wait_event.c
@@ -858,13 +858,19 @@ int pgwt_write_names_json(const char *trace_dir)
         const char *cname = class_names[c];
         if (!cname) continue;
 
+        /* Gate on dyn_loaded, NOT on dyn_max alone: dyn_max[] is
+         * zero-initialized in a fresh process (dyn_clear() sets it to -1
+         * but only ever runs on a dynamic load), so a raw dyn_max check
+         * made a no-dynamic-names daemon dump a bogus one-empty-entry
+         * table per class instead of the hardcoded fallback. */
+        int use_dyn = (dyn_loaded && dyn_max[c] >= 0);
         const char **htbl = NULL;
         int hmax = -1;
-        if (dyn_max[c] < 0 && !active_class_table(c, &htbl, &hmax))
+        if (!use_dyn && !active_class_table(c, &htbl, &hmax))
             continue;
 
         cJSON *arr = cJSON_CreateArray();
-        if (dyn_max[c] >= 0) {
+        if (use_dyn) {
             for (int i = 0; i <= dyn_max[c]; i++) {
                 const char *n = dyn_names[c][i];
                 cJSON_AddItemToArray(arr, cJSON_CreateString(n ? n : ""));

--- a/src/wait_event.c
+++ b/src/wait_event.c
@@ -815,6 +815,24 @@ int pgwt_load_event_names_from_buffer(const char *data)
     return 0;
 }
 
+/* Return the ACTIVE (version-selected) id→name table + max index for a
+ * class byte — what the daemon is actually decoding with right now (the
+ * PG13 tables on PG13, etc.), unlike hardcoded_class_table() which always
+ * returns the PG17/18-shared tables for reverse lookup. */
+static int active_class_table(int cb, const char ***tbl, int *max)
+{
+    switch (cb) {
+    case PG_WAIT_IO:       *tbl = io_events;              *max = io_events_max;              return 1;
+    case PG_WAIT_LOCK:     *tbl = lock_events;            *max = LOCK_EVENTS_MAX;            return 1;
+    case PG_WAIT_TIMEOUT:  *tbl = timeout_events_active;  *max = timeout_events_active_max;  return 1;
+    case PG_WAIT_ACTIVITY: *tbl = activity_events_active; *max = activity_events_active_max; return 1;
+    case PG_WAIT_CLIENT:   *tbl = client_events_active;   *max = client_events_active_max;   return 1;
+    case PG_WAIT_IPC:      *tbl = ipc_events_active;      *max = ipc_events_active_max;      return 1;
+    case PG_WAIT_LWLOCK:   *tbl = lwlock_events_active;   *max = lwlock_events_active_max;   return 1;
+    default:               return 0;
+    }
+}
+
 int pgwt_write_names_json(const char *trace_dir)
 {
     char path[512];
@@ -829,16 +847,33 @@ int pgwt_write_names_json(const char *trace_dir)
         NULL, NULL, NULL, NULL
     };
 
+    /* The sidecar records the mapping the trace was WRITTEN with, so the
+     * reader (pgwt-server) never decodes with mismatched tables. Prefer
+     * the dynamically-loaded names (PG17+, exact for this build); fall
+     * back to the active version-selected hardcoded tables otherwise —
+     * without this, a PG13 trace had no sidecar at all and pgwt-server
+     * silently decoded PG13 ids with PG18 tables (the #8 mislabeling
+     * class; caught by the CI capture-smoke PG13 cell). */
     for (int c = 0; c < 16; c++) {
-        if (dyn_max[c] < 0) continue;
-
         const char *cname = class_names[c];
         if (!cname) continue;
 
+        const char **htbl = NULL;
+        int hmax = -1;
+        if (dyn_max[c] < 0 && !active_class_table(c, &htbl, &hmax))
+            continue;
+
         cJSON *arr = cJSON_CreateArray();
-        for (int i = 0; i <= dyn_max[c]; i++) {
-            const char *n = dyn_names[c][i];
-            cJSON_AddItemToArray(arr, cJSON_CreateString(n ? n : ""));
+        if (dyn_max[c] >= 0) {
+            for (int i = 0; i <= dyn_max[c]; i++) {
+                const char *n = dyn_names[c][i];
+                cJSON_AddItemToArray(arr, cJSON_CreateString(n ? n : ""));
+            }
+        } else {
+            for (int i = 0; i <= hmax; i++) {
+                const char *n = htbl[i];
+                cJSON_AddItemToArray(arr, cJSON_CreateString(n ? n : ""));
+            }
         }
         cJSON_AddItemToObject(root, cname, arr);
     }

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -12,13 +12,25 @@ LIBBPF_LIB ?= -lbpf
 
 TESTS     = test_wait_event test_cmdline test_event_writer test_event_reader \
             test_trace_v2 test_sampler test_anomaly test_coop test_bucket \
-            test_pg13_resolve \
+            test_pg13_resolve test_discovery_pie test_discovery_nopie \
             gen_test_traces gen_bench_traces test_concurrent_rw cross_validate \
             dump_markers
 
-.PHONY: all clean
+.PHONY: all clean check
 
 all: $(TESTS)
+
+# Run the full C unit suite. The list of tests lives in unit_tests.list —
+# the SINGLE source of truth shared by CI (ci.yml) and tests/run_all.sh
+# (TST-3: two hand-maintained lists had drifted; never maintain a third).
+check: all
+	@fail=0; \
+	while read -r t; do \
+	    case "$$t" in ''|\#*) continue ;; esac; \
+	    echo "=== $$t ==="; \
+	    ./$$t || { echo "FAILED: $$t"; fail=1; }; \
+	done < unit_tests.list; \
+	exit $$fail
 
 test_wait_event: test_wait_event.c $(BUILD)/wait_event.o $(BUILD)/cJSON.o
 	$(CC) $(CFLAGS) -o $@ $^
@@ -43,6 +55,22 @@ test_bucket: test_bucket.c
 test_pg13_resolve: test_pg13_resolve.c ../src/discovery.c \
                    $(BUILD)/wait_event.o $(BUILD)/cJSON.o
 	$(CC) $(CFLAGS) -o $@ $^ -lelf -lz
+
+# test_discovery: load-base + ELF symbol resolution — the #24 regression
+# class (pgwt_find_load_base_in_maps against committed maps fixtures, plus
+# self-resolution of a known global via /proc/self/{exe,maps}). Built TWICE,
+# -pie and -no-pie, because PIE vs non-PIE is exactly the axis #24 broke on;
+# each build asserts (via the ELF header) that the flag actually took effect.
+# Compiles discovery.c directly (BPF-free, needs libelf) — same pattern as
+# test_pg13_resolve.
+DISCOVERY_TEST_DEPS = test_discovery.c ../src/discovery.c \
+                      $(BUILD)/wait_event.o $(BUILD)/cJSON.o
+
+test_discovery_pie: $(DISCOVERY_TEST_DEPS)
+	$(CC) $(CFLAGS) -DPGWT_TEST_EXPECT_PIE=1 -fPIE -pie -o $@ $^ -lelf -lz
+
+test_discovery_nopie: $(DISCOVERY_TEST_DEPS)
+	$(CC) $(CFLAGS) -DPGWT_TEST_EXPECT_PIE=0 -fno-pie -no-pie -o $@ $^ -lelf -lz
 
 # test_trace_v2: format round-trip (v2 typed blocks). Built against the
 # server objects (-DPGWT_SERVER) so it needs no BPF skeleton — buildable on

--- a/tests/ci_smoke.sh
+++ b/tests/ci_smoke.sh
@@ -1,0 +1,151 @@
+#!/bin/bash
+# ci_smoke.sh — real-PostgreSQL capture smoke test wrapper (Phase T0: TST-1/2).
+#
+# The CI capture-smoke job calls this against a freshly-installed PGDG
+# PostgreSQL; it also runs unchanged on any root box with a running PG.
+# It drives tests/test_capture_smoke.py in BOTH capture modes plus the
+# existing full-mode deterministic-accuracy test, and fails if capture
+# records nothing (that is its entire purpose).
+#
+#   tiered (the shipped default) — HARD requirement, always asserted:
+#     sampler capture, live-view feed (PR #30), query attribution (PR #31),
+#     trace-file write + pgwt-server read-back.
+#   full (hardware watchpoints) — depends on the environment: perf hw
+#     breakpoints may be unavailable on some hypervisors. The probe below
+#     DISCOVERS this empirically. If watchpoints work, the full-mode
+#     assertions are just as hard; if they don't, the full-mode section is
+#     skipped LOUDLY (stdout + $GITHUB_STEP_SUMMARY) — never silently.
+#
+# Usage: sudo tests/ci_smoke.sh [--pid POSTMASTER_PID] [--pg-version N]
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+source "$SCRIPT_DIR/testutil.sh"
+
+PM_PID=""
+PG_VERSION=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --pid) PM_PID="$2"; shift 2 ;;
+        --pg-version) PG_VERSION="$2"; shift 2 ;;
+        *) echo "Usage: $0 [--pid POSTMASTER_PID] [--pg-version N]"; exit 1 ;;
+    esac
+done
+
+if [[ $(id -u) -ne 0 ]]; then
+    echo "ERROR: must run as root (sudo)"; exit 1
+fi
+if [[ ! -x "$PROJECT_DIR/pg_wait_tracer" || ! -x "$PROJECT_DIR/pgwt-server" ]]; then
+    echo "ERROR: build first (make)"; exit 1
+fi
+
+if [[ -z "$PM_PID" ]]; then
+    if [[ -n "$PG_VERSION" ]]; then
+        PM_PID=$(find_postmaster --pg-version "$PG_VERSION")
+    else
+        PM_PID=$(find_postmaster)
+    fi
+fi
+if [[ -z "$PM_PID" ]]; then
+    echo "ERROR: cannot find postmaster PID"; exit 1
+fi
+echo "=== ci_smoke (postmaster PID $PM_PID, pg-version ${PG_VERSION:-auto}) ==="
+
+summary() {
+    echo "$1"
+    if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+        echo "$1" >> "$GITHUB_STEP_SUMMARY"
+    fi
+}
+
+# ── Watchpoint availability probe ──────────────────────────────────
+# perf hardware breakpoints (PERF_TYPE_BREAKPOINT) need debug-register
+# support from the hypervisor; discover rather than assume.
+probe_watchpoints() {
+    local src bin
+    src=$(mktemp /tmp/pgwt_wp_probe_XXXXXX.c)
+    bin="${src%.c}"
+    cat > "$src" <<'EOF'
+#include <linux/perf_event.h>
+#include <linux/hw_breakpoint.h>
+#include <sys/syscall.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <errno.h>
+static volatile int target;
+int main(void) {
+    struct perf_event_attr attr;
+    memset(&attr, 0, sizeof(attr));
+    attr.type = PERF_TYPE_BREAKPOINT;
+    attr.size = sizeof(attr);
+    attr.bp_type = HW_BREAKPOINT_W;
+    attr.bp_addr = (unsigned long)&target;
+    attr.bp_len = HW_BREAKPOINT_LEN_4;
+    attr.sample_period = 1;
+    attr.wakeup_events = 1;
+    int fd = syscall(SYS_perf_event_open, &attr, 0, -1, -1, 0);
+    if (fd < 0) { fprintf(stderr, "perf_event_open: %s\n", strerror(errno)); return 1; }
+    close(fd);
+    return 0;
+}
+EOF
+    if ! cc -o "$bin" "$src" 2>/dev/null; then
+        rm -f "$src" "$bin"
+        echo "unknown"; return
+    fi
+    if "$bin" 2>/tmp/pgwt_wp_probe.err; then
+        echo "yes"
+    else
+        echo "no"
+    fi
+    rm -f "$src" "$bin"
+}
+
+WP=$(probe_watchpoints)
+echo "Watchpoint probe: $WP"
+[[ "$WP" == "no" ]] && cat /tmp/pgwt_wp_probe.err 2>/dev/null
+
+overall=0
+
+run_section() {
+    local name="$1"; shift
+    echo ""
+    echo "════════════════════════════════════════"
+    echo "  $name"
+    echo "════════════════════════════════════════"
+    if "$@"; then
+        summary "- PASS: $name"
+    else
+        summary "- **FAIL**: $name"
+        overall=1
+    fi
+}
+
+# ── Tiered mode: the shipped default — always a hard requirement ───
+run_section "capture smoke: --mode tiered (live view + trace file)" \
+    python3 "$SCRIPT_DIR/test_capture_smoke.py" --mode tiered --pid "$PM_PID"
+
+# ── Full mode: hard when watchpoints exist; loud skip when they don't ──
+if [[ "$WP" == "yes" ]]; then
+    run_section "capture smoke: --mode full (live view + trace file)" \
+        python3 "$SCRIPT_DIR/test_capture_smoke.py" --mode full --pid "$PM_PID"
+    run_section "deterministic accuracy: exact counts/durations (--mode full)" \
+        python3 "$SCRIPT_DIR/test_deterministic.py" --pid "$PM_PID"
+else
+    summary "### WARNING: full-mode watchpoint assertions SKIPPED"
+    summary "perf hardware breakpoints are unavailable in this environment"
+    summary "(probe: perf_event_open(PERF_TYPE_BREAKPOINT) failed — see log)."
+    summary "Tiered/sampled assertions above remain the hard gate; full-mode"
+    summary "exactness is validated on real hardware via tests/run_all.sh"
+    summary "--require-live (Trust Milestone standing rule)."
+fi
+
+echo ""
+if [[ $overall -eq 0 ]]; then
+    echo "ci_smoke: ALL SECTIONS PASSED (watchpoints: $WP)"
+else
+    echo "ci_smoke: FAILURES (watchpoints: $WP)"
+fi
+exit $overall

--- a/tests/ci_smoke.sh
+++ b/tests/ci_smoke.sh
@@ -25,11 +25,13 @@ source "$SCRIPT_DIR/testutil.sh"
 
 PM_PID=""
 PG_VERSION=""
+EXPECT_UNSUPPORTED=0
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --pid) PM_PID="$2"; shift 2 ;;
         --pg-version) PG_VERSION="$2"; shift 2 ;;
-        *) echo "Usage: $0 [--pid POSTMASTER_PID] [--pg-version N]"; exit 1 ;;
+        --expect-unsupported) EXPECT_UNSUPPORTED=1; shift ;;
+        *) echo "Usage: $0 [--pid POSTMASTER_PID] [--pg-version N] [--expect-unsupported]"; exit 1 ;;
     esac
 done
 
@@ -51,6 +53,30 @@ if [[ -z "$PM_PID" ]]; then
     echo "ERROR: cannot find postmaster PID"; exit 1
 fi
 echo "=== ci_smoke (postmaster PID $PM_PID, pg-version ${PG_VERSION:-auto}) ==="
+
+summary_early() {
+    echo "$1"
+    [[ -n "${GITHUB_STEP_SUMMARY:-}" ]] && echo "$1" >> "$GITHUB_STEP_SUMMARY" || true
+}
+
+# ── Unsupported-version cell (e.g. PG16 until Track D lands) ───────
+# The contract under test is fail-safe refusal: no known
+# offsetof(PGPROC, wait_event_info) for this version => the tracer must
+# exit non-zero with a loud FATAL, never attach and trace garbage (the
+# CAP-2/CAP-3 "refuse on unknown layout" guarantee).
+if [[ $EXPECT_UNSUPPORTED -eq 1 ]]; then
+    echo "=== unsupported-version cell: tracer must refuse loudly ==="
+    OUT=$("$PROJECT_DIR/pg_wait_tracer" --mode tiered --pid "$PM_PID" \
+          --duration 5 --quiet 2>&1)
+    RC=$?
+    echo "$OUT" | tail -5
+    if [[ $RC -ne 0 ]] && grep -q "no known offsetof(PGPROC, wait_event_info)" <<<"$OUT"; then
+        summary_early "- PASS: unsupported PG version refused loudly (rc=$RC, fail-safe contract)"
+        exit 0
+    fi
+    summary_early "- **FAIL**: expected a loud refusal on an unsupported PG version (rc=$RC)"
+    exit 1
+fi
 
 summary() {
     echo "$1"

--- a/tests/fixtures/README.md
+++ b/tests/fixtures/README.md
@@ -1,0 +1,25 @@
+# /proc/<pid>/maps fixtures for tests/test_discovery.c
+
+The `/proc/<pid>/maps` format has no comment syntax, so fixture provenance
+lives here. All fixtures are RECONSTRUCTED layouts (kept minimal), not raw
+captures — modeled on the layouts documented in the #24 fix history
+(commits a878c72, 9342c1b) and the parsing notes in
+`src/discovery.c:pgwt_find_load_base_in_maps()`.
+
+- `maps_el8_nonpie.txt` — Rocky 8 / RHEL 8 PGDG RPM (`/usr/pgsql-13/bin/
+  postgres`), non-PIE (ET_EXEC): the binary's FIRST mapping is the `r-xp`
+  text segment at the fixed base 0x400000; the `r--p` rodata mapping is far
+  above it. This is the layout that broke the old "first r--p" match (#24):
+  expected load base 0x400000.
+- `maps_el9_pie.txt` — Rocky 9 PGDG RPM (`/usr/pgsql-18/bin/postgres`),
+  PIE (ET_DYN): modern 5-mapping split, first mapping is the `r--p`
+  ELF-header page. Expected load base 0x55d4c1000000.
+- `maps_ubuntu_pie.txt` — Ubuntu PGDG deb (`/usr/lib/postgresql/17/bin/
+  postgres`), PIE. Expected load base 0x5560d1a00000.
+- `maps_ext_below_binary.txt` — ADVERSARIAL (CAP-4, owned by Phase T4):
+  same Ubuntu layout, but `pg_stat_statements.so` is mapped BELOW the main
+  binary. Its path `/usr/lib/postgresql/17/lib/...` contains the substring
+  "postgres", so the current whole-line `strstr()` match returns the .so's
+  base (0x4f2a80000000) instead of the binary's (0x5560d1a00000) — the #24
+  class one directory layout away from recurring. test_discovery.c pins the
+  current (wrong) behavior as an expected failure until T4 fixes it.

--- a/tests/fixtures/maps_el8_nonpie.txt
+++ b/tests/fixtures/maps_el8_nonpie.txt
@@ -1,0 +1,19 @@
+00400000-00d5e000 r-xp 00000000 fd:00 67343532                           /usr/pgsql-13/bin/postgres
+00f5d000-00f8a000 r--p 0095d000 fd:00 67343532                           /usr/pgsql-13/bin/postgres
+00f8a000-00f96000 rw-p 0098a000 fd:00 67343532                           /usr/pgsql-13/bin/postgres
+00f96000-00fe2000 rw-p 00000000 00:00 0
+01a4b000-01aad000 rw-p 00000000 00:00 0                                  [heap]
+7f2f4c000000-7f2f4c021000 rw-p 00000000 00:00 0
+7f2f52a39000-7f2f52a49000 r-xp 00000000 fd:00 67343581                   /usr/pgsql-13/lib/pg_stat_statements.so
+7f2f52a49000-7f2f52c48000 ---p 00010000 fd:00 67343581                   /usr/pgsql-13/lib/pg_stat_statements.so
+7f2f52c48000-7f2f52c49000 r--p 0000f000 fd:00 67343581                   /usr/pgsql-13/lib/pg_stat_statements.so
+7f2f52c49000-7f2f52c4a000 rw-p 00010000 fd:00 67343581                   /usr/pgsql-13/lib/pg_stat_statements.so
+7f2f52c4a000-7f2f52e06000 r-xp 00000000 fd:00 33556489                   /usr/lib64/libc-2.28.so
+7f2f52e06000-7f2f53006000 ---p 001bc000 fd:00 33556489                   /usr/lib64/libc-2.28.so
+7f2f53006000-7f2f5300a000 r--p 001bc000 fd:00 33556489                   /usr/lib64/libc-2.28.so
+7f2f5300a000-7f2f5300c000 rw-p 001c0000 fd:00 33556489                   /usr/lib64/libc-2.28.so
+7f2f53252000-7f2f5327e000 r-xp 00000000 fd:00 33556481                   /usr/lib64/ld-2.28.so
+7ffd8a3b0000-7ffd8a3d1000 rw-p 00000000 00:00 0                          [stack]
+7ffd8a3f3000-7ffd8a3f7000 r--p 00000000 00:00 0                          [vvar]
+7ffd8a3f7000-7ffd8a3f9000 r-xp 00000000 00:00 0                          [vdso]
+ffffffffff600000-ffffffffff601000 --xp 00000000 00:00 0                  [vsyscall]

--- a/tests/fixtures/maps_el9_pie.txt
+++ b/tests/fixtures/maps_el9_pie.txt
@@ -1,0 +1,21 @@
+55d4c1000000-55d4c1052000 r--p 00000000 fd:00 51126382                   /usr/pgsql-18/bin/postgres
+55d4c1052000-55d4c17f0000 r-xp 00052000 fd:00 51126382                   /usr/pgsql-18/bin/postgres
+55d4c17f0000-55d4c1a4f000 r--p 007f0000 fd:00 51126382                   /usr/pgsql-18/bin/postgres
+55d4c1a4f000-55d4c1a63000 r--p 00a4e000 fd:00 51126382                   /usr/pgsql-18/bin/postgres
+55d4c1a63000-55d4c1a72000 rw-p 00a62000 fd:00 51126382                   /usr/pgsql-18/bin/postgres
+55d4c1a72000-55d4c1ac0000 rw-p 00000000 00:00 0
+55d4c2f31000-55d4c2f93000 rw-p 00000000 00:00 0                          [heap]
+7f10a4000000-7f10a4021000 rw-p 00000000 00:00 0
+7f10aa5f2000-7f10aa603000 r-xp 00001000 fd:00 51126417                   /usr/pgsql-18/lib/pg_stat_statements.so
+7f10aa603000-7f10aa604000 r--p 00012000 fd:00 51126417                   /usr/pgsql-18/lib/pg_stat_statements.so
+7f10aa604000-7f10aa605000 rw-p 00013000 fd:00 51126417                   /usr/pgsql-18/lib/pg_stat_statements.so
+7f10aa605000-7f10aa62d000 r--p 00000000 fd:00 33555532                   /usr/lib64/libc.so.6
+7f10aa62d000-7f10aa79c000 r-xp 00028000 fd:00 33555532                   /usr/lib64/libc.so.6
+7f10aa79c000-7f10aa7f4000 r--p 00197000 fd:00 33555532                   /usr/lib64/libc.so.6
+7f10aa7f4000-7f10aa7f8000 rw-p 001ee000 fd:00 33555532                   /usr/lib64/libc.so.6
+7f10aa858000-7f10aa85a000 r--p 00000000 fd:00 33555525                   /usr/lib64/ld-linux-x86-64.so.2
+7f10aa85a000-7f10aa881000 r-xp 00002000 fd:00 33555525                   /usr/lib64/ld-linux-x86-64.so.2
+7ffc1f6de000-7ffc1f6ff000 rw-p 00000000 00:00 0                          [stack]
+7ffc1f77d000-7ffc1f781000 r--p 00000000 00:00 0                          [vvar]
+7ffc1f781000-7ffc1f783000 r-xp 00000000 00:00 0                          [vdso]
+ffffffffff600000-ffffffffff601000 --xp 00000000 00:00 0                  [vsyscall]

--- a/tests/fixtures/maps_ext_below_binary.txt
+++ b/tests/fixtures/maps_ext_below_binary.txt
@@ -1,0 +1,16 @@
+4f2a80000000-4f2a80002000 r--p 00000000 fc:01 4719102                    /usr/lib/postgresql/17/lib/pg_stat_statements.so
+4f2a80002000-4f2a80012000 r-xp 00002000 fc:01 4719102                    /usr/lib/postgresql/17/lib/pg_stat_statements.so
+4f2a80012000-4f2a80014000 r--p 00012000 fc:01 4719102                    /usr/lib/postgresql/17/lib/pg_stat_statements.so
+4f2a80014000-4f2a80015000 rw-p 00013000 fc:01 4719102                    /usr/lib/postgresql/17/lib/pg_stat_statements.so
+5560d1a00000-5560d1a53000 r--p 00000000 fc:01 4718723                    /usr/lib/postgresql/17/bin/postgres
+5560d1a53000-5560d21c9000 r-xp 00053000 fc:01 4718723                    /usr/lib/postgresql/17/bin/postgres
+5560d21c9000-5560d2429000 r--p 007c9000 fc:01 4718723                    /usr/lib/postgresql/17/bin/postgres
+5560d2429000-5560d243c000 r--p 00a28000 fc:01 4718723                    /usr/lib/postgresql/17/bin/postgres
+5560d243c000-5560d244b000 rw-p 00a3b000 fc:01 4718723                    /usr/lib/postgresql/17/bin/postgres
+5560d3b17000-5560d3b79000 rw-p 00000000 00:00 0                          [heap]
+7f8e3a1f9000-7f8e3a221000 r--p 00000000 fc:01 3151553                    /usr/lib/x86_64-linux-gnu/libc.so.6
+7f8e3a221000-7f8e3a3b6000 r-xp 00028000 fc:01 3151553                    /usr/lib/x86_64-linux-gnu/libc.so.6
+7f8e3a3b6000-7f8e3a40e000 r--p 001bd000 fc:01 3151553                    /usr/lib/x86_64-linux-gnu/libc.so.6
+7f8e3a40e000-7f8e3a412000 rw-p 00215000 fc:01 3151553                    /usr/lib/x86_64-linux-gnu/libc.so.6
+7ffce92c1000-7ffce92e2000 rw-p 00000000 00:00 0                          [stack]
+7ffce930e000-7ffce9310000 r-xp 00000000 00:00 0                          [vdso]

--- a/tests/fixtures/maps_ubuntu_pie.txt
+++ b/tests/fixtures/maps_ubuntu_pie.txt
@@ -1,0 +1,22 @@
+5560d1a00000-5560d1a53000 r--p 00000000 fc:01 4718723                    /usr/lib/postgresql/17/bin/postgres
+5560d1a53000-5560d21c9000 r-xp 00053000 fc:01 4718723                    /usr/lib/postgresql/17/bin/postgres
+5560d21c9000-5560d2429000 r--p 007c9000 fc:01 4718723                    /usr/lib/postgresql/17/bin/postgres
+5560d2429000-5560d243c000 r--p 00a28000 fc:01 4718723                    /usr/lib/postgresql/17/bin/postgres
+5560d243c000-5560d244b000 rw-p 00a3b000 fc:01 4718723                    /usr/lib/postgresql/17/bin/postgres
+5560d244b000-5560d2499000 rw-p 00000000 00:00 0
+5560d3b17000-5560d3b79000 rw-p 00000000 00:00 0                          [heap]
+7f8e34000000-7f8e34021000 rw-p 00000000 00:00 0
+7f8e3a1e4000-7f8e3a1e6000 r--p 00000000 fc:01 4719102                    /usr/lib/postgresql/17/lib/pg_stat_statements.so
+7f8e3a1e6000-7f8e3a1f6000 r-xp 00002000 fc:01 4719102                    /usr/lib/postgresql/17/lib/pg_stat_statements.so
+7f8e3a1f6000-7f8e3a1f8000 r--p 00012000 fc:01 4719102                    /usr/lib/postgresql/17/lib/pg_stat_statements.so
+7f8e3a1f8000-7f8e3a1f9000 rw-p 00013000 fc:01 4719102                    /usr/lib/postgresql/17/lib/pg_stat_statements.so
+7f8e3a1f9000-7f8e3a221000 r--p 00000000 fc:01 3151553                    /usr/lib/x86_64-linux-gnu/libc.so.6
+7f8e3a221000-7f8e3a3b6000 r-xp 00028000 fc:01 3151553                    /usr/lib/x86_64-linux-gnu/libc.so.6
+7f8e3a3b6000-7f8e3a40e000 r--p 001bd000 fc:01 3151553                    /usr/lib/x86_64-linux-gnu/libc.so.6
+7f8e3a40e000-7f8e3a412000 rw-p 00215000 fc:01 3151553                    /usr/lib/x86_64-linux-gnu/libc.so.6
+7f8e3a5cf000-7f8e3a5d1000 r--p 00000000 fc:01 3151550                    /usr/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2
+7f8e3a5d1000-7f8e3a5fb000 r-xp 00002000 fc:01 3151550                    /usr/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2
+7ffce92c1000-7ffce92e2000 rw-p 00000000 00:00 0                          [stack]
+7ffce930a000-7ffce930e000 r--p 00000000 00:00 0                          [vvar]
+7ffce930e000-7ffce9310000 r-xp 00000000 00:00 0                          [vdso]
+ffffffffff600000-ffffffffff601000 --xp 00000000 00:00 0                  [vsyscall]

--- a/tests/results/overhead_trend.csv
+++ b/tests/results/overhead_trend.csv
@@ -1,0 +1,1 @@
+date,commit,clients,mode,run,tps

--- a/tests/run_all.sh
+++ b/tests/run_all.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 # run_all.sh — Master test runner for pg_wait_tracer
-# Usage: sudo tests/run_all.sh [--pid POSTMASTER_PID] [--pg-version N]
+# Usage: sudo tests/run_all.sh [--pid POSTMASTER_PID] [--pg-version N] [--require-live]
+#
+# --require-live: any skip in the root+PG live section is a FAILURE. This is
+# the gate for capture-behavior phases (Trust Milestone standing rule): an
+# all-skip run used to exit 0 (TST-4), which is how "green" runs happened on
+# boxes where nothing live actually executed. Use it on the real test box.
 set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -9,11 +14,13 @@ source "$SCRIPT_DIR/testutil.sh"
 
 PM_PID=""
 PG_VERSION=""
+REQUIRE_LIVE=0
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --pid) PM_PID="$2"; shift 2 ;;
         --pg-version) PG_VERSION="$2"; shift 2 ;;
-        *) echo "Usage: $0 [--pid POSTMASTER_PID] [--pg-version N]"; exit 1 ;;
+        --require-live) REQUIRE_LIVE=1; shift ;;
+        *) echo "Usage: $0 [--pid POSTMASTER_PID] [--pg-version N] [--require-live]"; exit 1 ;;
     esac
 done
 
@@ -63,6 +70,23 @@ skip_test() {
     skipped=$((skipped + 1))
 }
 
+# Skip in the root+PG LIVE section. Under --require-live a live skip is a
+# FAILURE, not a skip — the live suite silently not running is exactly how
+# all four field escapes (#8/#24/#30/#31) shipped (TST-4).
+skip_live_test() {
+    local name="$1"
+    local reason="$2"
+    if [[ $REQUIRE_LIVE -eq 1 ]]; then
+        echo ""
+        echo "════════════════════════════════════════"
+        echo "  $name — FAILED (--require-live set, but: $reason)"
+        echo "════════════════════════════════════════"
+        failed=$((failed + 1))
+    else
+        skip_test "$name" "$reason"
+    fi
+}
+
 # Step 0: Build main project if needed
 echo "Building main project..."
 make -C "$PROJECT_DIR" -q 2>/dev/null || make -C "$PROJECT_DIR"
@@ -71,15 +95,14 @@ make -C "$PROJECT_DIR" -q 2>/dev/null || make -C "$PROJECT_DIR"
 echo "Building C unit tests..."
 make -C "$SCRIPT_DIR"
 
-# Step 2: C unit tests (no root needed)
-run_test "test_wait_event" "$SCRIPT_DIR/test_wait_event"
-run_test "test_cmdline" "$SCRIPT_DIR/test_cmdline"
-run_test "test_bucket" "$SCRIPT_DIR/test_bucket"
-run_test "test_trace_v2" "$SCRIPT_DIR/test_trace_v2"
-run_test "test_sampler" "$SCRIPT_DIR/test_sampler"
-run_test "test_anomaly" "$SCRIPT_DIR/test_anomaly"
-run_test "test_coop" "$SCRIPT_DIR/test_coop"
-run_test "test_pg13_resolve" "$SCRIPT_DIR/test_pg13_resolve"
+# Step 2: C unit tests (no root needed).
+# The list lives in unit_tests.list — the SINGLE source of truth shared with
+# CI (`make -C tests check`). Never add unit tests here directly (TST-3).
+# (read via fd 3 so the tests' stdin stays the terminal, not the list file)
+while read -r t <&3; do
+    case "$t" in ''|\#*) continue ;; esac
+    run_test "$t" "$SCRIPT_DIR/$t"
+done 3< "$SCRIPT_DIR/unit_tests.list"
 
 # Step 2.5: Synthetic data correctness tests (no root needed, needs pgwt-server)
 if [[ -x "$PROJECT_DIR/pgwt-server" ]] && [[ -x "$SCRIPT_DIR/gen_test_traces" ]]; then
@@ -101,87 +124,95 @@ else
     skip_test "test_data_*" "pgwt-server or gen_test_traces not built"
 fi
 
-# Step 3: CLI tests (needs root)
+# Live test inventory (root + running PG). One list, used both to run and to
+# report skips — keep names and runners in sync here only.
+# test_overhead runs in --quick mode (~10 min instead of ~70) and appends a
+# CSV trend row set to tests/results/overhead_trend.csv; a full sweep is
+# still available via `sudo tests/test_overhead.sh` directly.
+run_overhead_quick() {
+    local results_dir="$SCRIPT_DIR/results"
+    local trend="$results_dir/overhead_trend.csv"
+    local tmp_csv
+    tmp_csv=$(mktemp /tmp/pgwt_overhead_XXXXXX.csv)
+    mkdir -p "$results_dir"
+    if bash "$SCRIPT_DIR/test_overhead.sh" --quick --output "$tmp_csv" $PID_ARG; then
+        local status=0
+    else
+        local status=1
+    fi
+    # Append per-run rows to the tracked trend file (date + commit prefixed)
+    if [[ -s "$tmp_csv" ]]; then
+        if [[ ! -f "$trend" ]]; then
+            echo "date,commit,clients,mode,run,tps" > "$trend"
+        fi
+        local when commit
+        when=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+        commit=$(git -C "$PROJECT_DIR" rev-parse --short HEAD 2>/dev/null || echo unknown)
+        tail -n +2 "$tmp_csv" | sed "s|^|$when,$commit,|" >> "$trend"
+        echo "Overhead trend appended to $trend"
+    fi
+    rm -f "$tmp_csv"
+    return $status
+}
+
+# Step 3: CLI tests (needs root; PG optional for the arg-validation checks)
 if [[ $(id -u) -eq 0 ]]; then
     run_test "test_cli" bash "$SCRIPT_DIR/test_cli.sh" $PID_ARG
 else
-    skip_test "test_cli" "requires root"
+    skip_live_test "test_cli" "requires root"
 fi
 
-# Step 4: Integration tests (need root + running PG)
-if [[ $(id -u) -eq 0 ]] && pgrep -x postgres > /dev/null 2>&1; then
-    run_test "test_lifecycle" bash "$SCRIPT_DIR/test_lifecycle.sh" $PID_ARG
-    run_test "test_cross_validate" python3 "$SCRIPT_DIR/test_cross_validate.py" $PID_ARG
-    run_test "test_accuracy" python3 "$SCRIPT_DIR/test_accuracy.py" $PID_ARG
-    run_test "test_deterministic" python3 "$SCRIPT_DIR/test_deterministic.py" $PID_ARG
-    run_test "test_overhead" bash "$SCRIPT_DIR/test_overhead.sh" $PID_ARG
-    run_test "test_client_wait" python3 "$SCRIPT_DIR/test_client_wait.py" $PID_ARG
-    run_test "test_cpu_time" python3 "$SCRIPT_DIR/test_cpu_time.py" $PID_ARG
-    run_test "test_lwlock" python3 "$SCRIPT_DIR/test_lwlock.py" $PID_ARG
-    run_test "test_query_event" python3 "$SCRIPT_DIR/test_query_event.py" $PID_ARG
-    run_test "test_cross_pg_wait_sampling" python3 "$SCRIPT_DIR/test_cross_pg_wait_sampling.py" $PID_ARG
-    run_test "test_event_classes" python3 "$SCRIPT_DIR/test_event_classes.py" $PID_ARG
-    run_test "test_multi_window" python3 "$SCRIPT_DIR/test_multi_window.py" $PID_ARG
-    run_test "test_active" python3 "$SCRIPT_DIR/test_active.py" $PID_ARG
+LIVE_TESTS=(
+    "test_lifecycle|bash|test_lifecycle.sh"
+    "test_cross_validate|python3|test_cross_validate.py"
+    "test_accuracy|python3|test_accuracy.py"
+    "test_deterministic|python3|test_deterministic.py"
+    "test_overhead|overhead_quick|"
+    "test_client_wait|python3|test_client_wait.py"
+    "test_cpu_time|python3|test_cpu_time.py"
+    "test_lwlock|python3|test_lwlock.py"
+    "test_query_event|python3|test_query_event.py"
+    "test_cross_pg_wait_sampling|python3|test_cross_pg_wait_sampling.py"
+    "test_event_classes|python3|test_event_classes.py"
+    "test_multi_window|python3|test_multi_window.py"
+    "test_active|python3|test_active.py"
+    # Live data correctness tests (Sprint 4)
+    "test_percentage|python3|test_percentage.py"
+    "test_aas_accuracy|python3|test_aas_accuracy.py"
+    "test_session_accuracy|python3|test_session_accuracy.py"
+    "test_query_accuracy|python3|test_query_accuracy.py"
+    "test_partition|python3|test_partition.py"
+    "test_idle_exclusion|python3|test_idle_exclusion.py"
+    "test_daemon_server|python3|test_daemon_server.py"
+    "test_control|bash|test_control.sh"
+    "test_escalation|bash|test_escalation.sh"
+    # Tiered-capture live tests (were built for A4/A5 but wired into
+    # nothing — TST-7). test_cross_validate_tiered is the test that
+    # justified tiered as the default mode.
+    "test_cross_validate_tiered|bash|test_cross_validate_tiered.sh"
+    "test_anomaly_live|bash|test_anomaly_live.sh"
+)
 
-    # Step 4.5: Live data correctness tests (Sprint 4)
-    run_test "test_percentage" python3 "$SCRIPT_DIR/test_percentage.py" $PID_ARG
-    run_test "test_aas_accuracy" python3 "$SCRIPT_DIR/test_aas_accuracy.py" $PID_ARG
-    run_test "test_session_accuracy" python3 "$SCRIPT_DIR/test_session_accuracy.py" $PID_ARG
-    run_test "test_query_accuracy" python3 "$SCRIPT_DIR/test_query_accuracy.py" $PID_ARG
-    run_test "test_partition" python3 "$SCRIPT_DIR/test_partition.py" $PID_ARG
-    run_test "test_idle_exclusion" python3 "$SCRIPT_DIR/test_idle_exclusion.py" $PID_ARG
-    run_test "test_daemon_server" python3 "$SCRIPT_DIR/test_daemon_server.py" $PID_ARG
-    run_test "test_control" bash "$SCRIPT_DIR/test_control.sh" $PID_ARG
-    run_test "test_escalation" bash "$SCRIPT_DIR/test_escalation.sh" $PID_ARG
+# Step 4: integration + live-correctness tests (root + running PG)
+if [[ $(id -u) -eq 0 ]] && pgrep -x postgres > /dev/null 2>&1; then
+    for entry in "${LIVE_TESTS[@]}"; do
+        IFS='|' read -r name runner file <<< "$entry"
+        case "$runner" in
+            bash)           run_test "$name" bash "$SCRIPT_DIR/$file" $PID_ARG ;;
+            python3)        run_test "$name" python3 "$SCRIPT_DIR/$file" $PID_ARG ;;
+            overhead_quick) run_test "$name (--quick)" run_overhead_quick ;;
+        esac
+    done
 else
     if [[ $(id -u) -ne 0 ]]; then
-        skip_test "test_lifecycle" "requires root"
-        skip_test "test_cross_validate" "requires root"
-        skip_test "test_accuracy" "requires root"
-        skip_test "test_deterministic" "requires root"
-        skip_test "test_overhead" "requires root"
-        skip_test "test_client_wait" "requires root"
-        skip_test "test_cpu_time" "requires root"
-        skip_test "test_lwlock" "requires root"
-        skip_test "test_query_event" "requires root"
-        skip_test "test_cross_pg_wait_sampling" "requires root"
-        skip_test "test_event_classes" "requires root"
-        skip_test "test_multi_window" "requires root"
-        skip_test "test_active" "requires root"
-        skip_test "test_percentage" "requires root"
-        skip_test "test_aas_accuracy" "requires root"
-        skip_test "test_session_accuracy" "requires root"
-        skip_test "test_query_accuracy" "requires root"
-        skip_test "test_partition" "requires root"
-        skip_test "test_idle_exclusion" "requires root"
-        skip_test "test_daemon_server" "requires root"
-        skip_test "test_control" "requires root"
-        skip_test "test_escalation" "requires root"
+        live_skip_reason="requires root"
     else
-        skip_test "test_lifecycle" "PostgreSQL not running"
-        skip_test "test_cross_validate" "PostgreSQL not running"
-        skip_test "test_accuracy" "PostgreSQL not running"
-        skip_test "test_deterministic" "PostgreSQL not running"
-        skip_test "test_overhead" "PostgreSQL not running"
-        skip_test "test_client_wait" "PostgreSQL not running"
-        skip_test "test_cpu_time" "PostgreSQL not running"
-        skip_test "test_lwlock" "PostgreSQL not running"
-        skip_test "test_query_event" "PostgreSQL not running"
-        skip_test "test_cross_pg_wait_sampling" "PostgreSQL not running"
-        skip_test "test_event_classes" "PostgreSQL not running"
-        skip_test "test_multi_window" "PostgreSQL not running"
-        skip_test "test_active" "PostgreSQL not running"
-        skip_test "test_percentage" "PostgreSQL not running"
-        skip_test "test_aas_accuracy" "PostgreSQL not running"
-        skip_test "test_session_accuracy" "PostgreSQL not running"
-        skip_test "test_query_accuracy" "PostgreSQL not running"
-        skip_test "test_partition" "PostgreSQL not running"
-        skip_test "test_idle_exclusion" "PostgreSQL not running"
-        skip_test "test_daemon_server" "PostgreSQL not running"
-        skip_test "test_control" "PostgreSQL not running"
-        skip_test "test_escalation" "PostgreSQL not running"
+        live_skip_reason="PostgreSQL not running"
     fi
+    for entry in "${LIVE_TESTS[@]}"; do
+        IFS='|' read -r name _ _ <<< "$entry"
+        skip_live_test "$name" "$live_skip_reason"
+    done
 fi
 
 # Step 5: Web UI tests (needs playwright + websockets, no root needed)
@@ -222,10 +253,18 @@ echo "════════════════════════�
 echo "  SUMMARY"
 echo "════════════════════════════════════════"
 total=$((passed + failed + skipped))
-echo "  Passed:  $passed"
-echo "  Failed:  $failed"
-echo "  Skipped: $skipped"
-echo "  Total:   $total"
+executed=$((passed + failed))
+echo "  Executed: $executed (passed $passed, failed $failed), skipped $skipped, total $total"
+if [[ $REQUIRE_LIVE -eq 1 ]]; then
+    echo "  Mode:     --require-live (live-section skips counted as failures)"
+fi
 echo ""
+
+# An all-skip run must never be green: something is wrong with the
+# environment or the runner itself if nothing executed (TST-4).
+if [[ $executed -eq 0 ]]; then
+    echo "ERROR: no test was executed — refusing to report success"
+    exit 1
+fi
 
 [[ $failed -eq 0 ]]

--- a/tests/test_capture_smoke.py
+++ b/tests/test_capture_smoke.py
@@ -1,0 +1,485 @@
+#!/usr/bin/env python3
+"""test_capture_smoke.py — end-to-end capture smoke test (Phase T0: TST-1/2).
+
+The one test whose entire purpose is: if the tracer silently records
+NOTHING from a real PostgreSQL, this must go red. All four field escapes
+(#8, #24, #30, #31) lived in the capture/discovery slice that no CI job
+executed; this test (driven by tests/ci_smoke.sh in the CI capture-smoke
+job) closes that hole.
+
+Deterministic workload, asserted with bounded values:
+  1. pg_sleep(3)              -> Timeout:PgSleep, total within tolerance
+  2. blocked LOCK TABLE pair  -> Lock:relation wait, bounded duration
+  3. short pgbench run        -> query_event view shows query_ids that
+                                 cross-check against pg_stat_statements
+
+Wait events are asserted in BOTH:
+  - the live view output (--view system_event / query_event), and
+  - the written trace file, read back through pgwt-server (the same JSON
+    protocol the web UI uses; --replay is NOT used because replay of
+    tiered traces is fidelity-broken until T1/FID-5).
+
+Regression coverage (referenced by PR number, per the Trust Milestone):
+  - PR #30: in sampled/tiered mode the sampler must feed the live
+    accumulator — the tiered live-view assertions here are empty if that
+    regresses.
+  - PR #31: the query-attribution uprobe must actually fire (on PG13 it
+    must probe standard_ExecutorStart) — the query-attribution assertions
+    here go empty if it regresses. The assertion cross-checks captured
+    query_ids against pg_stat_statements.queryid, so junk/phantom ids
+    (e.g. marker leakage, FID-4) cannot satisfy it.
+  - PR #24 (load base) would make this whole test capture zero events on
+    non-PIE layouts; the unit-level guard is tests/test_discovery*.
+
+Environment requirements (ci.yml configures both; fail loudly otherwise):
+  - pg_stat_statements in shared_preload_libraries (PG13: required for
+    query attribution at all; PG14+: activates compute_query_id=auto).
+  - pgbench + psql for the workload, connecting as "postgres" via local
+    trust auth.
+
+Usage: sudo python3 tests/test_capture_smoke.py --mode {full,tiered}
+           [--pid POSTMASTER_PID]
+"""
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from testutil import find_postmaster
+
+PROJECT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+TRACER = os.path.join(PROJECT_DIR, "pg_wait_tracer")
+SERVER = os.path.join(PROJECT_DIR, "pgwt-server")
+STRIP_ANSI = re.compile(r'\x1b\[[0-9;]*[a-zA-Z]')
+
+tests_run = 0
+tests_passed = 0
+tests_failed = 0
+
+
+def check(cond, msg):
+    global tests_run, tests_passed, tests_failed
+    tests_run += 1
+    if cond:
+        tests_passed += 1
+        print(f"  PASS: {msg}")
+    else:
+        tests_failed += 1
+        print(f"  FAIL: {msg}")
+
+
+def psql(sql, timeout=15):
+    result = subprocess.run(
+        ["psql", "-U", "postgres", "-d", "postgres", "-tAc", sql],
+        capture_output=True, text=True, timeout=timeout
+    )
+    return result.stdout.strip()
+
+
+def cleanup_stale_backends():
+    try:
+        psql("SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
+             "WHERE pid != pg_backend_pid() AND datname = 'postgres' "
+             "AND backend_type = 'client backend' AND state != 'active'")
+        psql("SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
+             "WHERE pid != pg_backend_pid() AND query LIKE '%pg_sleep%'")
+    except subprocess.TimeoutExpired:
+        pass
+    time.sleep(1)
+
+
+def pgss_query_ids():
+    """query_ids (as unsigned 64-bit) that pg_stat_statements recorded for
+    the pgbench workload — the ground truth for attribution asserts."""
+    out = psql("SELECT queryid FROM pg_stat_statements "
+               "WHERE queryid IS NOT NULL AND calls >= 3")
+    ids = set()
+    for line in out.split('\n'):
+        line = line.strip()
+        if re.fullmatch(r'-?\d+', line):
+            ids.add(int(line) & 0xFFFFFFFFFFFFFFFF)
+    return ids
+
+
+# ── deterministic workload ─────────────────────────────────────────
+
+class Workload:
+    """Three psql sessions held open on stdin pipes:
+         sleeper — runs SELECT pg_sleep(3) when fire()d, then sits idle
+                   (idle = Client:ClientRead, which is hidden — so the
+                   session's PgSleep total stays exactly ~3s; an extra
+                   keepalive pg_sleep would contaminate the assertion)
+         holder  — BEGIN; LOCK TABLE ... ACCESS EXCLUSIVE (idle-in-txn,
+                   holds the lock for the whole phase)
+         waiter  — SELECT on the table when fire()d -> blocks on
+                   Lock:relation until the phase ends
+
+    Sessions are opened BEFORE the tracer starts (the initial backend scan
+    finds them — same technique as test_deterministic.py: backends forked
+    after attach are subject to the fork->attach race, observed live on
+    Ubuntu 24.04/kernel 6.8 — a T4 hardening item, not smoke-test scope),
+    but the waits are fired AFTER the tracer attaches so their durations
+    are fully observed. release() commits the holder so the lock wait ENDS
+    inside the observation window — in full mode a transition is only
+    written to the trace when the wait ends, so a never-ending lock wait
+    would be absent from the trace file (the ESC-2/FID-class open-interval
+    gap, owned by T1/T3)."""
+
+    LOCK_TABLE = "_smoke_lock_wait"
+
+    def __init__(self):
+        self.sleeper = None
+        self.holder = None
+        self.waiter = None
+
+    def _session(self):
+        return subprocess.Popen(
+            ["psql", "-U", "postgres", "-d", "postgres"],
+            stdin=subprocess.PIPE, stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL, text=True)
+
+    def open_sessions(self):
+        psql(f"CREATE TABLE IF NOT EXISTS {self.LOCK_TABLE} (id int)")
+        self.sleeper = self._session()
+        self.holder = self._session()
+        self.waiter = self._session()
+        self.holder.stdin.write(
+            f"BEGIN; LOCK TABLE {self.LOCK_TABLE} IN ACCESS EXCLUSIVE MODE;\n")
+        self.holder.stdin.flush()
+        time.sleep(1.5)   # sessions connected, lock held
+        held = psql(
+            f"SELECT count(*) FROM pg_locks "
+            f"WHERE relation = '{self.LOCK_TABLE}'::regclass AND granted")
+        check(held != "" and int(held) >= 1,
+              f"workload: holder acquired AccessExclusiveLock (held={held!r})")
+
+    def fire(self, sleep_s=3):
+        """Start the observable waits (call after the tracer attached)."""
+        self.sleeper.stdin.write(f"SELECT pg_sleep({sleep_s});\n")
+        self.sleeper.stdin.flush()
+        self.waiter.stdin.write(f"SELECT count(*) FROM {self.LOCK_TABLE};\n")
+        self.waiter.stdin.flush()
+        time.sleep(1.5)
+        waiters = psql(
+            f"SELECT count(*) FROM pg_locks "
+            f"WHERE relation = '{self.LOCK_TABLE}'::regclass AND NOT granted")
+        check(waiters != "" and int(waiters) >= 1,
+              f"workload: waiter blocked on {self.LOCK_TABLE} (waiters={waiters!r})")
+
+    def release(self):
+        """Commit the holder -> the waiter's lock wait ends (and gets a
+        transition record in full mode)."""
+        self.holder.stdin.write("COMMIT;\n")
+        self.holder.stdin.flush()
+        time.sleep(0.5)
+
+    def stop(self):
+        for p in (self.sleeper, self.holder, self.waiter):
+            if p is None:
+                continue
+            p.terminate()
+            try:
+                p.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                p.kill()
+        self.sleeper = self.holder = self.waiter = None
+        try:
+            psql("SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
+                 "WHERE pid != pg_backend_pid() AND datname = 'postgres' "
+                 f"AND query LIKE '%{self.LOCK_TABLE}%'")
+            time.sleep(1)
+            psql(f"DROP TABLE IF EXISTS {self.LOCK_TABLE}")
+        except subprocess.TimeoutExpired:
+            pass
+
+
+# ── output parsers (same formats test_deterministic/test_query_event use) ──
+
+def parse_system_events(output):
+    events = []
+    for line in output.split('\n'):
+        m = re.match(
+            r'^(\S+(?::\S+)?)\s+(\d+)\s+([\d.]+)\s+([\d.]+)\s+([\d.]+)\s+([\d.]+|—)%?',
+            line.strip())
+        if m:
+            events.append({
+                'name': m.group(1),
+                'count': int(m.group(2)),
+                'total_ms': float(m.group(3)),
+            })
+    return events
+
+
+def parse_query_event_ids(output):
+    ids = set()
+    for line in output.split('\n'):
+        m = re.match(r'^(-?\d+)\s+(\S+(?::\S+)?)\s+(\d+)\s+([\d.]+)\s',
+                     line.strip())
+        if m:
+            qid = int(m.group(1))
+            if qid != 0:
+                ids.add(qid & 0xFFFFFFFFFFFFFFFF)
+    return ids
+
+
+def run_tracer(args, timeout):
+    proc = subprocess.Popen([TRACER] + args,
+                            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    try:
+        stdout, stderr = proc.communicate(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        stdout, stderr = proc.communicate()
+    out = STRIP_ANSI.sub('', stdout.decode('utf-8', errors='replace'))
+    err = stderr.decode('utf-8', errors='replace')
+    return out, err
+
+
+# ── pgwt-server trace-file reader ──────────────────────────────────
+
+def server_query(trace_dir, cmd, extra=None):
+    """One-shot pgwt-server JSON query against a trace dir."""
+    proc = subprocess.Popen([SERVER, trace_dir],
+                            stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+                            stderr=subprocess.PIPE, text=True)
+    try:
+        proc.stdin.write(json.dumps({"id": 1, "cmd": "info"}) + "\n")
+        proc.stdin.flush()
+        info = json.loads(proc.stdout.readline())
+        req = {"id": 2, "cmd": cmd,
+               "from": max(0, info.get("from_ns", 0) - 30_000_000_000),
+               "to": info.get("to_ns", 0) + 30_000_000_000}
+        if extra:
+            req.update(extra)
+        proc.stdin.write(json.dumps(req) + "\n")
+        proc.stdin.flush()
+        resp = json.loads(proc.stdout.readline())
+    finally:
+        proc.stdin.close()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+    return resp
+
+
+# ── shared assertions ──────────────────────────────────────────────
+
+def assert_wait_events(events, source, sleep_hi=6000):
+    """Deterministic-wait assertions, applied to live view or trace rows.
+
+    sleep_hi: live-view callers pass 7000 — in tiered mode the live
+    accumulator is fed by both the sampler and the exact stream, inflating
+    totals up to ~2x (the known ESC-3 double-count, owned by Phase T3;
+    observed 5710ms for a 3s sleep). Once T3 gates sampler accumulation
+    during exact coverage, tighten this back to 6000."""
+    names = [e['name'] for e in events]
+
+    sleep_ev = [e for e in events if e['name'] == 'Timeout:PgSleep']
+    check(len(sleep_ev) > 0, f"{source}: Timeout:PgSleep present (saw: {names})")
+    if sleep_ev:
+        total = sleep_ev[0]['total_ms']
+        # One pg_sleep(3), fired after attach, session idle afterwards.
+        # Sampled tier quantizes at the sample period; bounded either way:
+        # zero and wildly-wrong both fail.
+        check(1200 <= total <= sleep_hi,
+              f"{source}: PgSleep total = {total:.0f}ms (expect ~3000 ±tol)")
+
+    lock_ev = [e for e in events if e['name'] == 'Lock:relation']
+    check(len(lock_ev) > 0, f"{source}: Lock:relation present (saw: {names})")
+    if lock_ev:
+        total = lock_ev[0]['total_ms']
+        # The waiter blocks from fire() until the phase ends (>= ~8s of
+        # observation); open-interval accounting reports it at tick time.
+        check(total >= 4000, f"{source}: Lock:relation total = {total:.0f}ms (expect >= 4000)")
+        check(total <= 25000, f"{source}: Lock:relation total = {total:.0f}ms (expect <= 25000)")
+
+
+# ── phases ─────────────────────────────────────────────────────────
+
+def phase_live_system_event(pm_pid, mode):
+    print(f"--- Phase 1: live view (system_event, --mode {mode}) ---")
+    wl = Workload()
+    wl.open_sessions()
+    tracer = subprocess.Popen(
+        [TRACER, "--mode", mode, "--pid", str(pm_pid),
+         "--interval", "12", "--duration", "15",
+         "--view", "system_event"],
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    time.sleep(2.5)   # BPF load + initial scan + (full) watchpoint attach
+    try:
+        wl.fire(sleep_s=3)     # t≈2.5: pg_sleep(3) + lock wait begin
+        time.sleep(6.5)
+        wl.release()           # t≈10.5: lock wait ends (~8s) before the tick
+        stdout, stderr = tracer.communicate(timeout=40)
+    except subprocess.TimeoutExpired:
+        tracer.kill()
+        stdout, stderr = tracer.communicate()
+    finally:
+        wl.stop()
+
+    out = STRIP_ANSI.sub('', stdout.decode('utf-8', errors='replace'))
+    err = stderr.decode('utf-8', errors='replace')
+    events = parse_system_events(out)
+    # THE zero-event guard: an empty view here means capture is dead (#30).
+    check(len(events) > 0,
+          "live view shows at least one event" if events else
+          f"live view shows at least one event (stderr tail: {err[-300:]!r})")
+    assert_wait_events(events, f"live/{mode}", sleep_hi=7000)
+
+
+def phase_live_query_event(pm_pid, mode):
+    """PR #31 regression: the query-attribution path works end to end —
+    query_event view ids must intersect pg_stat_statements.queryid."""
+    print(f"--- Phase 2: query attribution (query_event, --mode {mode}) ---")
+
+    pgb_init = subprocess.run(
+        ["pgbench", "-U", "postgres", "-d", "postgres", "-i", "-s", "1"],
+        capture_output=True, text=True)
+    check(pgb_init.returncode == 0,
+          "pgbench -i succeeded" if pgb_init.returncode == 0 else
+          f"pgbench -i succeeded: {pgb_init.stderr[-200:]}")
+    psql("SELECT pg_stat_statements_reset()")
+
+    # pgbench starts FIRST: its backends must exist when the tracer's
+    # initial scan runs (backends forked after attach are subject to the
+    # fork->attach race — see Workload docstring).
+    pgbench = subprocess.Popen(
+        ["pgbench", "-U", "postgres", "-d", "postgres", "-c", "4", "-T", "14"],
+        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    time.sleep(1)
+
+    tracer = subprocess.Popen(
+        [TRACER, "--mode", mode, "--pid", str(pm_pid),
+         "--interval", "10", "--duration", "12",
+         "--view", "query_event"],
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    try:
+        stdout, stderr = tracer.communicate(timeout=40)
+    except subprocess.TimeoutExpired:
+        tracer.kill()
+        stdout, stderr = tracer.communicate()
+    pgbench.wait(timeout=30)
+
+    out = STRIP_ANSI.sub('', stdout.decode('utf-8', errors='replace'))
+    view_ids = parse_query_event_ids(out)
+    truth = pgss_query_ids()
+    check(len(truth) > 0,
+          f"pg_stat_statements recorded the pgbench queries ({len(truth)} ids)")
+    matched = view_ids & truth
+    check(len(matched) > 0,
+          f"query_event view ids cross-check against pg_stat_statements "
+          f"(view={len(view_ids)}, pgss={len(truth)}, matched={len(matched)}) "
+          f"[PR #31 regression]")
+
+
+def phase_trace_file(pm_pid, mode):
+    print(f"--- Phase 3: written trace file (pgwt-server read, --mode {mode}) ---")
+    trace_dir = tempfile.mkdtemp(prefix=f"pgwt_smoke_{mode}_")
+    os.chmod(trace_dir, 0o755)
+
+    wl = Workload()
+    wl.open_sessions()
+    psql("SELECT pg_stat_statements_reset()")
+    # pgbench backends must exist before the tracer attaches (fork->attach
+    # race, see Workload docstring).
+    pgbench = subprocess.Popen(
+        ["pgbench", "-U", "postgres", "-d", "postgres", "-c", "2", "-T", "16"],
+        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    time.sleep(1)
+    tracer = subprocess.Popen(
+        [TRACER, "--mode", mode, "--pid", str(pm_pid),
+         "-T", trace_dir, "--duration", "18", "--quiet",
+         "--interval", "5"],
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    time.sleep(2.5)
+    try:
+        wl.fire(sleep_s=3)     # t≈2.5 after attach
+        time.sleep(8)
+        wl.release()           # lock wait ends (~10s) inside the trace window
+        _, stderr = tracer.communicate(timeout=45)
+        err = stderr.decode('utf-8', errors='replace')
+        pgbench.wait(timeout=30)
+
+        resp = server_query(trace_dir, "top_events")
+        rows = resp.get("rows", [])
+        check(len(rows) > 0,
+              f"trace file has events (top_events rows={len(rows)})" if rows
+              else f"trace file has events (daemon stderr tail: {err[-300:]!r})")
+        events = [{'name': r.get('name'), 'count': r.get('count', 0),
+                   'total_ms': r.get('total_ms', 0.0)} for r in rows]
+        assert_wait_events(events, f"trace/{mode}")
+
+        # Query attribution must land in the trace too — and cross-check
+        # against pg_stat_statements so phantom ids can't satisfy it.
+        qresp = server_query(trace_dir, "top_queries")
+        trace_ids = set()
+        for r in qresp.get("rows", []):
+            try:
+                qid = int(str(r.get("query_id", "0")), 10)
+            except ValueError:
+                continue
+            if qid != 0:
+                trace_ids.add(qid & 0xFFFFFFFFFFFFFFFF)
+        truth = pgss_query_ids()
+        matched = trace_ids & truth
+        check(len(matched) > 0,
+              f"trace file query attribution cross-checks against "
+              f"pg_stat_statements (trace={len(trace_ids)}, pgss={len(truth)}, "
+              f"matched={len(matched)}) [PR #31 regression]")
+    finally:
+        wl.stop()
+        subprocess.run(["rm", "-rf", trace_dir])
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--pid', type=int, help='Postmaster PID')
+    parser.add_argument('--mode', required=True, choices=['full', 'tiered'])
+    args = parser.parse_args()
+
+    if os.geteuid() != 0:
+        print("ERROR: must run as root (sudo)")
+        sys.exit(1)
+    for binpath in (TRACER, SERVER):
+        if not os.path.exists(binpath):
+            print(f"ERROR: {binpath} not built")
+            sys.exit(1)
+
+    pm_pid = args.pid or find_postmaster()
+    if not pm_pid:
+        print("ERROR: cannot find PostgreSQL postmaster PID")
+        sys.exit(1)
+
+    print(f"=== test_capture_smoke --mode {args.mode} (postmaster PID {pm_pid}) ===")
+
+    # Environment gate: query-attribution assertions need query_ids to be
+    # computed at all. Fail LOUDLY rather than skipping (this test exists
+    # to prevent vacuous greens).
+    preload = psql("SHOW shared_preload_libraries")
+    if "pg_stat_statements" not in preload:
+        print("ERROR: pg_stat_statements is not in shared_preload_libraries "
+              f"(got: {preload!r}).\n"
+              "  PG13 needs it for query attribution; PG14+ need it (or "
+              "compute_query_id=on) for query_ids.\n"
+              "  ci.yml configures this — do the same on this box.")
+        sys.exit(1)
+    psql("CREATE EXTENSION IF NOT EXISTS pg_stat_statements")
+
+    cleanup_stale_backends()
+
+    phase_live_system_event(pm_pid, args.mode)
+    phase_live_query_event(pm_pid, args.mode)
+    phase_trace_file(pm_pid, args.mode)
+
+    print(f"\n{tests_passed}/{tests_run} checks passed")
+    sys.exit(0 if tests_failed == 0 else 1)
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/test_discovery.c
+++ b/tests/test_discovery.c
@@ -1,0 +1,176 @@
+/* test_discovery.c — unit tests for the #24 (load-base / symbol resolution)
+ * regression class: pgwt_find_load_base_in_maps, pgwt_find_symbol_offset,
+ * pgwt_resolve_symbol.
+ *
+ * This code broke in the field twice (PR #24: non-PIE EL8 load base; the
+ * earlier "first r--p" bug) and had zero tests. Two test axes:
+ *
+ *  1. Committed /proc/<pid>/maps fixtures (tests/fixtures/maps_*.txt,
+ *     provenance in tests/fixtures/README.md): EL8 non-PIE, EL9 PIE,
+ *     Ubuntu PIE, and the adversarial CAP-4 case (extension .so whose path
+ *     contains "postgres" mapped below the binary).
+ *
+ *  2. Self-resolution: this binary is built TWICE by tests/Makefile — once
+ *     -pie (test_discovery_pie), once -no-pie (test_discovery_nopie), the
+ *     exact axis #24 broke on. Each build resolves a known global symbol in
+ *     its own image via /proc/self/exe + /proc/self/maps and asserts the
+ *     computed runtime VA equals the symbol's actual address. A load-base
+ *     regression on either ELF type fails here in milliseconds, no
+ *     PostgreSQL needed.
+ *
+ * PGWT_TEST_EXPECT_PIE (1/0) is set by the Makefile per build so the test
+ * also verifies it really IS the ELF type it claims to cover (guards
+ * against toolchain defaults silently overriding the -pie/-no-pie flags).
+ */
+#include "discovery.h"
+
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+#include <unistd.h>
+#include <libgen.h>
+#include <elf.h>
+
+static int run = 0, ok = 0;
+#define CHECK(c, ...) do { \
+        run++; \
+        if (c) { ok++; } \
+        else { printf("  FAIL: "); printf(__VA_ARGS__); printf("\n"); } \
+    } while (0)
+
+/* A global with external linkage in .data: the self-resolution target.
+ * volatile + non-zero init keep it present and unmergeable. */
+volatile uint32_t pgwt_test_fixture_symbol = 0xC0FFEE42u;
+
+/* Locate tests/fixtures/ relative to this binary (cwd-independent). */
+static void fixture_path(char *out, size_t outsz, const char *name)
+{
+    char exe[512];
+    ssize_t n = readlink("/proc/self/exe", exe, sizeof(exe) - 1);
+    if (n < 0) { snprintf(out, outsz, "fixtures/%s", name); return; }
+    exe[n] = '\0';
+    snprintf(out, outsz, "%s/fixtures/%s", dirname(exe), name);
+}
+
+static uint64_t load_base_fixture(const char *name, const char *basename_)
+{
+    char path[600];
+    fixture_path(path, sizeof(path), name);
+    return pgwt_find_load_base_in_maps(path, basename_);
+}
+
+/* ELF type (ET_EXEC / ET_DYN) of a binary, for the PIE/non-PIE sanity check. */
+static int elf_type(const char *path)
+{
+    Elf64_Ehdr eh;
+    FILE *f = fopen(path, "rb");
+    if (!f) return -1;
+    size_t r = fread(&eh, 1, sizeof(eh), f);
+    fclose(f);
+    if (r != sizeof(eh) || memcmp(eh.e_ident, ELFMAG, SELFMAG) != 0)
+        return -1;
+    return eh.e_type;
+}
+
+int main(void)
+{
+    printf("=== test_discovery (%s build) ===\n",
+           PGWT_TEST_EXPECT_PIE ? "PIE" : "non-PIE");
+
+    /* ── 1. maps fixtures: pgwt_find_load_base_in_maps ─────────────── */
+
+    /* EL8 non-PIE PGDG: first mapping of the binary is the r-xp text
+     * segment at 0x400000 (no r--p below it). The old "first r--p" match
+     * returned the rodata base 0xf5d000 here → wrong VAs → zero events
+     * (the #24 symptom). */
+    CHECK(load_base_fixture("maps_el8_nonpie.txt", "postgres") == 0x400000ULL,
+          "EL8 non-PIE load base != 0x400000");
+
+    /* EL9 PIE PGDG: first mapping is the r--p ELF-header page. */
+    CHECK(load_base_fixture("maps_el9_pie.txt", "postgres") == 0x55d4c1000000ULL,
+          "EL9 PIE load base != 0x55d4c1000000");
+
+    /* Ubuntu PGDG deb, PIE. */
+    CHECK(load_base_fixture("maps_ubuntu_pie.txt", "postgres") == 0x5560d1a00000ULL,
+          "Ubuntu PIE load base != 0x5560d1a00000");
+
+    /* Binary not mapped at all → 0 (caller fails loudly, never guesses). */
+    CHECK(load_base_fixture("maps_ubuntu_pie.txt", "no_such_binary") == 0,
+          "missing basename should return 0");
+
+    /* ── CAP-4 adversarial case (fix owned by Phase T4) ───────────────
+     * pg_stat_statements.so mapped BELOW the binary; its path
+     * "/usr/lib/postgresql/17/lib/..." contains the substring "postgres",
+     * so the current whole-line strstr() match picks the .so's base.
+     * Correct answer: 0x5560d1a00000 (the binary). Current answer:
+     * 0x4f2a80000000 (the .so). This test PINS the current wrong behavior
+     * as an expected failure so the hazard stays visible; when T4 lands
+     * the exact-pathname match, flip this to assert the correct base.
+     * TODO(T4/CAP-4): assert == 0x5560d1a00000 and drop the xfail. */
+    {
+        uint64_t got = load_base_fixture("maps_ext_below_binary.txt", "postgres");
+        if (got == 0x5560d1a00000ULL) {
+            printf("  XPASS(CAP-4): extension-.so-below-binary now resolves the\n"
+                   "  BINARY's base — T4 fix landed? Promote this to a hard assert.\n");
+            run++; ok++;
+        } else {
+            CHECK(got == 0x4f2a80000000ULL,
+                  "CAP-4 fixture: got 0x%llx, expected the known-wrong .so base "
+                  "0x4f2a80000000 (current strstr behavior) — behavior changed "
+                  "without updating this test", (unsigned long long)got);
+            printf("  XFAIL(CAP-4/T4): substring match returns the extension .so's "
+                   "base below the binary\n"
+                   "  (documented hazard — the #24 class; exact-path match is "
+                   "owned by Phase T4)\n");
+        }
+    }
+
+    /* ── 2. self-resolution: the #24 regression test proper ───────────
+     * Resolve a known global in THIS binary through the real code path
+     * (ELF symbol table + /proc/self/maps + PIE/non-PIE base arithmetic)
+     * and compare against the symbol's actual address. */
+
+    char exe[512];
+    ssize_t n = readlink("/proc/self/exe", exe, sizeof(exe) - 1);
+    CHECK(n > 0, "readlink(/proc/self/exe) failed");
+    if (n > 0) {
+        exe[n] = '\0';
+        const char *base = strrchr(exe, '/');
+        base = base ? base + 1 : exe;
+
+        /* The build flag must have produced the ELF type it claims. */
+        int et = elf_type(exe);
+#if PGWT_TEST_EXPECT_PIE
+        CHECK(et == ET_DYN, "expected PIE (ET_DYN), got e_type=%d — "
+              "-pie flag did not take effect", et);
+#else
+        CHECK(et == ET_EXEC, "expected non-PIE (ET_EXEC), got e_type=%d — "
+              "-no-pie flag did not take effect", et);
+#endif
+
+        uint64_t sym_val = pgwt_find_symbol_offset(exe, "pgwt_test_fixture_symbol");
+        CHECK(sym_val != 0, "pgwt_find_symbol_offset found nothing");
+
+        uint64_t load_base = pgwt_find_load_base(getpid(), base);
+        CHECK(load_base != 0, "pgwt_find_load_base(self) returned 0");
+
+        uint64_t va = pgwt_resolve_symbol(exe, "pgwt_test_fixture_symbol",
+                                          getpid(), base);
+        uint64_t actual = (uint64_t)(uintptr_t)&pgwt_test_fixture_symbol;
+        CHECK(va == actual,
+              "resolved VA 0x%llx != actual &symbol 0x%llx (load_base=0x%llx, "
+              "sym_val=0x%llx) — the #24 load-base bug class",
+              (unsigned long long)va, (unsigned long long)actual,
+              (unsigned long long)load_base, (unsigned long long)sym_val);
+
+        /* And the resolved address must read back the magic value through
+         * /proc/<pid>/mem — exactly how the daemon consumes it. */
+        uint64_t readback = pgwt_read_pointer(getpid(), va);
+        CHECK((uint32_t)readback == 0xC0FFEE42u,
+              "read-through-/proc/mem at resolved VA gave 0x%llx, not the magic",
+              (unsigned long long)readback);
+    }
+
+    printf("\n%d/%d tests passed\n", ok, run);
+    return (ok == run) ? 0 : 1;
+}

--- a/tests/test_wait_event.c
+++ b/tests/test_wait_event.c
@@ -300,7 +300,14 @@ static void test_pg13_names(void)
  * active version-selected hardcoded tables even when no dynamic names
  * were loaded (PG13 has no pg_wait_events view) — before the fix, PG13
  * traces had no sidecar at all and pgwt-server silently decoded PG13 ids
- * with PG18 tables (PgSleep rendered as CheckpointWriteDelay). */
+ * with PG18 tables (PgSleep rendered as CheckpointWriteDelay).
+ *
+ * MUST RUN FIRST (fresh-process dyn state): dyn_max[] is 0-initialized at
+ * process start and only becomes -1 after a dyn_clear(). The daemon
+ * writes the sidecar in exactly that fresh state, and the first version
+ * of the fix passed this test only because an earlier test had already
+ * clear()ed — while a fresh daemon still wrote a bogus one-empty-entry
+ * sidecar. Running first reproduces the daemon's real initial state. */
 static void test_pg13_sidecar_roundtrip(void)
 {
     printf("--- PG13 name sidecar round-trip ---\n");
@@ -327,11 +334,17 @@ static void test_pg13_sidecar_roundtrip(void)
     snprintf(path, sizeof(path), "%s/wait_event_names.json", dir);
     remove(path);
     remove(dir);
+
+    /* Reset dynamic-name state for the remaining tests: an unparseable
+     * buffer makes the loader clear the dyn tables and return -1. */
+    CHECK(pgwt_load_event_names_from_buffer("no separators here") == -1,
+          "dyn reset via invalid buffer");
 }
 
 int main(void)
 {
     printf("=== test_wait_event ===\n");
+    test_pg13_sidecar_roundtrip();   /* FIRST: needs fresh-process dyn state */
     pgwt_init_event_names(18);
     test_cpu();
     test_io_events();
@@ -345,8 +358,7 @@ int main(void)
     test_extension();
     test_pg13_names();
     test_unknown_fallbacks();
-    test_dynamic_name_mapping();     /* near-last: sets dyn_loaded */
-    test_pg13_sidecar_roundtrip();   /* last: overwrites dyn tables from sidecar */
+    test_dynamic_name_mapping();  /* must run last: sets dyn_loaded */
 
     printf("\n%d/%d tests passed\n", tests_passed, tests_run);
     return (tests_passed == tests_run) ? 0 : 1;

--- a/tests/test_wait_event.c
+++ b/tests/test_wait_event.c
@@ -294,6 +294,41 @@ static void test_pg13_names(void)
     pgwt_init_event_names(18);
 }
 
+/* Regression (#8 mislabeling class; caught live by the CI capture-smoke
+ * PG13 cell): a trace recorded on PG13 must ship a name sidecar carrying
+ * the mapping it was WRITTEN with. pgwt_write_names_json() must dump the
+ * active version-selected hardcoded tables even when no dynamic names
+ * were loaded (PG13 has no pg_wait_events view) — before the fix, PG13
+ * traces had no sidecar at all and pgwt-server silently decoded PG13 ids
+ * with PG18 tables (PgSleep rendered as CheckpointWriteDelay). */
+static void test_pg13_sidecar_roundtrip(void)
+{
+    printf("--- PG13 name sidecar round-trip ---\n");
+
+    char dir[] = "/tmp/pgwt_names_XXXXXX";
+    CHECK(mkdtemp(dir) != NULL, "mkdtemp failed");
+
+    /* Daemon side: PG13 tables active, no dynamic names available. */
+    pgwt_init_event_names(13);
+    CHECK(pgwt_write_names_json(dir) == 0,
+          "write sidecar without dynamic names");
+
+    /* Reader side: fresh pgwt-server defaults to PG18 tables, then loads
+     * the sidecar — PG13 ids must decode with PG13 names afterwards. */
+    pgwt_init_event_names(18);
+    CHECK(pgwt_load_names_json(dir) == 0, "load sidecar");
+
+    CHECK_NAME(WEI(PG_WAIT_TIMEOUT, 1), "Timeout:PgSleep");      /* PG18 id1 = CheckpointWriteDelay */
+    CHECK_NAME(WEI(PG_WAIT_TIMEOUT, 4), "Timeout:VacuumDelay");  /* PG18 id4 = RecoveryRetrieve... */
+    CHECK_NAME(WEI(PG_WAIT_LWLOCK, 11), "LWLock:XactSLRU");      /* individual lock in PG13 */
+    CHECK_NAME(WEI(PG_WAIT_LOCK, 0),   "Lock:relation");
+
+    char path[600];
+    snprintf(path, sizeof(path), "%s/wait_event_names.json", dir);
+    remove(path);
+    remove(dir);
+}
+
 int main(void)
 {
     printf("=== test_wait_event ===\n");
@@ -310,7 +345,8 @@ int main(void)
     test_extension();
     test_pg13_names();
     test_unknown_fallbacks();
-    test_dynamic_name_mapping();  /* must run last: sets dyn_loaded */
+    test_dynamic_name_mapping();     /* near-last: sets dyn_loaded */
+    test_pg13_sidecar_roundtrip();   /* last: overwrites dyn tables from sidecar */
 
     printf("\n%d/%d tests passed\n", tests_passed, tests_run);
     return (tests_passed == tests_run) ? 0 : 1;

--- a/tests/unit_tests.list
+++ b/tests/unit_tests.list
@@ -1,0 +1,22 @@
+# unit_tests.list — the single source of truth for the C unit-test suite.
+#
+# Consumed by BOTH .github/workflows/ci.yml (via `make -C tests check`) and
+# tests/run_all.sh. Do not hand-maintain test lists anywhere else: TST-3 was
+# exactly that drift (test_event_writer/test_event_reader missing from
+# run_all.sh, test_concurrent_rw built but run nowhere).
+#
+# One binary name per line; '#' starts a comment. Every binary listed here
+# must be built by `make -C tests` (tests/Makefile TESTS).
+test_wait_event
+test_cmdline
+test_bucket
+test_event_writer
+test_event_reader
+test_trace_v2
+test_sampler
+test_anomaly
+test_coop
+test_concurrent_rw
+test_pg13_resolve
+test_discovery_pie
+test_discovery_nopie


### PR DESCRIPTION
## Phase T0 — Safety net: real-PG CI + gate hardening (Trust Milestone)

Owns findings **TST-1..8** from `docs/TRUST_MILESTONE_PLAN.md`. The meta-finding this phase fixes: all four field escapes to date (#8, #24, #30, #31) lived in the capture/discovery slice that CI never executed, `run_all.sh` passed when everything skipped, and the last three field fixes shipped with zero regression tests.

**Proof it works: the new job found (and this PR fixes) a live silent-wrong-data bug on its very first runs** — PG13 traces were decoded by `pgwt-server` with PG18 name tables (see "Bugs found by the job" below).

### 1. CI capture-smoke job (TST-1/2)

New `capture-smoke` job: matrix **PG 13 / 16 / 17 / 18** from PGDG apt (with an `apt-archive.postgresql.org` fallback for when the live repo drops EOL versions — 13.23 currently still ships from the live repo), `pg_stat_statements` preloaded everywhere (PG13 requires it for query attribution; PG14+ get `compute_query_id=on`).

`tests/ci_smoke.sh` drives `tests/test_capture_smoke.py`: a deterministic workload — `pg_sleep(3)`, a blocked `LOCK TABLE` pair released mid-window, a short pgbench run — asserted with **bounded durations** in **both** the live view output and the written trace file read back through `pgwt-server`. Zero captured events = red; that is the job's entire purpose.

- **`--mode tiered`** (the shipped default) is always a hard gate.
- **`--mode full`**: the script probes perf hardware-breakpoint availability empirically. **Empirical answer: watchpoints WORK on GitHub's Azure runners** — full-mode assertions and `test_deterministic.py` (exact counts/durations, 11/11) run as hard gates on every supported-version cell. If a future runner generation loses them, the section skips **loudly** into the job summary, never silently.
- **PG16 cell**: PG16 is not a supported version (Track D owns PG14–16; only PG13's PGPROC offset is validated). Instead of dropping the plan's cell, it asserts the **fail-safe contract**: the tracer must refuse loudly (non-zero exit + FATAL) on an unsupported version, never attach and trace garbage.
- Query attribution is cross-checked against `pg_stat_statements.queryid`, so phantom/junk ids cannot satisfy the assertion.

**What it would have caught:** #24 (wrong load base → zero events on non-PIE: every assertion goes red), #30 (sampled/tiered `--view` empty: the tiered live-view assertions go red), #31 (query-attr uprobe never fires on PG13: the PG13 cell's query assertions go red), and the #8 class (mislabeled events — it literally caught a live instance, below).

### 2. Bugs found by the job on its first runs (fixed here, with regression tests)

1. **PG13 traces silently mislabeled by `pgwt-server`** (the #8 class). The `wait_event_names.json` sidecar was only written when *dynamic* names loaded (PG17+); PG13 recorded traces with no sidecar, and `pgwt-server` decoded PG13 ids with PG18 tables — `Timeout:PgSleep` rendered as `Timeout:CheckpointWriteDelay`, silently, in every PG13 trace. Fix: the daemon always writes the sidecar with the mapping the trace is written with (dynamic if loaded, else the active version-selected tables).
2. **Fresh-process sidecar corruption.** `dyn_max[]` is zero-initialized (not `-1`) until the first `dyn_clear()`, so the first version of fix (1) wrote a bogus one-empty-entry table per class from a fresh daemon — and the unit test masked it because an earlier test had already cleared the state. The round-trip unit test now runs FIRST (the daemon's real fresh-process state); it reproduces the exact CI symptom against the old code.

### 3. discovery.c unit tests (TST-8, the #24 regression class)

`pgwt_find_load_base` / `pgwt_find_symbol_offset` broke in the field twice and had zero tests.

- Extracted `pgwt_find_load_base_in_maps(maps_path, basename)` (thin-wrapper refactor, no behavior change) so committed `/proc/<pid>/maps` fixtures can drive the parser: EL8 non-PIE PGDG, EL9 PIE, Ubuntu PIE (provenance in `tests/fixtures/README.md`).
- Adversarial **CAP-4** fixture: an extension `.so` whose path contains `postgres` mapped *below* the binary — the test pins the current (wrong) substring-match result as a documented expected-failure with a `TODO(T4)`; the exact-path fix is Phase T4's.
- `tests/test_discovery.c` is built **twice** (`-pie` / `-no-pie` — exactly the axis #24 broke on), asserts its own ELF type, resolves a known global in itself through the real code path, and requires the computed VA to equal the symbol's actual address, read back through `/proc/<pid>/mem` the way the daemon consumes it. A deliberate load-base regression fails in milliseconds, no PostgreSQL needed.

### 4. run_all.sh gate hardening (TST-3/4/5/7)

- **`--require-live`**: any skip in the root+PG live section is a failure — a non-root run exits 1 instead of green (verified). Independently, an executed==0 run can never report success.
- **Single shared unit list**: `tests/unit_tests.list` is consumed by both CI (`make -C tests check`) and `run_all.sh`. Fixes the TST-3 drift — `test_event_writer`/`test_event_reader` were missing from run_all, and `test_concurrent_rw` was built but run **nowhere** (it passes).
- **Orphaned live tests wired** (TST-7): `test_cross_validate_tiered.sh` (the test that justified tiered-by-default) and `test_anomaly_live.sh`. Note: `test_control.sh`, listed in the plan as orphaned, was already wired — the findings register is off by one there.
- **Overhead** (TST-5 partial): run_all now uses `--quick` (~10 min instead of ~70, which guaranteed it was skipped) and appends date+commit-stamped rows to the tracked `tests/results/overhead_trend.csv`.

### CI status

All jobs green, including all four capture-smoke cells: PG 13/17/18 = tiered 20/20 + full 20/20 + deterministic 11/11 each (watchpoints available and exercised); PG16 = loud-refusal contract PASS.

### Observations for later phases (deliberately not fixed here)

- **Fork→attach race is worse than "flaky"** (T4 scope, CAP-8 neighborhood): during pre-CI validation on a real box, full-mode capture recorded *nothing* for backends forked after tracer start (the shipped `test_query_event.py` fails there for this reason). The smoke test pre-opens its sessions — the documented `test_deterministic` technique.
- **ESC-3 live double-count reproduced** (T3 scope): the tiered live view showed a 3 s sleep as ~5.7 s (sampler + exact stream both feed the live accumulator). The live-view tolerance is widened to 7 s with a comment to tighten after T3.
- **FID-4 marker leakage reproduced** (T1 scope): `top_events` over real traces shows `Unknown:id=16777200..5` marker junk rows.
