### PR TITLE
T4: capture & sampler hardening (silent-wrong-data class)

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -475,3 +475,44 @@ that field depends on the PostgreSQL major version:
   `MyProc->wait_event_info`, but their verified PGPROC offsets and per-version
   name tables are not yet added, so the daemon fails fast at startup rather than
   capturing incorrect data. Support is planned.
+
+### Operational contracts (run under a supervisor)
+
+Two behaviors are by design and must be handled by your service manager:
+
+- **The daemon exits when the postmaster dies.** All resolved addresses
+  (load base, `MyProc`/`my_wait_event_info`, per-backend PGPROC slots) are
+  specific to one postmaster instance; after a PostgreSQL restart they are
+  meaningless, so the daemon exits with the reason
+  `PostgreSQL (PID ...) stopped` instead of guessing. Run it under systemd
+  so it re-attaches to the new postmaster automatically:
+
+  ```ini
+  [Service]
+  ExecStart=/usr/local/bin/pg_wait_tracer --daemon --mode tiered -T /var/lib/pgwt
+  Restart=always
+  RestartSec=5
+  # Watchpoint + bootstrap fds: 2 per backend + headroom (the daemon also
+  # raises RLIMIT_NOFILE itself at startup, but the hard limit must allow it)
+  LimitNOFILE=4096
+  ```
+
+  (`--daemon` already retries discovery in a loop; `Restart=always` covers
+  daemon crashes as well.)
+
+- **Same PID namespace as PostgreSQL.** The daemon matches BPF-reported
+  kernel PIDs against `/proc` and `postmaster.pid`, which assumes it shares
+  the PID namespace with PostgreSQL. Run it on the host for a host
+  PostgreSQL. For a containerized PostgreSQL, run the daemon **inside that
+  container** (or join its PID namespace, e.g.
+  `nsenter -t <postmaster-pid> -p`); running it on the host against a
+  container's PostgreSQL will mis-map PIDs.
+
+### File descriptor limits (many backends)
+
+Full/tiered capture holds up to two perf fds per backend. The daemon raises
+`RLIMIT_NOFILE` at startup to cover its 1024-backend registry, but it cannot
+exceed the hard limit granted to it. If you see
+`perf_event_open: ... file descriptor limit reached` in the log (each such
+failure also increments `wp_attach_failures_total` on the control socket),
+raise the hard limit: `LimitNOFILE=` in the systemd unit or `ulimit -Hn`.

--- a/Makefile
+++ b/Makefile
@@ -93,6 +93,7 @@ USER_SRCS  = $(SRC_DIR)/pg_wait_tracer.c \
              $(SRC_DIR)/event_stream.c \
              $(SRC_DIR)/output.c \
              $(SRC_DIR)/wait_event.c \
+             $(SRC_DIR)/spawn.c \
              $(SRC_DIR)/perf_event.c \
              $(SRC_DIR)/cmdline.c \
              $(SRC_DIR)/snapshot.c \
@@ -114,6 +115,7 @@ SERVER_SRCS = $(SRC_DIR)/server.c \
               $(SRC_DIR)/summary_writer.c \
               $(SRC_DIR)/summary_reader.c \
               $(SRC_DIR)/wait_event.c \
+              $(SRC_DIR)/spawn.c \
               $(SRC_DIR)/cmdline.c \
               $(SRC_DIR)/backend_meta.c \
               $(SRC_DIR)/cJSON.c

--- a/src/backend.c
+++ b/src/backend.c
@@ -14,6 +14,7 @@
 #include <time.h>
 #include <fcntl.h>
 #include <unistd.h>
+#include <errno.h>
 #include <bpf/libbpf.h>
 #include <bpf/bpf.h>
 #include "pg_wait_tracer.skel.h"
@@ -24,6 +25,7 @@ void pgwt_backend_init(struct pgwt_backend_table *bt)
     for (int i = 0; i < MAX_BACKENDS; i++) {
         bt->entries[i].wp_fd = -1;
         bt->entries[i].bootstrap_fd = -1;
+        bt->entries[i].wp_addr_shared = -1;
     }
 }
 
@@ -44,6 +46,7 @@ static struct pgwt_backend *alloc_backend(struct pgwt_backend_table *bt, pid_t p
             memset(&bt->entries[i], 0, sizeof(bt->entries[i]));
             bt->entries[i].wp_fd = -1;
             bt->entries[i].bootstrap_fd = -1;
+            bt->entries[i].wp_addr_shared = -1;
             bt->entries[i].pid = pid;
             bt->entries[i].is_alive = true;
             return &bt->entries[i];
@@ -59,6 +62,7 @@ static struct pgwt_backend *alloc_backend(struct pgwt_backend_table *bt, pid_t p
     memset(be, 0, sizeof(*be));
     be->wp_fd = -1;
     be->bootstrap_fd = -1;
+    be->wp_addr_shared = -1;
     be->pid = pid;
     be->is_alive = true;
     return be;
@@ -84,24 +88,72 @@ uint64_t pgwt_resolve_backend_wait_addr(struct pgwt_daemon *d, pid_t pid)
     return pgwt_read_pointer(pid, d->my_wait_ptr_addr);
 }
 
+/* Loud, once-only report that the BPF state_map is full (CAP-1). Every
+ * failed insert is a backend that will record NOTHING — never silent. */
+static void report_state_map_full(struct pgwt_daemon *d, pid_t pid)
+{
+    d->counters.state_map_full_total++;
+    if (d->state_map_full_logged)
+        return;
+    d->state_map_full_logged = true;
+    fprintf(stderr,
+            "ERROR: BPF state_map is FULL — cannot track PID %d (and any "
+            "further backend).\n"
+            "  Backends without a state_map entry record NO events/samples. "
+            "state_map_full_total on the control socket counts every "
+            "affected backend.\n",
+            pid);
+}
+
 /* Pre-seed the BPF state_map for a backend whose wait_event_info address is
  * already resolved (be->wp_addr). Reads the backend's CURRENT wait_event_info
  * and query_id and writes them as the initial state, so the first watchpoint
  * fire ACCUMULATES the in-progress wait instead of discarding it (otherwise a
  * backend already blocked at attach time — e.g. Lock:relation — loses its
- * opening interval). Idempotent via BPF_NOEXIST. */
-static void preseed_state_map(struct pgwt_daemon *d, pid_t pid, uint64_t addr,
-                              uint64_t attach_ts)
+ * opening interval).
+ *
+ * CAP-2/5 backstop: the value read here is classified on EVERY call (all PG
+ * versions, re-exercised on each escalation): a garbage class byte means the
+ * resolved address is wrong — counted + logged loudly, and never seeded as
+ * if it were a real wait. A non-zero valid reading (re)confirms the offset.
+ * Returns 0 on success, -1 if the state_map insert failed (map full). */
+static int preseed_state_map(struct pgwt_daemon *d, pid_t pid, uint64_t addr,
+                             uint64_t attach_ts)
 {
     char mem_path[64];
     snprintf(mem_path, sizeof(mem_path), "/proc/%d/mem", pid);
     int mem_fd = open(mem_path, O_RDONLY);
     if (mem_fd < 0)
-        return;
+        return 0;   /* backend gone — nothing to seed */
 
+    int rc = 0;
     uint32_t current_wei = 0;
     if (pread(mem_fd, &current_wei, sizeof(current_wei), addr) ==
         sizeof(current_wei)) {
+        switch (pgwt_classify_wei(current_wei)) {
+        case PGWT_WEI_VALID_NONZERO:
+            d->wait_offset_validated = true;   /* ongoing re-validation */
+            break;
+        case PGWT_WEI_GARBAGE:
+            d->counters.invalid_wait_reads_total++;
+            if (!d->invalid_wait_reads_logged) {
+                d->invalid_wait_reads_logged = true;
+                fprintf(stderr,
+                        "ERROR: wait_event_info read for PID %d returned "
+                        "0x%08x — invalid wait-event class byte.\n"
+                        "  The resolved address/offset is wrong for this "
+                        "PostgreSQL build; data from this address is NOT "
+                        "recorded (invalid_wait_reads_total counts these).\n",
+                        pid, current_wei);
+            }
+            /* Do not seed a garbage wait state; seed as on-CPU so nothing
+             * fabricated ever enters the trace. */
+            current_wei = 0;
+            break;
+        default:
+            break;   /* zero: consistent, not proof */
+        }
+
         /* Read current query_id from MyBEEntry->st_query_id */
         uint64_t current_qid = 0;
         if (d->my_be_entry_addr && d->st_query_id_offset > 0) {
@@ -127,10 +179,18 @@ static void preseed_state_map(struct pgwt_daemon *d, pid_t pid, uint64_t addr,
         /* BPF_ANY (not NOEXIST): on first full-mode attach this creates the
          * entry; on tiered RE-escalation it REFRESHES a reset/sampled entry to
          * the backend's CURRENT wait state, so an in-progress wait at escalate
-         * time is captured instead of being lost behind a stale last_event. */
-        bpf_map_update_elem(state_fd, &pid_key, &init_state, BPF_ANY);
+         * time is captured instead of being lost behind a stale last_event.
+         * (This BPF_ANY refresh also covers the PID-reuse window — CAP-9: a
+         * stale entry from a recycled PID is overwritten on every attach.)
+         * CAP-1: the insert is CHECKED — a full map is a backend that records
+         * nothing, which must never be silent. */
+        if (bpf_map_update_elem(state_fd, &pid_key, &init_state, BPF_ANY) != 0) {
+            report_state_map_full(d, pid);
+            rc = -1;
+        }
     }
     close(mem_fd);
+    return rc;
 }
 
 int pgwt_attach_backend_watchpoint(struct pgwt_daemon *d,
@@ -139,8 +199,12 @@ int pgwt_attach_backend_watchpoint(struct pgwt_daemon *d,
     if (be->wp_addr == 0 || be->wp_fd >= 0)
         return be->wp_fd >= 0 ? 0 : -1;
 
+    /* CAP-8 ordering: open DISABLED → preseed state_map → enable. Opening
+     * enabled first left a window where the first transition fired against
+     * an unseeded (or stale, on re-escalation) state entry and the opening
+     * interval was mis-timed. */
     int wp_prog_fd = bpf_program__fd(d->skel->progs.on_watchpoint);
-    be->wp_fd = pgwt_open_watchpoint(be->pid, be->wp_addr, wp_prog_fd);
+    be->wp_fd = pgwt_open_watchpoint_disabled(be->pid, be->wp_addr, wp_prog_fd);
     if (be->wp_fd < 0) {
         /* Process likely exited before attach — caller decides on cleanup. */
         d->counters.wp_attach_failures_total++;
@@ -150,6 +214,13 @@ int pgwt_attach_backend_watchpoint(struct pgwt_daemon *d,
     if (be->attach_ts == 0)
         be->attach_ts = now_ns();
     preseed_state_map(d, be->pid, be->wp_addr, be->attach_ts);
+
+    if (pgwt_watchpoint_enable(be->wp_fd) != 0) {
+        pgwt_close_watchpoint(be->wp_fd);
+        be->wp_fd = -1;
+        d->counters.wp_attach_failures_total++;
+        return -1;
+    }
     return 0;
 }
 
@@ -200,27 +271,37 @@ int pgwt_scan_existing_backends(struct pgwt_daemon *d)
             continue;
         }
 
-        /* Runtime validation (PG<17 MyProc path): the offset is global, so a
-         * single sane reading proves it. Check the first backend we resolve;
-         * if its wait_event_info value's class byte is garbage, the offset is
-         * wrong (custom build / mis-detected layout) — refuse to attach rather
-         * than trace nonsense. PG17+ skips this (my_wait_event_info already
-         * points exactly at the field). */
-        if (d->use_myproc && !d->wait_offset_validated) {
+        /* Runtime validation (CAP-2/3/5) — ALL versions. Classify the value
+         * at the resolved address for EVERY backend until one produces
+         * proof:
+         *   garbage class byte  → the offset/address is wrong (custom build
+         *                         / mis-detected layout) — refuse to attach
+         *                         rather than trace nonsense;
+         *   non-zero valid      → proof, offset validated;
+         *   zero                → NOT proof (zero is also the most likely
+         *                         reading from a wrong offset) — keep
+         *                         checking the remaining backends; if the
+         *                         whole scan proves nothing,
+         *                         pgwt_confirm_wait_offset() re-polls. */
+        if (!d->wait_offset_validated) {
             int v = pgwt_validate_wait_addr(pid, ptr);
-            if (v == 0) {
+            if (v == PGWT_WEI_GARBAGE) {
                 fprintf(stderr,
                         "FATAL: resolved wait_event_info for PID %d holds a value "
                         "with an invalid wait-event class byte.\n"
-                        "  offsetof(PGPROC, wait_event_info)=%d is likely wrong for "
-                        "this PG%d build — refusing to attach.\n",
-                        pid, d->pgproc_wait_offset, d->pg_major_version);
+                        "  %s is likely wrong for this PG%d build — refusing "
+                        "to attach.\n",
+                        pid,
+                        d->use_myproc
+                            ? "offsetof(PGPROC, wait_event_info)"
+                            : "the resolved my_wait_event_info address",
+                        d->pg_major_version);
                 closedir(proc);
-                return -1;
+                return -2;   /* validation refusal — caller must ABORT */
             }
-            if (v == 1)
+            if (v == PGWT_WEI_VALID_NONZERO)
                 d->wait_offset_validated = true;
-            /* v < 0: transient read error — try the next backend. */
+            /* v == PGWT_WEI_ZERO or v < 0: inconclusive — next backend. */
         }
 
         /* Already initialized — record the address. */
@@ -245,7 +326,12 @@ int pgwt_scan_existing_backends(struct pgwt_daemon *d)
                 .wait_event_addr = ptr,
             };
             uint32_t pid_key = pid;
-            bpf_map_update_elem(state_fd, &pid_key, &init_state, BPF_NOEXIST);
+            /* CAP-1: EEXIST is fine (idempotent seed); anything else means
+             * the map is full — this backend's query_ids will be missing. */
+            int urc = bpf_map_update_elem(state_fd, &pid_key, &init_state,
+                                          BPF_NOEXIST);
+            if (urc != 0 && urc != -EEXIST && errno != EEXIST)
+                report_state_map_full(d, pid);
 
             if (d->verbose)
                 fprintf(stderr, "INFO: tracking PID %d (%s), sampled at 0x%lx\n",
@@ -279,6 +365,87 @@ int pgwt_scan_existing_backends(struct pgwt_daemon *d)
     }
     closedir(proc);
     return count;
+}
+
+/* CAP-2/3: post-scan offset confirmation. Only reached when the initial scan
+ * resolved backends but NONE of them read a non-zero class-valid value at
+ * that instant. On a real PostgreSQL this is transient (aux processes sit in
+ * Activity:*Main waits almost always), so a short re-poll settles it; a
+ * WRONG offset pointing into zeroed memory reads zero FOREVER — exactly the
+ * case CAP-2 exists for — and must not be blessed. */
+int pgwt_confirm_wait_offset(struct pgwt_daemon *d)
+{
+    if (d->wait_offset_validated)
+        return 0;
+
+    /* Collect resolved live backends. */
+    int have_resolved = 0;
+    for (int i = 0; i < d->backends.count; i++)
+        if (d->backends.entries[i].is_alive
+            && d->backends.entries[i].pid > 0
+            && d->backends.entries[i].wp_addr != 0)
+            have_resolved++;
+    if (have_resolved == 0)
+        return 0;   /* nothing to confirm yet — handle_init validates later */
+
+    /* Re-poll for up to ~2s (40 × 50ms). Exits on the FIRST proof, so on a
+     * healthy system this costs one round. */
+    for (int round = 0; round < 40; round++) {
+        for (int i = 0; i < d->backends.count; i++) {
+            struct pgwt_backend *be = &d->backends.entries[i];
+            if (!be->is_alive || be->pid <= 0 || be->wp_addr == 0)
+                continue;
+            int v = pgwt_validate_wait_addr(be->pid, be->wp_addr);
+            if (v == PGWT_WEI_VALID_NONZERO) {
+                d->wait_offset_validated = true;
+                if (d->verbose)
+                    fprintf(stderr, "INFO: wait_event_info offset confirmed "
+                            "(PID %d, non-zero class-valid reading)\n",
+                            be->pid);
+                return 0;
+            }
+            if (v == PGWT_WEI_GARBAGE) {
+                fprintf(stderr,
+                        "FATAL: resolved wait_event_info for PID %d holds a "
+                        "value with an invalid wait-event class byte.\n"
+                        "  %s is wrong for this PG%d build — refusing to "
+                        "attach.\n",
+                        be->pid,
+                        d->use_myproc
+                            ? "offsetof(PGPROC, wait_event_info)"
+                            : "the resolved my_wait_event_info address",
+                        d->pg_major_version);
+                return -1;
+            }
+        }
+        usleep(50000);
+    }
+
+    if (d->use_myproc) {
+        /* Hardcoded-offset path (PG<17): an offset that cannot be confirmed
+         * is indistinguishable from a wrong one — fail safe, never trace
+         * garbage (or nothing) labeled as real. */
+        fprintf(stderr,
+                "FATAL: cannot confirm offsetof(PGPROC, wait_event_info)=%d "
+                "for PG%d: every reading from %d resolved backend(s) was "
+                "zero.\n"
+                "  A wrong offset into zeroed memory reads exactly this way. "
+                "Refusing to attach rather than record garbage or nothing.\n"
+                "  If this instance is genuinely all-idle, retry while a "
+                "session is waiting (e.g. run SELECT pg_sleep(60)).\n",
+                d->pgproc_wait_offset, d->pg_major_version, have_resolved);
+        return -1;
+    }
+
+    /* PG17+: the address comes from the backend's own my_wait_event_info
+     * pointer, so an unconfirmed (all-zero) state is far less suspicious —
+     * degrade to a loud warning; preseed/sampler reads keep re-validating. */
+    fprintf(stderr,
+            "WARN: wait_event_info address not yet confirmed by a non-zero "
+            "reading (%d backends, all on-CPU/zero). Validation continues on "
+            "every read; garbage readings will be counted and reported.\n",
+            have_resolved);
+    return 0;
 }
 
 int pgwt_handle_fork(struct pgwt_daemon *d, pid_t child_pid)
@@ -317,6 +484,23 @@ int pgwt_handle_fork(struct pgwt_daemon *d, pid_t child_pid)
         return -1;
     }
 
+    /* fork→attach race (T4/CAP-8, observed live by the T0 CI smoke job):
+     * the sched_process_fork event travels fork → BPF ringbuf → daemon
+     * epoll → here, while the child races through InitProcess(). If the
+     * child already WROTE the my_wait_event_info/MyProc pointer before the
+     * bootstrap watchpoint armed, the watchpoint NEVER fires and the backend
+     * records nothing, silently, for its whole life. Close the race by
+     * checking the pointer NOW that the watchpoint is armed: either the
+     * write comes later (watchpoint catches it) or it already happened
+     * (visible right here) — no gap between the two. */
+    uint64_t ptr = pgwt_resolve_backend_wait_addr(d, child_pid);
+    if (ptr != 0) {
+        if (d->verbose)
+            fprintf(stderr, "INFO: fork PID %d already initialized "
+                    "(fork->attach race) — attaching directly\n", child_pid);
+        return pgwt_handle_init(d, child_pid, ptr);
+    }
+
     if (d->verbose)
         fprintf(stderr, "INFO: fork detected PID %d, bootstrap watchpoint attached\n",
                 child_pid);
@@ -344,38 +528,44 @@ int pgwt_handle_init(struct pgwt_daemon *d, pid_t pid, uint64_t addr)
         be->wp_fd = -1;
     }
 
-    /* Runtime offset validation (PG<17 MyProc path), once. Covers the case
+    /* Runtime offset validation (CAP-2/5) — all versions. Covers the case
      * where PG was idle at daemon start (scan validated nothing) and the
      * first backend arrives via bootstrap→init. A garbage class byte means
-     * the offset is wrong — refuse rather than trace nonsense. */
-    if (d->use_myproc && !d->wait_offset_validated) {
+     * the offset/address is wrong — refuse rather than trace nonsense; a
+     * zero reading is NOT proof (keep validating on later backends). */
+    if (!d->wait_offset_validated) {
         int v = pgwt_validate_wait_addr(pid, addr);
-        if (v == 0) {
+        if (v == PGWT_WEI_GARBAGE) {
             fprintf(stderr,
                     "FATAL: resolved wait_event_info for PID %d holds a value "
                     "with an invalid wait-event class byte.\n"
-                    "  offsetof(PGPROC, wait_event_info)=%d is likely wrong for "
-                    "this PG%d build — refusing to attach.\n",
-                    pid, d->pgproc_wait_offset, d->pg_major_version);
+                    "  %s is likely wrong for this PG%d build — refusing to "
+                    "attach.\n",
+                    pid,
+                    d->use_myproc
+                        ? "offsetof(PGPROC, wait_event_info)"
+                        : "the resolved my_wait_event_info address",
+                    d->pg_major_version);
             return -1;
         }
-        if (v == 1)
+        if (v == PGWT_WEI_VALID_NONZERO)
             d->wait_offset_validated = true;
     }
 
-    /* Attach real watchpoint on PGPROC->wait_event_info */
+    /* Attach real watchpoint on PGPROC->wait_event_info via the shared
+     * helper: open DISABLED → preseed state_map → enable (CAP-8). This also
+     * closes the old gap where init-path backends were never preseeded (the
+     * raw BPF first-event path had to reconstruct their state). */
     be->wp_addr = addr;
-    int wp_prog_fd = bpf_program__fd(d->skel->progs.on_watchpoint);
-    be->wp_fd = pgwt_open_watchpoint(pid, addr, wp_prog_fd);
-    if (be->wp_fd < 0) {
+    be->wp_addr_shared = -1;   /* address may have changed — re-detect */
+    be->attach_ts = 0;         /* stamp attach time fresh in the helper */
+    if (pgwt_attach_backend_watchpoint(d, be) != 0) {
         /* Silently skip — process likely exited before attach */
-        d->counters.wp_attach_failures_total++;
         be->is_alive = false;
         be->pid = 0;
         return -1;
     }
 
-    be->attach_ts = now_ns();
     pgwt_parse_cmdline(pid, &be->meta);
     if (d->backend_meta)
         pgwt_bm_write(d->backend_meta, pid, &be->meta);

--- a/src/backend.c
+++ b/src/backend.c
@@ -261,7 +261,16 @@ int pgwt_scan_existing_backends(struct pgwt_daemon *d)
             continue;
 
         /* This is a postgres child. Resolve its wait_event_info address
-         * (PG17+ my_wait_event_info global; PG<17 MyProc + offset). */
+         * (PG17+ my_wait_event_info global; PG<17 MyProc + offset).
+         *
+         * Note: on PG17+ a long-lived process whose pointer still targets
+         * the process-local dummy (aux processes without a PGPROC, e.g.
+         * syslogger) is deliberately accepted here — the dummy IS that
+         * process's wait_event_info, so watchpointing it is correct. The
+         * one residual edge is a backend caught in its few-ms init window
+         * DURING this one-time scan (dummy now, PGPROC in a moment); the
+         * fork path (pgwt_handle_fork) closes the same race properly via
+         * the shared-memory check + bootstrap watchpoint. */
         uint64_t ptr = pgwt_resolve_backend_wait_addr(d, pid);
         if (ptr == 0) {
             /* Not yet initialized — treat as fresh fork */
@@ -492,9 +501,19 @@ int pgwt_handle_fork(struct pgwt_daemon *d, pid_t child_pid)
      * records nothing, silently, for its whole life. Close the race by
      * checking the pointer NOW that the watchpoint is armed: either the
      * write comes later (watchpoint catches it) or it already happened
-     * (visible right here) — no gap between the two. */
+     * (visible right here) — no gap between the two.
+     *
+     * "Already happened" must mean the pointer targets SHARED memory: on
+     * PG17+ my_wait_event_info is non-zero from the very first instruction
+     * (its static initializer points at the process-LOCAL dummy
+     * local_my_wait_event_info), so non-zero alone proves nothing —
+     * InitProcess is done only once the pointer targets the backend's
+     * PGPROC, which lives in shm. A local (non-shared) target here means
+     * init has not switched the pointer yet — the armed bootstrap
+     * watchpoint will catch that write. (PG<17: MyProc starts NULL, and a
+     * non-NULL PGPROC is in shm, so the same predicate holds.) */
     uint64_t ptr = pgwt_resolve_backend_wait_addr(d, child_pid);
-    if (ptr != 0) {
+    if (ptr != 0 && pgwt_addr_is_shared(child_pid, ptr) == 1) {
         if (d->verbose)
             fprintf(stderr, "INFO: fork PID %d already initialized "
                     "(fork->attach race) — attaching directly\n", child_pid);

--- a/src/backend.h
+++ b/src/backend.h
@@ -14,6 +14,10 @@ struct pgwt_backend {
     int      wp_fd;            /* real watchpoint perf_event fd (-1 if none) */
     int      bootstrap_fd;     /* bootstrap watchpoint fd (-1 if none) */
     uint64_t wp_addr;          /* PGPROC->wait_event_info address */
+    /* Is wp_addr in a MAP_SHARED mapping? -1 unknown (not yet checked),
+     * 0 process-local, 1 shared. SMP-2: the sampler may only batch-read
+     * SHARED addresses through one pid; local ones need per-pid reads. */
+    int      wp_addr_shared;
     uint64_t attach_ts;        /* monotonic ns when attached */
     bool     is_alive;
     struct pgwt_metadata meta;
@@ -55,6 +59,16 @@ int pgwt_attach_backend_watchpoint(struct pgwt_daemon *d,
  * path (PG17+ my_wait_event_info global vs PG<17 MyProc+offset). Returns 0 if
  * the backend has not yet set the pointer (still in early init). */
 uint64_t pgwt_resolve_backend_wait_addr(struct pgwt_daemon *d, pid_t pid);
+
+/* CAP-2/3: confirm the resolved wait_event_info addresses with a NON-ZERO
+ * class-valid reading before trusting them. Called once after the initial
+ * backend scan when the scan itself produced no proof (every backend read
+ * zero at that instant — also exactly what a WRONG offset reads forever).
+ * Re-polls the resolved backends briefly; on the PG<17 hardcoded-offset path
+ * an unconfirmed offset is FATAL (returns -1, refuse to attach); on PG17+
+ * (address derived from the backend's own pointer) it degrades to a loud
+ * warning. A garbage reading is FATAL on every version. */
+int pgwt_confirm_wait_offset(struct pgwt_daemon *d);
 
 /* Find backend by PID. Returns NULL if not found. */
 struct pgwt_backend *pgwt_find_backend(struct pgwt_backend_table *bt, pid_t pid);

--- a/src/bpf/pg_wait_tracer.bpf.c
+++ b/src/bpf/pg_wait_tracer.bpf.c
@@ -53,10 +53,18 @@ volatile const u32 pg13_qd_sourcetext_off = 0;   /* offsetof(QueryDesc, sourceTe
 /* Per-PID state: last event + timestamp for duration computation.
  * Must be regular HASH (not PERCPU) because a backend can migrate
  * between CPUs — we need the same last_ts regardless of CPU.
- * 512 entries is enough for any PG deployment; smaller = better cache. */
+ *
+ * CAP-1: sized to MAX_BACKENDS — the same capacity as the userspace backend
+ * registry. It was 512 (< MAX_BACKENDS < common max_connections): above 512
+ * live backends every insert failed silently and those backends NEVER
+ * recorded an event. Inserts are now also CHECKED (fail_counters slot
+ * PGWT_BPF_FAIL_STATE_MAP + the userspace state_map_full_total counter), and
+ * the daemon may shrink the map before load via PGWT_STATE_MAP_ENTRIES
+ * (test hook — proves the loud path without 1024 real connections).
+ * Memory cost at 1024 entries × ~40B values is ~100KB — negligible. */
 struct {
     __uint(type, BPF_MAP_TYPE_HASH);
-    __uint(max_entries, 512);
+    __uint(max_entries, MAX_BACKENDS);
     __type(key, u32);
     __type(value, struct pgwt_pid_state);
 } state_map SEC(".maps");
@@ -105,6 +113,26 @@ struct {
     __type(key, u32);
     __type(value, u64);
 } ringbuf_drops SEC(".maps");
+
+/* Map-insert failure counters (CAP-1/CAP-6). Slots defined in
+ * pg_wait_tracer.h (PGWT_BPF_FAIL_*). PERCPU so the hot path stays
+ * atomic-free; the daemon sums across CPUs and surfaces them as
+ * state_map_full_total / seen_query_ids_full_total on the control socket.
+ * A full map must NEVER be silent: it means backends that record nothing
+ * (state_map) or query text that is never captured (seen_query_ids). */
+struct {
+    __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+    __uint(max_entries, PGWT_BPF_FAIL_MAX);
+    __type(key, u32);
+    __type(value, u64);
+} fail_counters SEC(".maps");
+
+static __always_inline void count_map_fail(u32 slot)
+{
+    u64 *c = bpf_map_lookup_elem(&fail_counters, &slot);
+    if (c)
+        (*c)++;
+}
 
 /* Emit a trace event to event_ringbuf, counting drops on failure.
  * bpf_ringbuf_output() returns 0 on success, negative when the ring is full. */
@@ -253,7 +281,10 @@ int on_watchpoint(struct bpf_perf_event_data *ctx)
             .be_entry_ptr = resolve_be_entry(),
             .wait_event_addr = wait_addr,
         };
-        bpf_map_update_elem(&state_map, &pid, &new_st, BPF_ANY);
+        /* CAP-1: a failed insert (map full) means this backend will never
+         * record a single event — count it so the daemon can scream. */
+        if (bpf_map_update_elem(&state_map, &pid, &new_st, BPF_ANY))
+            count_map_fail(PGWT_BPF_FAIL_STATE_MAP);
     }
     return 0;
 }
@@ -472,9 +503,12 @@ int on_report_query_id(struct pt_regs *ctx)
         bpf_ringbuf_submit(evt, 0);
     }
 
-    /* Mark as seen */
+    /* Mark as seen. CAP-6: when the map is full the insert fails and text
+     * for NEW query_ids is never captured again — count it (the daemon
+     * logs once and surfaces seen_query_ids_full_total). */
     u8 one = 1;
-    bpf_map_update_elem(&seen_query_ids, &query_id, &one, BPF_ANY);
+    if (bpf_map_update_elem(&seen_query_ids, &query_id, &one, BPF_ANY))
+        count_map_fail(PGWT_BPF_FAIL_SEEN_QIDS);
 
     return 0;
 }
@@ -553,7 +587,8 @@ int on_executor_start(struct pt_regs *ctx)
     }
 
     u8 one = 1;
-    bpf_map_update_elem(&seen_query_ids, &query_id, &one, BPF_ANY);
+    if (bpf_map_update_elem(&seen_query_ids, &query_id, &one, BPF_ANY))
+        count_map_fail(PGWT_BPF_FAIL_SEEN_QIDS);
 
     return 0;
 }

--- a/src/control.c
+++ b/src/control.c
@@ -5,6 +5,8 @@
 #include "event_writer.h"
 #include "provider.h"
 #include "escalation.h"
+#include "sampler.h"
+#include "map_reader.h"
 #include "cJSON.h"
 
 #include <stdio.h>
@@ -109,6 +111,23 @@ static cJSON *build_status(const struct pgwt_daemon *d)
                             d->escalation.active
                                 ? esc_reason_str(d->escalation.window_reason)
                                 : "none");
+
+    /* Sampler read health (SMP-1). A total read failure renders as an idle
+     * database in the DATA — this out-of-band flag is how a client can tell
+     * "idle" from "blind". healthy=true when no sampler runs (full mode). */
+    bool sampler_healthy = true;
+    char reason[160] = "";
+    if (d->sampler && !d->sampler->health.healthy) {
+        sampler_healthy = false;
+        snprintf(reason, sizeof(reason),
+                 "sampler reads failing: %s (%llu consecutive ticks, "
+                 "%llu total)",
+                 strerror(d->sampler->health.last_errno),
+                 (unsigned long long)d->sampler->health.consec_failed_ticks,
+                 (unsigned long long)d->sampler->health.failed_ticks_total);
+    }
+    cJSON_AddBoolToObject(root, "sampler_healthy", sampler_healthy);
+    cJSON_AddStringToObject(root, "sampler_unhealthy_reason", reason);
     return root;
 }
 
@@ -138,6 +157,26 @@ static cJSON *build_metrics(const struct pgwt_daemon *d)
     cJSON_AddNumberToObject(root, "samples_per_sec", ctr->samples_per_sec);
     cjson_add_uint64(root, "sample_read_faults_total",
                      ctr->sample_read_faults_total);
+    cjson_add_uint64(root, "sampler_ticks_missed_total",
+                     ctr->sampler_ticks_missed_total);
+
+    /* Capture hardening (T4): any non-zero here is a loudly-logged problem.
+     * state_map_full_total = BPF-side insert failures + userspace
+     * preseed/seed failures (each one is a backend recording nothing or
+     * losing query attribution — CAP-1). seen_query_ids_full_total = query
+     * text capture lost for new ids (CAP-6). invalid_wait_reads_total =
+     * garbage class-byte readings dropped (wrong offset backstop, CAP-2/5). */
+    cjson_add_uint64(root, "state_map_full_total",
+                     ctr->state_map_full_total
+                     + pgwt_read_bpf_fail_counter((struct pgwt_daemon *)d,
+                                                  PGWT_BPF_FAIL_STATE_MAP));
+    cjson_add_uint64(root, "seen_query_ids_full_total",
+                     pgwt_read_bpf_fail_counter((struct pgwt_daemon *)d,
+                                                PGWT_BPF_FAIL_SEEN_QIDS));
+    cjson_add_uint64(root, "invalid_wait_reads_total",
+                     ctr->invalid_wait_reads_total);
+    cJSON_AddBoolToObject(root, "sampler_healthy",
+                          !(d->sampler && !d->sampler->health.healthy));
 
     /* Provider self-metrics. ringbuf_drops_total is the full tier's BPF-side
      * event_ringbuf drop count (A2 wired this; A0 deliberately omitted it). */

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -20,6 +20,7 @@
 #include <sys/epoll.h>
 #include <sys/timerfd.h>
 #include <sys/signalfd.h>
+#include <sys/resource.h>
 
 #include <bpf/libbpf.h>
 #include <bpf/bpf.h>
@@ -146,6 +147,19 @@ static void handle_timer(struct pgwt_daemon *d)
             pgwt_summary_cleanup_old_files(d->summary_writer);
     }
 
+    /* CAP-6: the BPF seen_query_ids dedup map (4096 entries) never ages;
+     * once full, query TEXT for new query_ids is silently never captured
+     * again. Log it once; seen_query_ids_full_total keeps counting. */
+    if (!d->seen_qids_full_logged
+        && pgwt_read_bpf_fail_counter(d, PGWT_BPF_FAIL_SEEN_QIDS) > 0) {
+        d->seen_qids_full_logged = true;
+        fprintf(stderr,
+                "WARN: BPF seen_query_ids map is FULL (4096 unique query_ids)"
+                " — query TEXT for new query_ids will no longer be captured "
+                "(ids and waits are unaffected). Restart the daemon to reset;"
+                " seen_query_ids_full_total counts the misses.\n");
+    }
+
     /* Refresh recent event/sample rates for control-socket metrics */
     if (d->interval > 0) {
         d->counters.events_per_sec =
@@ -166,11 +180,56 @@ static void handle_timer(struct pgwt_daemon *d)
 
 static void handle_sample_timer(struct pgwt_daemon *d)
 {
-    uint64_t expirations;
+    uint64_t expirations = 0;
     ssize_t r = read(d->sample_timer_fd, &expirations, sizeof(expirations));
-    (void)r;
+    /* SMP-3: expirations > 1 means the daemon stalled and ticks coalesced —
+     * those samples are gone. The sampler compensates by weighting each tick
+     * with the MEASURED inter-tick elapsed time (see pgwt_sampler_poll), so
+     * the loss is in resolution, not in total weight. Count it so a chronic
+     * stall is visible on the control socket. */
+    if (r == (ssize_t)sizeof(expirations) && expirations > 1)
+        d->counters.sampler_ticks_missed_total += expirations - 1;
     if (d->provider && d->provider->poll)
         d->provider->poll(d);
+}
+
+/* CAP-12: raise RLIMIT_NOFILE to what MAX_BACKENDS needs. Full/tiered mode
+ * holds up to two perf fds per backend (watchpoint + bootstrap) plus BPF
+ * maps/ringbufs, trace files and the control socket; the common default of
+ * 1024 is below that, and hitting it turns every further attach into a
+ * quiet EMFILE failure (now also loudly reported in perf_event.c). */
+static void bump_rlimit_nofile(struct pgwt_daemon *d)
+{
+    const rlim_t need = MAX_BACKENDS * 2 + 512;
+    struct rlimit rl;
+    if (getrlimit(RLIMIT_NOFILE, &rl) != 0)
+        return;
+    if (rl.rlim_cur >= need)
+        return;
+
+    struct rlimit want = rl;
+    want.rlim_cur = need;
+    if (want.rlim_max != RLIM_INFINITY && want.rlim_max < need)
+        want.rlim_max = need;   /* root may raise the hard limit */
+    if (setrlimit(RLIMIT_NOFILE, &want) == 0) {
+        if (d->verbose)
+            fprintf(stderr, "INFO: RLIMIT_NOFILE raised %llu -> %llu\n",
+                    (unsigned long long)rl.rlim_cur,
+                    (unsigned long long)need);
+        return;
+    }
+    /* Could not raise the hard limit (not root?) — take what we can get. */
+    want.rlim_max = rl.rlim_max;
+    want.rlim_cur = (rl.rlim_max == RLIM_INFINITY || rl.rlim_max > need)
+                  ? need : rl.rlim_max;
+    if (setrlimit(RLIMIT_NOFILE, &want) == 0 && want.rlim_cur >= need)
+        return;
+    fprintf(stderr,
+            "WARN: RLIMIT_NOFILE is %llu (< %llu needed for %d backends). "
+            "Watchpoint attach will fail with EMFILE beyond the limit — "
+            "raise the hard limit (ulimit -Hn / LimitNOFILE=).\n",
+            (unsigned long long)want.rlim_cur, (unsigned long long)need,
+            MAX_BACKENDS);
 }
 
 static void handle_signal(struct pgwt_daemon *d)
@@ -184,6 +243,10 @@ static void handle_signal(struct pgwt_daemon *d)
 int pgwt_daemon_init(struct pgwt_daemon *d)
 {
     int err;
+
+    /* CAP-12: enough fds for a full-size backend registry, before anything
+     * starts opening watchpoints. */
+    bump_rlimit_nofile(d);
 
     /* Select the capture provider for this mode. FULL (default) is the
      * original watchpoint path; SAMPLED is the userspace tier; TIERED runs
@@ -247,6 +310,21 @@ int pgwt_daemon_init(struct pgwt_daemon *d)
     d->skel->rodata->pg13_qd_plannedstmt_off = (uint32_t)d->pg13_qd_plannedstmt_off;
     d->skel->rodata->pg13_ps_queryid_off = (uint32_t)d->pg13_ps_queryid_off;
     d->skel->rodata->pg13_qd_sourcetext_off = (uint32_t)d->pg13_qd_sourcetext_off;
+
+    /* CAP-1: state_map is compiled at MAX_BACKENDS entries (the registry
+     * capacity). PGWT_STATE_MAP_ENTRIES shrinks it before load — a TEST hook
+     * so CI can prove the map-full loud path with a handful of connections
+     * instead of >1024 real ones. Never set it in production. */
+    {
+        const char *sme = getenv("PGWT_STATE_MAP_ENTRIES");
+        if (sme && atoi(sme) > 0) {
+            uint32_t entries = (uint32_t)atoi(sme);
+            bpf_map__set_max_entries(d->skel->maps.state_map, entries);
+            fprintf(stderr, "WARN: PGWT_STATE_MAP_ENTRIES=%u — state_map "
+                    "shrunk below MAX_BACKENDS (test hook; backends beyond "
+                    "this record nothing, loudly)\n", entries);
+        }
+    }
 
     /* Resolve debug_query_string address for BPF query text capture */
     if (d->pg_binary_saved) {
@@ -478,11 +556,24 @@ int pgwt_daemon_init(struct pgwt_daemon *d)
     /* Scan existing backends (tracepoints are already attached,
      * so any new forks during scan will be caught) */
     int n = pgwt_scan_existing_backends(d);
-    if (n < 0) {
+    if (n == -2) {
+        /* Runtime offset validation refused (garbage class byte). The old
+         * code path degraded this to a WARN and kept running — the exact
+         * silent-garbage failure CAP-2 exists to prevent. Abort. */
+        goto fail;
+    } else if (n < 0) {
         fprintf(stderr, "WARN: scan_existing_backends failed\n");
     } else if (d->verbose) {
         fprintf(stderr, "INFO: attached to %d existing backends\n", n);
     }
+
+    /* CAP-2/3: if the scan resolved backends but none produced a NON-ZERO
+     * class-valid reading, re-poll briefly and refuse to run on the
+     * hardcoded-offset path (PG<17) if the offset still cannot be confirmed
+     * — a wrong offset into zeroed memory reads zero forever, and blessing
+     * it would trace garbage (or nothing) labeled as real. */
+    if (pgwt_confirm_wait_offset(d) != 0)
+        goto fail;
 
     /* Create timer fd */
     d->timer_fd = timerfd_create(CLOCK_MONOTONIC, TFD_CLOEXEC);

--- a/src/daemon.h
+++ b/src/daemon.h
@@ -39,6 +39,12 @@ struct pgwt_counters {
     uint64_t prev_samples_total;       /* samples_total at previous timer tick */
     double   samples_per_sec;          /* recent sample rate, refreshed each tick */
     uint64_t sample_read_faults_total; /* process_vm_readv partial/EFAULT fallbacks */
+
+    /* Capture hardening (T4). All of these mean "something the operator
+     * must know about is happening" — each is paired with a loud log. */
+    uint64_t state_map_full_total;     /* userspace state_map inserts failed (map full, CAP-1) */
+    uint64_t invalid_wait_reads_total; /* wait_event_info reads with a garbage class byte (CAP-2/5) */
+    uint64_t sampler_ticks_missed_total; /* sampler timer expirations coalesced/missed (SMP-3) */
 };
 
 /* View modes */
@@ -172,6 +178,12 @@ struct pgwt_daemon {
     /* Control socket (D4) — created when trace_dir is set */
     struct pgwt_control *control;           /* NULL if disabled/unavailable */
     struct pgwt_counters counters;          /* self-observability (D6) */
+
+    /* Log-once latches for loud degradation warnings (T4). The counters
+     * above keep counting; the log fires once so it cannot flood. */
+    bool state_map_full_logged;      /* CAP-1 */
+    bool seen_qids_full_logged;      /* CAP-6 */
+    bool invalid_wait_reads_logged;  /* CAP-2/5 backstop */
 
     /* State */
     struct pgwt_backend_table backends;

--- a/src/discovery.c
+++ b/src/discovery.c
@@ -1,6 +1,7 @@
 /* discovery.c — Postmaster PID, ELF symbol offset, /proc helpers,
  *                PG version detection, st_query_id offset detection */
 #include "discovery.h"
+#include "pg_wait_tracer.h"   /* pgwt_classify_wei, PGWT_WEI_* */
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -138,13 +139,16 @@ static uint64_t elf_base_vaddr(const char *binary)
 }
 
 uint64_t pgwt_resolve_symbol(const char *binary, const char *symbol,
-                             pid_t pid, const char *binary_basename)
+                             pid_t pid)
 {
     uint64_t sym_val = pgwt_find_symbol_offset(binary, symbol);
     if (sym_val == 0)
         return 0;
 
-    uint64_t load_base = pgwt_find_load_base(pid, binary_basename);
+    /* Load base is matched against the FULL binary path (CAP-4): a basename
+     * or substring match can hit an extension .so whose path contains
+     * "postgres" and is mapped below the binary. */
+    uint64_t load_base = pgwt_find_load_base(pid, binary);
     if (load_base == 0)
         return 0;
 
@@ -155,12 +159,74 @@ uint64_t pgwt_resolve_symbol(const char *binary, const char *symbol,
     return sym_val - elf_base + load_base;
 }
 
+/* Extract the pathname field from a /proc/<pid>/maps line, in place.
+ * Format: "address perms offset dev inode   pathname\n" — the pathname is
+ * everything after the 5th field (it may itself contain spaces). Returns
+ * NULL for anonymous mappings (no pathname field). */
+static char *maps_line_pathname(char *line)
+{
+    char *p = line;
+    for (int field = 0; field < 5; field++) {
+        while (*p && *p != ' ' && *p != '\t')
+            p++;                     /* skip field */
+        while (*p == ' ' || *p == '\t')
+            p++;                     /* skip separator */
+    }
+    if (*p == '\0' || *p == '\n')
+        return NULL;
+    char *nl = strchr(p, '\n');
+    if (nl)
+        *nl = '\0';
+    return p;
+}
+
+/* Does this maps pathname refer to `binary_path`?
+ *
+ * CAP-4 (the #24 class): this used to be strstr(line, basename) over the
+ * whole line, which also matched extension libraries whose PATH contains
+ * "postgres" (e.g. /usr/lib/postgresql/17/lib/pg_stat_statements.so). Under
+ * PIE, such a .so mapped below the binary won the "lowest match" and every
+ * resolved symbol VA was garbage — zero events, silently. The match is now
+ * EXACT:
+ *   - binary_path with a '/': full-pathname equality against the maps field
+ *     (this is the daemon's path — /proc/<pid>/exe and the maps pathname
+ *     both come from the kernel's dentry path, so they agree);
+ *   - bare name: exact-basename equality (unit-test fixtures; never a
+ *     substring match).
+ * A " (deleted)" suffix (binary replaced while running) is tolerated on
+ * either side — both /proc/<pid>/exe and maps grow the same suffix. */
+static int maps_path_matches(const char *maps_path_field,
+                             const char *binary_path)
+{
+    static const char DELETED[] = " (deleted)";
+
+    /* Strip " (deleted)" suffixes for comparison. */
+    char field[512], want[512];
+    snprintf(field, sizeof(field), "%s", maps_path_field);
+    snprintf(want, sizeof(want), "%s", binary_path);
+    size_t fl = strlen(field), wl = strlen(want), dl = sizeof(DELETED) - 1;
+    if (fl > dl && strcmp(field + fl - dl, DELETED) == 0)
+        field[fl - dl] = '\0';
+    if (wl > dl && strcmp(want + wl - dl, DELETED) == 0)
+        want[wl - dl] = '\0';
+
+    if (strchr(want, '/'))
+        return strcmp(field, want) == 0;
+
+    const char *bn = strrchr(field, '/');
+    bn = bn ? bn + 1 : field;
+    return strcmp(bn, want) == 0;
+}
+
 /* Parse a maps file (the /proc/<pid>/maps format) and return the load base
- * for the given binary basename. Split out from pgwt_find_load_base so unit
- * tests can drive it with committed fixture files (tests/test_discovery.c —
- * the #24 regression class: EL8 non-PIE vs EL9/Ubuntu PIE layouts). */
+ * for the given binary. `binary_path` is matched exactly against the
+ * pathname field (full path, or exact basename if it contains no '/' —
+ * see maps_path_matches). Split out from pgwt_find_load_base so unit tests
+ * can drive it with committed fixture files (tests/test_discovery.c —
+ * the #24 regression class: EL8 non-PIE vs EL9/Ubuntu PIE layouts, plus the
+ * CAP-4 adversarial extension-.so-below-binary case). */
 uint64_t pgwt_find_load_base_in_maps(const char *maps_path,
-                                     const char *binary_basename)
+                                     const char *binary_path)
 {
     FILE *f = fopen(maps_path, "r");
     if (!f) {
@@ -171,7 +237,8 @@ uint64_t pgwt_find_load_base_in_maps(const char *maps_path,
     uint64_t base = 0;
     char line[512];
     while (fgets(line, sizeof(line), f)) {
-        if (!strstr(line, binary_basename))
+        char *path_field = maps_line_pathname(line);
+        if (!path_field || !maps_path_matches(path_field, binary_path))
             continue;
         /* The load base is the LOWEST-address mapping of the binary.
          * /proc/<pid>/maps is sorted by start address, so the first mapping
@@ -195,15 +262,54 @@ uint64_t pgwt_find_load_base_in_maps(const char *maps_path,
 
     if (base == 0)
         fprintf(stderr, "Load base for '%s' not found in %s\n",
-                binary_basename, maps_path);
+                binary_path, maps_path);
     return base;
 }
 
-uint64_t pgwt_find_load_base(pid_t pid, const char *binary_basename)
+uint64_t pgwt_find_load_base(pid_t pid, const char *binary_path)
 {
     char path[64];
     snprintf(path, sizeof(path), "/proc/%d/maps", pid);
-    return pgwt_find_load_base_in_maps(path, binary_basename);
+    return pgwt_find_load_base_in_maps(path, binary_path);
+}
+
+/* Is `addr` inside a MAP_SHARED mapping of process `pid`? (SMP-2)
+ *
+ * The sampler may batch-read many backends' wait_event_info through ONE
+ * reader pid — sound ONLY for addresses in PG's shared memory (mapped at the
+ * same VA in every backend AND backed by the same pages). A process-LOCAL
+ * address (.data/.bss — e.g. the my_wait_event_info dummy in aux processes
+ * without a PGPROC) exists at the same VA in every forked child but is
+ * backed by PRIVATE pages: reading it through another pid SUCCEEDS and
+ * returns the reader's value, silently misattributed. The 's' perm bit in
+ * /proc/<pid>/maps distinguishes the two.
+ *
+ * Returns 1 (shared), 0 (private / not found), -1 (maps unreadable).
+ * Callers must treat anything but 1 as "not batchable" (per-pid reads). */
+int pgwt_addr_is_shared(pid_t pid, uint64_t addr)
+{
+    char path[64];
+    snprintf(path, sizeof(path), "/proc/%d/maps", pid);
+    FILE *f = fopen(path, "r");
+    if (!f)
+        return -1;
+
+    int result = 0;
+    char line[512];
+    while (fgets(line, sizeof(line), f)) {
+        unsigned long long start = 0, end = 0;
+        char perms[8] = "";
+        if (sscanf(line, "%llx-%llx %7s", &start, &end, perms) != 3)
+            continue;
+        if (addr < start)
+            break;      /* maps is address-sorted — no containing range */
+        if (addr >= end)
+            continue;
+        result = (perms[3] == 's') ? 1 : 0;
+        break;
+    }
+    fclose(f);
+    return result;
 }
 
 uint64_t pgwt_read_pointer(pid_t pid, uint64_t addr)
@@ -249,7 +355,18 @@ int pgwt_detect_pgproc_wait_offset(int pg_major)
      * PG14/15/16 deliberately omitted here until their offset is header-derived
      * and validated; the runtime guard (pgwt_validate_wait_addr) refuses to
      * attach if an offset is wrong, so a missing entry fails safe rather than
-     * tracing garbage. */
+     * tracing garbage.
+     *
+     * CAP-3 CONSTRAINT: these values are from ONE build (PGDG RPM/deb,
+     * default configure flags, x86_64). PGPROC layout is NOT ABI-stable
+     * across configure options (e.g. --with-blocksize, atomics fallbacks) or
+     * forks — a custom build can shift the field. The offsets here are
+     * therefore only a HYPOTHESIS; the strict runtime validation is the
+     * authority: the daemon refuses to attach until at least one backend
+     * reads a NON-ZERO value with a valid wait-class byte at the resolved
+     * address (see pgwt_confirm_wait_offset / pgwt_validate_wait_addr —
+     * zero readings are never accepted as proof), and every later read path
+     * (preseed, sampler) keeps classifying values and screams on garbage. */
     case 13: return 684;
     default: return 0;
     }
@@ -335,34 +452,39 @@ int pgwt_validate_wait_addr(pid_t pid, uint64_t wait_addr)
     if (r != (ssize_t)sizeof(wei))
         return -1;
 
-    /* Class byte is the high byte. CPU (0x00000000) is valid (not waiting);
-     * otherwise the class must be a known wait-event class. PG wait classes
-     * occupy 0x01..0x0B (LWLock..InjectionPoint); anything else means the
-     * offset is wrong (custom build / mis-detected layout). */
-    if (wei == 0)
-        return 1;
-    unsigned cls = (wei >> 24) & 0xFF;
-    if (cls >= 0x01 && cls <= 0x0B)
-        return 1;
-    return 0;
+    /* Classify the reading (pgwt_classify_wei, pg_wait_tracer.h):
+     *   PGWT_WEI_GARBAGE (0)       — unknown class byte: the offset is wrong
+     *                                (custom build / mis-detected layout).
+     *   PGWT_WEI_VALID_NONZERO (1) — a real wait class: PROOF the address
+     *                                is right.
+     *   PGWT_WEI_ZERO (2)          — on-CPU. Consistent with a correct
+     *                                address, but ALSO the most likely read
+     *                                from a WRONG offset (zeroed memory) —
+     *                                CAP-2: callers must NEVER take zero as
+     *                                validation proof, only as "keep
+     *                                checking other backends / later". */
+    return pgwt_classify_wei(wei);
 }
 
 /* ── PG Version Detection ─────────────────────────────────── */
 
+#include "spawn.h"
+
 int pgwt_detect_pg_version(const char *pg_binary)
 {
-    char cmd[512];
-    snprintf(cmd, sizeof(cmd), "%s --version 2>/dev/null", pg_binary);
-
-    FILE *fp = popen(cmd, "r");
-    if (!fp) {
+    /* CAP-7: run the binary directly (fork/execvp, no shell) — the path
+     * comes from /proc/<pid>/exe and must never touch a shell command line
+     * in a root daemon. */
+    char *argv[] = { (char *)pg_binary, "--version", NULL };
+    struct pgwt_proc proc;
+    if (pgwt_proc_open(&proc, argv) != 0) {
         fprintf(stderr, "WARN: cannot run '%s --version'\n", pg_binary);
         return 0;
     }
 
-    char line[256];
+    char line[256] = "";
     int major = 0;
-    if (fgets(line, sizeof(line), fp)) {
+    if (fgets(line, sizeof(line), proc.out)) {
         /* Format: "postgres (PostgreSQL) 18.2" or "postgres (PostgreSQL) 14.12" */
         char *p = strstr(line, "PostgreSQL");
         if (p) {
@@ -373,7 +495,7 @@ int pgwt_detect_pg_version(const char *pg_binary)
             major = atoi(p);
         }
     }
-    pclose(fp);
+    pgwt_proc_close(&proc);
 
     if (major < 1 || major > 99) {
         fprintf(stderr, "WARN: cannot parse PG version from '%s'\n", line);
@@ -384,39 +506,71 @@ int pgwt_detect_pg_version(const char *pg_binary)
 
 /* ── st_query_id Offset Detection ─────────────────────────── */
 
+/* Extract the trailing decimal integer from a line ("[0-9]+$" after
+ * stripping the newline), or 0 if the line does not end in digits. */
+static int trailing_int(const char *line)
+{
+    size_t len = strlen(line);
+    while (len > 0 && (line[len - 1] == '\n' || line[len - 1] == '\r'))
+        len--;
+    size_t end = len;
+    while (len > 0 && line[len - 1] >= '0' && line[len - 1] <= '9')
+        len--;
+    if (len == end)
+        return 0;   /* no trailing digits */
+    return atoi(line + len);
+}
+
+/* Find offsetof(struct_name, member_name) in DWARF debug info by streaming
+ * `readelf --debug-dump=info <binary>` (fork/execvp — CAP-7: no shell, the
+ * binary path is caller-derived and the daemon runs as root). C port of the
+ * awk program this replaced, with identical matching behavior:
+ *   - a DW_TAG_structure_type line resets the in-struct flag
+ *   - a DW_AT_name line containing struct_name sets it
+ *   - inside the struct, a DW_AT_name line containing member_name starts a
+ *     scan of the following lines for DW_AT_data_member_location (trailing
+ *     integer = the offset), aborted at the next DW_TAG_.
+ * readelf handles detached debug info (Debian/Ubuntu .build-id) itself.
+ * Returns the offset, or 0 if unavailable. */
+static int dwarf_member_offset(const char *pg_binary,
+                               const char *struct_name,
+                               const char *member_name)
+{
+    char *argv[] = { "readelf", "--debug-dump=info", (char *)pg_binary, NULL };
+    struct pgwt_proc proc;
+    if (pgwt_proc_open(&proc, argv) != 0)
+        return 0;
+
+    int offset = 0;
+    int in_struct = 0;
+    char line[1024];
+    while (offset == 0 && fgets(line, sizeof(line), proc.out)) {
+        if (strstr(line, "DW_TAG_structure_type"))
+            in_struct = 0;
+        if (strstr(line, "DW_AT_name") && strstr(line, struct_name))
+            in_struct = 1;
+        if (in_struct && strstr(line, "DW_AT_name")
+            && strstr(line, member_name)) {
+            while (fgets(line, sizeof(line), proc.out)) {
+                if (strstr(line, "DW_AT_data_member_location")) {
+                    offset = trailing_int(line);
+                    break;
+                }
+                if (strstr(line, "DW_TAG_"))
+                    break;
+            }
+        }
+    }
+    /* We may stop reading before EOF (found early) — readelf gets EPIPE;
+     * its exit status is meaningless then, so it is deliberately ignored. */
+    pgwt_proc_close(&proc);
+    return offset;
+}
+
 /* Tier 1: Try DWARF debug info via readelf */
 static int detect_offset_dwarf(const char *pg_binary)
 {
-    /* Try the binary itself first, then the detached debug info.
-     * Debian/Ubuntu: /usr/lib/debug/.build-id/XX/YYYY.debug
-     * We let readelf handle the debug link automatically. */
-    char cmd[1024];
-    snprintf(cmd, sizeof(cmd),
-             "readelf --debug-dump=info '%s' 2>/dev/null | awk '"
-             "/DW_TAG_structure_type/ { s=0 } "
-             "/DW_AT_name.*PgBackendStatus/ { s=1 } "
-             "s && /DW_AT_name.*st_query_id/ { "
-             "  while ((getline line) > 0) { "
-             "    if (line ~ /DW_AT_data_member_location/) { "
-             "      match(line, /[0-9]+$/); "
-             "      if (RSTART>0) { print substr(line,RSTART,RLENGTH); exit } "
-             "    } "
-             "    if (line ~ /DW_TAG_/) break "
-             "  } "
-             "}'",
-             pg_binary);
-
-    FILE *fp = popen(cmd, "r");
-    if (!fp)
-        return 0;
-
-    char buf[64];
-    int offset = 0;
-    if (fgets(buf, sizeof(buf), fp))
-        offset = atoi(buf);
-    pclose(fp);
-
-    return offset;
+    return dwarf_member_offset(pg_binary, "PgBackendStatus", "st_query_id");
 }
 
 /* Tier 2: Known offsets for common PG versions on x86_64 */
@@ -467,33 +621,7 @@ int pgwt_detect_query_id_offset(const char *pg_binary, int pg_major)
 /* Tier 1: Try DWARF debug info via readelf */
 static int detect_activity_offset_dwarf(const char *pg_binary)
 {
-    char cmd[1024];
-    snprintf(cmd, sizeof(cmd),
-             "readelf --debug-dump=info '%s' 2>/dev/null | awk '"
-             "/DW_TAG_structure_type/ { s=0 } "
-             "/DW_AT_name.*PgBackendStatus/ { s=1 } "
-             "s && /DW_AT_name.*st_activity_raw/ { "
-             "  while ((getline line) > 0) { "
-             "    if (line ~ /DW_AT_data_member_location/) { "
-             "      match(line, /[0-9]+$/); "
-             "      if (RSTART>0) { print substr(line,RSTART,RLENGTH); exit } "
-             "    } "
-             "    if (line ~ /DW_TAG_/) break "
-             "  } "
-             "}'",
-             pg_binary);
-
-    FILE *fp = popen(cmd, "r");
-    if (!fp)
-        return 0;
-
-    char buf[64];
-    int offset = 0;
-    if (fgets(buf, sizeof(buf), fp))
-        offset = atoi(buf);
-    pclose(fp);
-
-    return offset;
+    return dwarf_member_offset(pg_binary, "PgBackendStatus", "st_activity_raw");
 }
 
 /* Tier 2: Known offsets for common PG versions on x86_64 */
@@ -796,10 +924,6 @@ int pgwt_discover(struct pgwt_daemon *d)
     if (d->trace_dir)
         pgwt_write_names_json(d->trace_dir);
 
-    /* Extract basename for /proc/pid/maps matching */
-    const char *base = strrchr(binary, '/');
-    base = base ? base + 1 : binary;
-
     /* Resolve the wait_event_info access path. Per-version strategy:
      *   PG17+  → the `my_wait_event_info` global (a uint32* pointing AT the
      *            field). UNCHANGED — must not regress.
@@ -818,7 +942,7 @@ int pgwt_discover(struct pgwt_daemon *d)
                     d->pg_major_version);
             return -1;
         }
-        d->my_wait_ptr_addr = pgwt_resolve_symbol(binary, "MyProc", pm_pid, base);
+        d->my_wait_ptr_addr = pgwt_resolve_symbol(binary, "MyProc", pm_pid);
         if (d->my_wait_ptr_addr == 0) {
             fprintf(stderr, "FATAL: cannot resolve 'MyProc' in %s (PID %d)\n",
                     binary, pm_pid);
@@ -831,7 +955,7 @@ int pgwt_discover(struct pgwt_daemon *d)
                     d->pgproc_wait_offset);
     } else {
         d->my_wait_ptr_addr = pgwt_resolve_symbol(binary, "my_wait_event_info",
-                                                   pm_pid, base);
+                                                   pm_pid);
         if (d->my_wait_ptr_addr == 0) {
             fprintf(stderr, "FATAL: cannot resolve 'my_wait_event_info' in %s (PID %d)\n",
                     binary, pm_pid);
@@ -853,7 +977,7 @@ int pgwt_discover(struct pgwt_daemon *d)
      * (Route B1, resolved below), NOT from MyBEEntry — and PG13 does not export
      * MyBEEntry in .dynsym anyway — so a missing MyBEEntry is not fatal there. */
     d->my_be_entry_addr = pgwt_resolve_symbol(binary, "MyBEEntry",
-                                               pm_pid, base);
+                                               pm_pid);
     if (d->my_be_entry_addr == 0) {
         if (d->view == PGWT_VIEW_QUERY_EVENT && d->pg_major_version != 13) {
             fprintf(stderr, "FATAL: symbol 'MyBEEntry' not found — query_event view unavailable\n");

--- a/src/discovery.h
+++ b/src/discovery.h
@@ -16,20 +16,32 @@ int pgwt_find_pg_binary(pid_t pid, char *buf, size_t bufsz);
  * Returns the raw st_value from the ELF symbol table. */
 uint64_t pgwt_find_symbol_offset(const char *binary, const char *symbol);
 
-/* Find the load base address of the binary in the target process. */
-uint64_t pgwt_find_load_base(pid_t pid, const char *binary_basename);
+/* Find the load base address of the binary in the target process.
+ * `binary_path` is matched EXACTLY against the maps pathname field: full
+ * pathname equality when it contains a '/', exact-basename equality
+ * otherwise — never a substring match (CAP-4: extension .so paths that
+ * contain "postgres" must not win). */
+uint64_t pgwt_find_load_base(pid_t pid, const char *binary_path);
 
 /* Same, but against an explicit maps file (the /proc/<pid>/maps format).
  * pgwt_find_load_base() is a thin wrapper over this; the split exists so
  * unit tests can drive the parser with committed fixture files
  * (tests/test_discovery.c — the #24 load-base regression class). */
 uint64_t pgwt_find_load_base_in_maps(const char *maps_path,
-                                     const char *binary_basename);
+                                     const char *binary_path);
 
 /* Resolve a symbol to its runtime virtual address in the target process.
- * Handles both PIE (ET_DYN) and non-PIE (ET_EXEC) binaries correctly. */
+ * Handles both PIE (ET_DYN) and non-PIE (ET_EXEC) binaries correctly.
+ * The load base is matched against the FULL `binary` path (CAP-4). */
 uint64_t pgwt_resolve_symbol(const char *binary, const char *symbol,
-                             pid_t pid, const char *binary_basename);
+                             pid_t pid);
+
+/* Is addr inside a MAP_SHARED mapping of pid? 1 = shared, 0 = private or
+ * not mapped, -1 = maps unreadable. The sampler may only BATCH-read
+ * addresses that are shared (SMP-2): a process-local address mapped at the
+ * same VA in every forked child reads *successfully* through another pid
+ * and returns the reader's value, silently misattributed. */
+int pgwt_addr_is_shared(pid_t pid, uint64_t addr);
 
 /* Read an 8-byte pointer from /proc/<pid>/mem at addr. Returns 0 on error. */
 uint64_t pgwt_read_pointer(pid_t pid, uint64_t addr);
@@ -83,10 +95,17 @@ int pgwt_detect_pgproc_wait_offset(int pg_major);
 uint64_t pgwt_resolve_wait_addr_via_myproc(pid_t pid, uint64_t my_proc_global_addr,
                                            int pgproc_wait_offset);
 
-/* Validate that a resolved wait_event_info address holds a plausible value:
- * the class byte must be CPU (0) or a known wait-event class (0x01..0x0B).
- * Guards against a wrong offset (custom build) producing garbage. Returns 1
- * if valid, 0 if the value looks like garbage, -1 on read error. */
+/* Validate a resolved wait_event_info address by classifying the value it
+ * currently holds (CAP-2/3/5). Returns (see pgwt_classify_wei):
+ *   PGWT_WEI_VALID_NONZERO (1) — a known wait class: PROOF the address is
+ *                                right (callers may set validated).
+ *   PGWT_WEI_ZERO (2)          — on-CPU: consistent with a correct address
+ *                                but ALSO the most likely reading from a
+ *                                WRONG offset (zeroed memory). NEVER proof —
+ *                                keep sampling other backends / re-check.
+ *   PGWT_WEI_GARBAGE (0)       — unknown class byte: the offset/address is
+ *                                wrong — the caller must refuse to attach.
+ *   -1                         — transient read error (process gone). */
 int pgwt_validate_wait_addr(pid_t pid, uint64_t wait_addr);
 
 /* Detect st_activity_raw offset in PgBackendStatus.

--- a/src/escalation.c
+++ b/src/escalation.c
@@ -10,6 +10,7 @@
 #include "daemon.h"
 #include "backend.h"
 #include "event_writer.h"
+#include "perf_event.h"
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/map_reader.c
+++ b/src/map_reader.c
@@ -275,3 +275,27 @@ void pgwt_read_accum_map(struct pgwt_daemon *d)
     }
 }
 
+
+/* Sum one BPF fail_counters slot across CPUs (CAP-1/CAP-6). The BPF programs
+ * bump these when a map insert fails (state_map / seen_query_ids full); the
+ * control socket surfaces them so a full map is never silent. */
+uint64_t pgwt_read_bpf_fail_counter(struct pgwt_daemon *d, uint32_t slot)
+{
+    if (!d->skel || slot >= PGWT_BPF_FAIL_MAX)
+        return 0;
+    int fd = bpf_map__fd(d->skel->maps.fail_counters);
+    if (fd < 0)
+        return 0;
+
+    int num_cpus = libbpf_num_possible_cpus();
+    if (num_cpus <= 0)
+        num_cpus = 1;
+    uint64_t per_cpu[num_cpus];
+    if (bpf_map_lookup_elem(fd, &slot, per_cpu) != 0)
+        return 0;
+
+    uint64_t total = 0;
+    for (int i = 0; i < num_cpus; i++)
+        total += per_cpu[i];
+    return total;
+}

--- a/src/map_reader.h
+++ b/src/map_reader.h
@@ -87,6 +87,10 @@ void pgwt_read_state_map(struct pgwt_daemon *d);
 /* Read BPF accum_map (lightweight mode) and merge into event_accum. */
 void pgwt_read_accum_map(struct pgwt_daemon *d);
 
+/* Sum one BPF fail_counters slot (PGWT_BPF_FAIL_*) across CPUs (CAP-1/6).
+ * Returns 0 when the skeleton/map is unavailable. */
+uint64_t pgwt_read_bpf_fail_counter(struct pgwt_daemon *d, uint32_t slot);
+
 /* Find per-PID accumulator. Returns NULL if not found. */
 struct pgwt_pid_accum *pgwt_find_pid_accum(struct pgwt_accumulator *acc, uint32_t pid);
 

--- a/src/perf_event.c
+++ b/src/perf_event.c
@@ -16,7 +16,8 @@ static long sys_perf_event_open(struct perf_event_attr *attr, pid_t pid,
     return syscall(__NR_perf_event_open, attr, pid, cpu, group_fd, flags);
 }
 
-int pgwt_open_watchpoint(pid_t pid, uint64_t addr, int bpf_prog_fd)
+static int open_watchpoint_common(pid_t pid, uint64_t addr, int bpf_prog_fd,
+                                  int start_enabled)
 {
     struct perf_event_attr attr;
     memset(&attr, 0, sizeof(attr));
@@ -31,14 +32,31 @@ int pgwt_open_watchpoint(pid_t pid, uint64_t addr, int bpf_prog_fd)
     attr.wakeup_events  = 0;            /* BPF handles events, no perf buffer wakeup */
     attr.exclude_kernel = 1;            /* PGPROC is userspace-only */
     attr.exclude_hv     = 1;            /* no hypervisor writes */
+    /* CAP-8: callers that preseed the BPF state_map open the watchpoint
+     * disabled, seed, then enable — so the first fire always sees a seeded
+     * state and the opening interval is timed correctly. */
+    attr.disabled       = start_enabled ? 0 : 1;
 
     int fd = sys_perf_event_open(&attr, pid, -1, -1, PERF_FLAG_FD_CLOEXEC);
     if (fd < 0) {
         /* ESRCH = process exited before we could attach — expected for
-         * short-lived backends. Don't spam stderr with these. */
-        if (errno != ESRCH)
+         * short-lived backends. Don't spam stderr with these.
+         * EMFILE/ENFILE (CAP-12) is a very different failure — the daemon
+         * ran out of file descriptors, and every further backend would
+         * silently record nothing. Scream, with the fix. */
+        if (errno == EMFILE || errno == ENFILE) {
+            fprintf(stderr,
+                    "ERROR: perf_event_open(pid=%d): %s — file descriptor "
+                    "limit reached.\n"
+                    "  Backends beyond this point CANNOT be traced. The "
+                    "daemon raises RLIMIT_NOFILE at startup; if this "
+                    "persists, raise the hard limit (ulimit -Hn / "
+                    "LimitNOFILE= in the systemd unit).\n",
+                    pid, strerror(errno));
+        } else if (errno != ESRCH) {
             fprintf(stderr, "perf_event_open(pid=%d, addr=0x%lx): %s\n",
                     pid, (unsigned long)addr, strerror(errno));
+        }
         return -1;
     }
 
@@ -48,13 +66,32 @@ int pgwt_open_watchpoint(pid_t pid, uint64_t addr, int bpf_prog_fd)
         return -1;
     }
 
-    if (ioctl(fd, PERF_EVENT_IOC_ENABLE, 0) != 0) {
+    if (start_enabled && ioctl(fd, PERF_EVENT_IOC_ENABLE, 0) != 0) {
         fprintf(stderr, "ioctl ENABLE(pid=%d): %s\n", pid, strerror(errno));
         close(fd);
         return -1;
     }
 
     return fd;
+}
+
+int pgwt_open_watchpoint(pid_t pid, uint64_t addr, int bpf_prog_fd)
+{
+    return open_watchpoint_common(pid, addr, bpf_prog_fd, 1);
+}
+
+int pgwt_open_watchpoint_disabled(pid_t pid, uint64_t addr, int bpf_prog_fd)
+{
+    return open_watchpoint_common(pid, addr, bpf_prog_fd, 0);
+}
+
+int pgwt_watchpoint_enable(int perf_fd)
+{
+    if (ioctl(perf_fd, PERF_EVENT_IOC_ENABLE, 0) != 0) {
+        fprintf(stderr, "ioctl ENABLE: %s\n", strerror(errno));
+        return -1;
+    }
+    return 0;
 }
 
 void pgwt_close_watchpoint(int perf_fd)

--- a/src/perf_event.h
+++ b/src/perf_event.h
@@ -5,9 +5,21 @@
 #include <sys/types.h>
 #include <stdint.h>
 
-/* Open a hardware write-watchpoint on addr for pid, attach bpf_prog_fd.
+/* Open a hardware write-watchpoint on addr for pid, attach bpf_prog_fd,
+ * and ENABLE it immediately.
  * Returns perf_event fd (>= 0) on success, -1 on error (errno set). */
 int pgwt_open_watchpoint(pid_t pid, uint64_t addr, int bpf_prog_fd);
+
+/* Same, but the watchpoint is created DISABLED (CAP-8): the caller preseeds
+ * the BPF state_map with the backend's current wait state FIRST, then calls
+ * pgwt_watchpoint_enable(). Opening enabled before the preseed left a window
+ * where a transition fired against an unseeded/stale state entry, mis-timing
+ * the opening interval (re-exercised on every escalation). */
+int pgwt_open_watchpoint_disabled(pid_t pid, uint64_t addr, int bpf_prog_fd);
+
+/* Enable a watchpoint opened with pgwt_open_watchpoint_disabled().
+ * Returns 0 on success, -1 on error (errno set). */
+int pgwt_watchpoint_enable(int perf_fd);
 
 /* Close a watchpoint fd (auto-detaches the hardware breakpoint). */
 void pgwt_close_watchpoint(int perf_fd);

--- a/src/pg_wait_tracer.h
+++ b/src/pg_wait_tracer.h
@@ -147,6 +147,38 @@ struct pgwt_query_text_event {
 /* Client:ClientRead — idle between queries (like Oracle's SQL*Net message from client) */
 #define PG_WAIT_CLIENT_READ  ((PG_WAIT_CLIENT << 24) | 0x000000)
 
+/* ── wait_event_info reading classification (CAP-2/3/5) ─────────
+ * A reading from a resolved wait_event_info address falls in one of three
+ * classes. Only a NON-ZERO reading with a known class byte PROVES the
+ * address/offset is right: zero is also the most likely reading from a
+ * WRONG offset (pointing into zeroed memory), so it must never be taken
+ * as validation proof — only as "consistent, keep checking". */
+#define PGWT_WEI_GARBAGE        0   /* unknown class byte — wrong offset */
+#define PGWT_WEI_VALID_NONZERO  1   /* known wait class — proof of validity */
+#define PGWT_WEI_ZERO           2   /* on-CPU; consistent but NOT proof */
+
+#ifndef __BPF__
+/* Pure classifier shared by the runtime validator (discovery.c), the
+ * watchpoint preseed (backend.c) and the sampler read path (sampler.c).
+ * PG wait classes occupy 0x01..0x0B (LWLock..InjectionPoint). */
+static inline int pgwt_classify_wei(uint32_t wei)
+{
+    if (wei == 0)
+        return PGWT_WEI_ZERO;
+    unsigned cls = (wei >> 24) & 0xFF;
+    return (cls >= 0x01 && cls <= 0x0B) ? PGWT_WEI_VALID_NONZERO
+                                        : PGWT_WEI_GARBAGE;
+}
+#endif
+
+/* ── BPF-side failure counters (CAP-1/CAP-6) ────────────────────
+ * Slots in the fail_counters PERCPU_ARRAY map. The BPF programs bump these
+ * when a map insert fails (map full); the daemon sums across CPUs and
+ * surfaces them via the control socket so a full map is never silent. */
+#define PGWT_BPF_FAIL_STATE_MAP  0  /* state_map insert failed (map full) */
+#define PGWT_BPF_FAIL_SEEN_QIDS  1  /* seen_query_ids insert failed (full) */
+#define PGWT_BPF_FAIL_MAX        2
+
 /* ── BPF Accumulator (lightweight mode — no ringbuf) ───── */
 #define ACCUM_MAP_MAX_ENTRIES 1024
 

--- a/src/sampler.c
+++ b/src/sampler.c
@@ -534,18 +534,32 @@ int pgwt_sampler_poll(struct pgwt_daemon *d)
          * it via the version-appropriate path (PG17+ my_wait_event_info
          * global; PG<17 MyProc + offset — same global VA in every backend,
          * the deref gives that backend's own PGPROC slot). Skip this tick if
-         * the backend hasn't set the pointer yet. */
-        if (be->wp_addr == 0) {
-            be->wp_addr = pgwt_resolve_backend_wait_addr(d, be->pid);
-            if (be->wp_addr == 0)
+         * the backend hasn't set the pointer yet.
+         *
+         * While the resolved address is NOT in shared memory, keep
+         * re-resolving every tick: on PG17+ the pointer is non-zero from the
+         * first instruction (static initializer → the process-local dummy
+         * local_my_wait_event_info) — a tick landing in the fork→InitProcess
+         * window would otherwise cache the dummy FOREVER and that backend's
+         * waits would never be sampled (the fork→attach race's sampled-tier
+         * sibling). Genuinely-local addresses (aux processes without a
+         * PGPROC, e.g. syslogger) stay non-shared and are simply re-resolved
+         * to the same value — a cheap /proc read per tick for a handful of
+         * processes. Once the address lands in shm it is cached for good. */
+        if (be->wp_addr == 0 || be->wp_addr_shared == 0) {
+            uint64_t addr = pgwt_resolve_backend_wait_addr(d, be->pid);
+            if (addr == 0 && be->wp_addr == 0)
                 continue;
-            be->wp_addr_shared = -1;
-            /* First time we resolved this backend — seed its state_map entry
-             * so the query_id uprobe can populate it. */
-            seed_state_entry(d, be->pid, be->wp_addr);
+            if (addr != 0 && addr != be->wp_addr) {
+                be->wp_addr = addr;
+                be->wp_addr_shared = -1;
+                /* Seed its state_map entry so the query_id uprobe can
+                 * populate it (idempotent — BPF_NOEXIST). */
+                seed_state_entry(d, be->pid, be->wp_addr);
+            }
         }
-        /* SMP-2: classify the address once — only verified-shared addresses
-         * may be batched through a foreign pid. */
+        /* SMP-2: classify the address — only verified-shared addresses may
+         * be batched through a foreign pid. */
         if (be->wp_addr_shared < 0)
             be->wp_addr_shared =
                 (pgwt_addr_is_shared(be->pid, be->wp_addr) == 1) ? 1 : 0;

--- a/src/sampler.c
+++ b/src/sampler.c
@@ -1,11 +1,12 @@
-/* sampler.c — Sampled capture provider (Track A, D1)
+/* sampler.c — Sampled capture provider (Track A, D1; hardened in T4)
  *
  * See sampler.h for the design. The core read/build logic
- * (pgwt_sampler_read_targets / pgwt_sampler_build_batch) is free of BPF and
- * daemon dependencies so the unit test can exercise it against a controlled
- * target process. The provider hooks (start/stop/poll/metrics) bridge to the
- * live daemon: they build the per-tick target list from the backend registry
- * + BPF state_map and push the batch into the trace writer.
+ * (pgwt_sampler_read_targets / pgwt_sampler_build_batch) and the pure
+ * helpers (health state machine, effective period, qid join index) are free
+ * of BPF and daemon dependencies so the unit test can exercise them against
+ * a controlled target process. The provider hooks (start/stop/poll/metrics)
+ * bridge to the live daemon: they build the per-tick target list from the
+ * backend registry + BPF state_map and push the batch into the trace writer.
  *
  * The provider vtable itself lives at the bottom and is compiled into both
  * the daemon (with BPF) and never into pgwt-server. The BPF-touching parts
@@ -25,6 +26,22 @@
 
 /* ── BPF-free core (testable without a daemon) ────────────────────────── */
 
+/* Read one target's value against its OWN pid via /proc/<pid>/mem.
+ * Returns 1 on success (val written), 0 on failure (errno preserved). */
+static int read_target_own_pid(const struct pgwt_sample_target *t,
+                               uint32_t *val)
+{
+    char path[64];
+    snprintf(path, sizeof(path), "/proc/%d/mem", t->pid);
+    int fd = open(path, O_RDONLY | O_CLOEXEC);
+    if (fd < 0)
+        return 0;
+    int ok = (pread(fd, val, sizeof(*val),
+                    (off_t)t->wait_event_addr) == (ssize_t)sizeof(*val));
+    close(fd);
+    return ok;
+}
+
 int pgwt_sampler_read_targets(const struct pgwt_sample_target *targets, int n,
                               uint32_t *out_vals, uint64_t *read_faults)
 {
@@ -33,71 +50,84 @@ int pgwt_sampler_read_targets(const struct pgwt_sample_target *targets, int n,
 
     struct iovec *liov = calloc(n, sizeof(*liov));
     struct iovec *riov = calloc(n, sizeof(*riov));
-    if (!liov || !riov) {
+    int *idx = calloc(n, sizeof(*idx));   /* batch position -> target index */
+    if (!liov || !riov || !idx) {
         free(liov);
         free(riov);
+        free(idx);
         return 0;
     }
 
+    int got = 0;
+    int nb = 0;   /* number of batchable (shared-memory) targets */
     for (int i = 0; i < n; i++) {
         out_vals[i] = 0;
-        liov[i].iov_base = &out_vals[i];
-        liov[i].iov_len  = sizeof(uint32_t);
-        riov[i].iov_base = (void *)(uintptr_t)targets[i].wait_event_addr;
-        riov[i].iov_len  = sizeof(uint32_t);
+        /* SMP-2: only targets whose address is verified to live in a
+         * MAP_SHARED mapping may be read through another pid. A private
+         * address mapped at the same VA in every child reads SUCCESSFULLY
+         * through a foreign pid and returns the READER's value —
+         * misattributed, silently. Everything else goes per-pid below. */
+        if (targets[i].is_shared != 1)
+            continue;
+        liov[nb].iov_base = &out_vals[i];
+        liov[nb].iov_len  = sizeof(uint32_t);
+        riov[nb].iov_base = (void *)(uintptr_t)targets[i].wait_event_addr;
+        riov[nb].iov_len  = sizeof(uint32_t);
+        idx[nb] = i;
+        nb++;
     }
 
-    /* Most backends' wait_event_info lives in PG's shared-memory mmap, which
-     * is mapped at the SAME virtual address in every backend — so one
-     * process_vm_readv across all of them via a single reader pid resolves
-     * them in one syscall. A few processes (logger, some aux workers) keep a
-     * process-LOCAL wait_event_info whose address is only mapped in that
-     * process; reading it via another pid faults. process_vm_readv reads
-     * iovecs in order and returns the bytes transferred, stopping at the
-     * first faulting entry. We therefore sweep: read as far as possible in
-     * one syscall, per-pid pread() the single faulting entry, then RESUME the
+    /* Shared-memory batch: the addresses are backed by the SAME pages in
+     * every backend, so one process_vm_readv through a single reader pid
+     * resolves them all in one syscall. process_vm_readv reads iovecs in
+     * order and stops at the first faulting entry; we sweep — read as far
+     * as possible, per-pid pread the single faulting entry, then RESUME the
      * combined read for the remainder. One outlier costs one pread, not N. */
-    int got = 0;
-    int base = 0;   /* first not-yet-read index */
-    while (base < n) {
-        pid_t reader_pid = targets[base].pid;
-        int rem = n - base;
+    int base = 0;   /* first not-yet-read batch position */
+    while (base < nb) {
+        pid_t reader_pid = targets[idx[base]].pid;
+        int rem = nb - base;
         ssize_t r = process_vm_readv(reader_pid, liov + base, rem,
                                      riov + base, rem, 0);
         int done = (r > 0) ? (int)(r / sizeof(uint32_t)) : 0;
         got  += done;
         base += done;
-        if (base >= n)
+        if (base >= nb)
             break;
 
-        /* targets[base] faulted under reader_pid (or the reader itself is
-         * gone). Read it against its own pid via /proc/<pid>/mem. */
+        /* batch entry `base` faulted under reader_pid (or the reader itself
+         * is gone). Read it against its own pid. */
         uint32_t val = 0;
-        char path[64];
-        snprintf(path, sizeof(path), "/proc/%d/mem", targets[base].pid);
-        int fd = open(path, O_RDONLY | O_CLOEXEC);
-        if (fd >= 0) {
-            if (pread(fd, &val, sizeof(val),
-                      (off_t)targets[base].wait_event_addr) ==
-                (ssize_t)sizeof(val)) {
-                out_vals[base] = val;
-                got++;
-            }
-            close(fd);
+        if (read_target_own_pid(&targets[idx[base]], &val)) {
+            out_vals[idx[base]] = val;
+            got++;
         }
         if (read_faults)
             (*read_faults)++;
         base++;   /* move past the entry we just handled (or skipped) */
     }
 
+    /* Per-pid reads for everything not proven shared (SMP-2). */
+    for (int i = 0; i < n; i++) {
+        if (targets[i].is_shared == 1)
+            continue;
+        uint32_t val = 0;
+        if (read_target_own_pid(&targets[i], &val)) {
+            out_vals[i] = val;
+            got++;
+        }
+    }
+
     free(liov);
     free(riov);
+    free(idx);
     return got;
 }
 
 int pgwt_sampler_build_batch(const struct pgwt_sample_target *targets,
                              const uint32_t *vals, int n, uint64_t tick_ts,
-                             struct pgwt_trace_event *out)
+                             struct pgwt_trace_event *out,
+                             uint64_t *invalid_reads)
 {
     int count = 0;
     for (int i = 0; i < n; i++) {
@@ -107,6 +137,15 @@ int pgwt_sampler_build_batch(const struct pgwt_sample_target *targets,
          * A3 derives CPU from coverage, not from on-CPU samples). */
         if (we == 0)
             continue;
+
+        /* CAP-2/5 backstop (all PG versions, every tick): a value with an
+         * unknown class byte is garbage from a wrong offset/address — it
+         * must NEVER be recorded as data. Count it so the daemon screams. */
+        if (pgwt_classify_wei(we) == PGWT_WEI_GARBAGE) {
+            if (invalid_reads)
+                (*invalid_reads)++;
+            continue;
+        }
 
         struct pgwt_trace_event *e = &out[count++];
         e->timestamp_ns = tick_ts;
@@ -118,6 +157,81 @@ int pgwt_sampler_build_batch(const struct pgwt_sample_target *targets,
         e->query_id     = targets[i].query_id;
     }
     return count;
+}
+
+uint64_t pgwt_sampler_effective_period(uint64_t nominal_ns,
+                                       uint64_t last_tick_ns,
+                                       uint64_t now_ns)
+{
+    if (last_tick_ns == 0 || now_ns <= last_tick_ns)
+        return nominal_ns;
+    uint64_t elapsed = now_ns - last_tick_ns;
+    if (elapsed < nominal_ns)
+        return nominal_ns;   /* the timer never fires early; jitter only */
+    if (elapsed > 60ULL * 1000000000ULL)
+        return 60ULL * 1000000000ULL;   /* sanity clamp on absurd stalls */
+    return elapsed;
+}
+
+enum pgwt_sampler_health_action
+pgwt_sampler_health_note(struct pgwt_sampler_health *h, int n_targets,
+                         int n_read, int err_no, uint64_t now_ns)
+{
+    /* Re-log period while persistently failing: once a minute. */
+    const uint64_t RELOG_NS = 60ULL * 1000000000ULL;
+
+    if (n_targets <= 0)
+        return PGWT_SAMPLER_LOG_NONE;   /* nothing to read — neutral tick */
+
+    if (n_read > 0) {
+        int was_unhealthy = !h->healthy;
+        h->healthy = 1;
+        h->consec_failed_ticks = 0;
+        return was_unhealthy ? PGWT_SAMPLER_LOG_RECOVERED
+                             : PGWT_SAMPLER_LOG_NONE;
+    }
+
+    /* Total failure: N targets, zero readable. Indistinguishable from an
+     * idle database in the data — must be loud out-of-band (SMP-1). */
+    h->consec_failed_ticks++;
+    h->failed_ticks_total++;
+    h->last_errno = err_no;
+    h->healthy = 0;
+    if (h->consec_failed_ticks == 1 || now_ns - h->last_log_ns >= RELOG_NS) {
+        h->last_log_ns = now_ns;
+        return PGWT_SAMPLER_LOG_DEGRADED;
+    }
+    return PGWT_SAMPLER_LOG_NONE;
+}
+
+/* ── SMP-4: pid -> query_id join index ────────────────────────────────── */
+
+static int qid_entry_cmp(const void *a, const void *b)
+{
+    uint32_t pa = ((const struct pgwt_qid_entry *)a)->pid;
+    uint32_t pb = ((const struct pgwt_qid_entry *)b)->pid;
+    return (pa > pb) - (pa < pb);
+}
+
+void pgwt_qid_index_sort(struct pgwt_qid_entry *entries, int n)
+{
+    qsort(entries, (size_t)n, sizeof(*entries), qid_entry_cmp);
+}
+
+uint64_t pgwt_qid_index_lookup(const struct pgwt_qid_entry *entries, int n,
+                               uint32_t pid)
+{
+    int lo = 0, hi = n - 1;
+    while (lo <= hi) {
+        int mid = lo + (hi - lo) / 2;
+        if (entries[mid].pid == pid)
+            return entries[mid].query_id;
+        if (entries[mid].pid < pid)
+            lo = mid + 1;
+        else
+            hi = mid - 1;
+    }
+    return 0;
 }
 
 /* ── Daemon-side provider hooks (need the BPF skeleton) ───────────────── */
@@ -144,7 +258,8 @@ static uint64_t mono_ns(void)
 }
 
 /* Read pid -> query_id from the BPF state_map, maintained by the
- * on_report_query_id uprobe. Returns 0 if unknown. */
+ * on_report_query_id uprobe. Returns 0 if unknown. Per-pid fallback for
+ * kernels without BPF_MAP_LOOKUP_BATCH (SMP-4). */
 static uint64_t lookup_query_id(struct pgwt_daemon *d, pid_t pid)
 {
     if (!d->skel)
@@ -159,11 +274,64 @@ static uint64_t lookup_query_id(struct pgwt_daemon *d, pid_t pid)
     return 0;
 }
 
+/* SMP-4: dump the whole state_map in (at most) a few BPF_MAP_LOOKUP_BATCH
+ * syscalls and build a sorted pid->query_id index, instead of one
+ * bpf_map_lookup_elem syscall per backend per tick (10k syscalls/s at
+ * 1000 backends × 10 Hz). Returns the number of index entries, or -1 when
+ * batch lookup is unsupported (caller falls back to per-pid lookups). */
+static int dump_qid_index(struct pgwt_daemon *d, struct pgwt_sampler *s,
+                          struct pgwt_qid_entry *out)
+{
+    if (!d->skel || s->qid_batch_supported == 0)
+        return -1;
+    int fd = bpf_map__fd(d->skel->maps.state_map);
+    if (fd < 0)
+        return -1;
+
+    uint32_t in_batch = 0, out_batch = 0;
+    void *in = NULL;
+    int total = 0;
+    while (total < s->qid_cap) {
+        uint32_t count = (uint32_t)(s->qid_cap - total);
+        int err = bpf_map_lookup_batch(fd, in, &out_batch,
+                                       s->qid_keys + total,
+                                       s->qid_vals + total, &count, NULL);
+        if (err == 0 || err == -ENOENT) {
+            total += (int)count;
+            if (err == -ENOENT)
+                break;   /* map exhausted */
+            in_batch = out_batch;
+            in = &in_batch;
+            continue;
+        }
+        if (total == 0) {
+            /* First call failed outright: kernel lacks batch support
+             * (EINVAL/ENOTSUPP...). Remember and fall back per-pid. */
+            s->qid_batch_supported = 0;
+            if (d->verbose)
+                fprintf(stderr, "INFO: BPF_MAP_LOOKUP_BATCH unavailable "
+                        "(%s) — using per-pid query_id lookups\n",
+                        strerror(-err));
+            return -1;
+        }
+        break;   /* partial dump: use what we have */
+    }
+    s->qid_batch_supported = 1;
+
+    for (int i = 0; i < total; i++) {
+        out[i].pid = s->qid_keys[i];
+        out[i].query_id = s->qid_vals[i].last_query_id;
+    }
+    pgwt_qid_index_sort(out, total);
+    return total;
+}
+
 /* Seed an empty state_map entry for a sampled-mode backend. The
  * on_report_query_id uprobe only UPDATES existing entries (it never creates
  * them), so without a seed the sampler would never see a query_id — there is
  * no on_watchpoint in sampled mode to create the entry. Idempotent
- * (BPF_NOEXIST). */
+ * (BPF_NOEXIST). CAP-1: a full map here means this backend's samples lose
+ * query attribution — counted + logged loudly, never silent. */
 static void seed_state_entry(struct pgwt_daemon *d, pid_t pid, uint64_t addr)
 {
     if (!d->skel)
@@ -178,7 +346,20 @@ static void seed_state_entry(struct pgwt_daemon *d, pid_t pid, uint64_t addr)
         .last_query_id = 0,
         .wait_event_addr = addr,
     };
-    bpf_map_update_elem(fd, &key, &st, BPF_NOEXIST);
+    int rc = bpf_map_update_elem(fd, &key, &st, BPF_NOEXIST);
+    if (rc != 0 && rc != -EEXIST && errno != EEXIST) {
+        d->counters.state_map_full_total++;
+        if (!d->state_map_full_logged) {
+            d->state_map_full_logged = true;
+            fprintf(stderr,
+                    "ERROR: BPF state_map is FULL — cannot seed PID %d (and "
+                    "any further backend).\n"
+                    "  Affected backends' samples lose query attribution. "
+                    "state_map_full_total on the control socket counts every "
+                    "affected backend.\n",
+                    pid);
+        }
+    }
 }
 
 int pgwt_sampler_start(struct pgwt_daemon *d)
@@ -191,12 +372,27 @@ int pgwt_sampler_start(struct pgwt_daemon *d)
 
     int hz = d->sample_rate_hz > 0 ? d->sample_rate_hz : 10;
     s->sample_period_ns = 1000000000ULL / (uint64_t)hz;
+    s->health.healthy = 1;
+    s->qid_batch_supported = -1;
+
+    /* qid dump buffers sized to the LOADED state_map capacity (it can be
+     * shrunk via PGWT_STATE_MAP_ENTRIES in test builds). */
+    s->qid_cap = MAX_BACKENDS;
+    if (d->skel) {
+        uint32_t me = bpf_map__max_entries(d->skel->maps.state_map);
+        if (me > 0 && (int)me < s->qid_cap)
+            s->qid_cap = (int)me;
+    }
 
     s->read_vals = calloc(MAX_BACKENDS, sizeof(*s->read_vals));
     s->samples   = calloc(MAX_BACKENDS, sizeof(*s->samples));
-    if (!s->read_vals || !s->samples) {
+    s->qid_keys  = calloc(s->qid_cap, sizeof(*s->qid_keys));
+    s->qid_vals  = calloc(s->qid_cap, sizeof(*s->qid_vals));
+    if (!s->read_vals || !s->samples || !s->qid_keys || !s->qid_vals) {
         free(s->read_vals);
         free(s->samples);
+        free(s->qid_keys);
+        free(s->qid_vals);
         free(s);
         fprintf(stderr, "FATAL: cannot allocate sampler buffers\n");
         return -1;
@@ -216,6 +412,8 @@ int pgwt_sampler_stop(struct pgwt_daemon *d)
         return 0;
     free(s->read_vals);
     free(s->samples);
+    free(s->qid_keys);
+    free(s->qid_vals);
     free(s);
     d->sampler = NULL;
     return 0;
@@ -231,7 +429,7 @@ int pgwt_sampler_stop(struct pgwt_daemon *d)
  * even though samples are correctly captured and written to the trace file.
  *
  * Each sample is an ASH point observation worth one sample period of wall time;
- * we weight it by sample_period_ns exactly as the offline reader/server do
+ * we weight it by period_ns exactly as the offline reader/server do
  * (event_reader.c sets FLAG_SAMPLE; server.c normalizes old_event/duration_ns).
  * The build_batch records keep their on-disk shape (new_event set, old/duration
  * zero) so the trace-file format is unchanged; we read new_event here and apply
@@ -300,13 +498,29 @@ static void pgwt_sampler_accumulate(struct pgwt_daemon *d,
 }
 
 /* One sampling tick. Build the target list from the live registry, read all
- * wait_event_info in one syscall (+ per-pid fallback), encode non-CPU
+ * wait_event_info (shared-memory batch + per-pid fallbacks), encode non-CPU
  * readings, and push a SAMPLES block. Called from the daemon timer. */
 int pgwt_sampler_poll(struct pgwt_daemon *d)
 {
     struct pgwt_sampler *s = d->sampler;
     if (!s)
         return 0;
+
+    uint64_t tick_ts = mono_ns();
+    /* SMP-3: weight this tick by the MEASURED inter-tick elapsed time, not
+     * the nominal period — when the daemon stalls (attach storms, load) and
+     * timer expirations coalesce, the nominal weight would silently deflate
+     * AAS/DB-Time exactly when it matters. The SAMPLES block header carries
+     * the per-block period, so the on-disk format is unchanged. */
+    uint64_t period_ns = pgwt_sampler_effective_period(s->sample_period_ns,
+                                                       s->last_tick_ns,
+                                                       tick_ts);
+    s->last_tick_ns = tick_ts;
+
+    /* SMP-4: one batched state_map dump per tick for the query_id join.
+     * Falls back to per-pid lookups on kernels without batch support. */
+    struct pgwt_qid_entry qidx_buf[MAX_BACKENDS];
+    int qidx_n = dump_qid_index(d, s, qidx_buf);
 
     /* Reuse a stack target array sized to the live count; MAX_BACKENDS cap. */
     static struct pgwt_sample_target targets[MAX_BACKENDS];
@@ -325,30 +539,75 @@ int pgwt_sampler_poll(struct pgwt_daemon *d)
             be->wp_addr = pgwt_resolve_backend_wait_addr(d, be->pid);
             if (be->wp_addr == 0)
                 continue;
+            be->wp_addr_shared = -1;
             /* First time we resolved this backend — seed its state_map entry
              * so the query_id uprobe can populate it. */
             seed_state_entry(d, be->pid, be->wp_addr);
         }
+        /* SMP-2: classify the address once — only verified-shared addresses
+         * may be batched through a foreign pid. */
+        if (be->wp_addr_shared < 0)
+            be->wp_addr_shared =
+                (pgwt_addr_is_shared(be->pid, be->wp_addr) == 1) ? 1 : 0;
         targets[n].pid             = be->pid;
         targets[n].wait_event_addr = be->wp_addr;
-        targets[n].query_id        = lookup_query_id(d, be->pid);
+        targets[n].is_shared       = be->wp_addr_shared;
+        targets[n].query_id        = (qidx_n >= 0)
+            ? pgwt_qid_index_lookup(qidx_buf, qidx_n, (uint32_t)be->pid)
+            : lookup_query_id(d, be->pid);
         n++;
     }
     if (n == 0)
         return 0;
 
-    uint64_t tick_ts = mono_ns();
     uint64_t faults_before = s->read_faults_total;
-    pgwt_sampler_read_targets(targets, n, s->read_vals, &s->read_faults_total);
+    errno = 0;
+    int got = pgwt_sampler_read_targets(targets, n, s->read_vals,
+                                        &s->read_faults_total);
+    int read_errno = errno;
     d->counters.sample_read_faults_total +=
         (s->read_faults_total - faults_before);
 
+    /* SMP-1: a tick where NOTHING could be read looks exactly like an idle
+     * database in the data — it must be loud out-of-band. */
+    switch (pgwt_sampler_health_note(&s->health, n, got, read_errno, tick_ts)) {
+    case PGWT_SAMPLER_LOG_DEGRADED:
+        fprintf(stderr,
+                "ERROR: sampler read failure: 0 of %d backends readable "
+                "(last error: %s; %llu consecutive failed ticks).\n"
+                "  Sampled data is NOT being captured — an idle-looking view "
+                "now means 'blind', not 'idle'. status.sampler_healthy=false "
+                "until reads recover.\n",
+                n, strerror(s->health.last_errno),
+                (unsigned long long)s->health.consec_failed_ticks);
+        break;
+    case PGWT_SAMPLER_LOG_RECOVERED:
+        fprintf(stderr, "INFO: sampler reads recovered (%llu failed ticks "
+                "total)\n",
+                (unsigned long long)s->health.failed_ticks_total);
+        break;
+    default:
+        break;
+    }
+
+    uint64_t invalid_before = d->counters.invalid_wait_reads_total;
     int count = pgwt_sampler_build_batch(targets, s->read_vals, n, tick_ts,
-                                         s->samples);
+                                         s->samples,
+                                         &d->counters.invalid_wait_reads_total);
+    if (d->counters.invalid_wait_reads_total != invalid_before
+        && !d->invalid_wait_reads_logged) {
+        d->invalid_wait_reads_logged = true;
+        fprintf(stderr,
+                "ERROR: sampler read wait_event_info value(s) with an invalid "
+                "wait-event class byte — the resolved address/offset is wrong "
+                "for this PostgreSQL build.\n"
+                "  Garbage readings are dropped, never recorded "
+                "(invalid_wait_reads_total counts them).\n");
+    }
 
     /* Fold the batch into the live accumulator so the running --view reflects
      * sampled data in real time (there is no ringbuf consumer in this tier). */
-    pgwt_sampler_accumulate(d, s->samples, count, s->sample_period_ns);
+    pgwt_sampler_accumulate(d, s->samples, count, period_ns);
 
     /* Anomaly-trigger rules (A5) run on the live sample batch every tick — in
      * tiered mode they may AUTO-escalate to full fidelity. Evaluated even when
@@ -361,7 +620,7 @@ int pgwt_sampler_poll(struct pgwt_daemon *d)
 
     if (d->event_writer)
         pgwt_writer_push_samples(d->event_writer, s->samples, count,
-                                 s->sample_period_ns);
+                                 period_ns);
 
     s->samples_total += (uint64_t)count;
     d->counters.samples_total += (uint64_t)count;

--- a/src/sampler.h
+++ b/src/sampler.h
@@ -1,23 +1,33 @@
 /* sampler.h — Sampled capture provider (Track A, D1)
  *
  * Pure-userspace ASH-style sampling: on each timer tick read every tracked
- * backend's PGPROC->wait_event_info with a SINGLE process_vm_readv() call
- * (one remote iovec per backend, 4 bytes each), turn each non-CPU reading
- * into a SAMPLES record, and hand the batch to the trace writer via
- * pgwt_writer_push_samples(). No BPF in the per-sample hot path; PostgreSQL
- * executes zero extra instructions.
+ * backend's PGPROC->wait_event_info (batched process_vm_readv for targets in
+ * SHARED memory, per-pid pread for process-local ones — SMP-2), turn each
+ * non-CPU reading into a SAMPLES record, and hand the batch to the trace
+ * writer via pgwt_writer_push_samples(). No BPF in the per-sample hot path;
+ * PostgreSQL executes zero extra instructions.
  *
  * Addresses come from the backend registry (pid -> resolved wait_event_info
  * address, the same field the watchpoint tier resolves). query_id per sample
  * is joined from the BPF state_map (the on_report_query_id uprobe maintains
- * pid->query_id) — never read from PG memory in the sample path.
+ * pid->query_id) — never read from PG memory in the sample path. The join is
+ * one batched map dump per tick (BPF_MAP_LOOKUP_BATCH) with a per-pid
+ * lookup fallback on kernels without batch support (SMP-4).
  *
- * Robustness: PG's main shm is inherited anonymous mmap, so the address is
- * identical across backends and one process_vm_readv from any live pid would
- * suffice — but we issue per-pid local/remote iovec pairs so a single
- * concurrently-exiting backend that returns EFAULT only loses its own entry.
- * On a short read we fall back to per-pid pread() of /proc/<pid>/mem for the
- * affected entries instead of aborting the whole tick.
+ * Batching soundness (SMP-2): PG's main shm is an inherited MAP_SHARED
+ * anonymous mmap — same VA in every backend AND the same pages, so reading
+ * many backends' fields through ONE reader pid is exact. That argument does
+ * NOT hold for process-local (.data/.bss) addresses (e.g. the
+ * my_wait_event_info dummy in aux processes without a PGPROC): those exist
+ * at the same VA in every forked child but are PRIVATE pages — a batched
+ * read through another pid SUCCEEDS and returns the reader's value,
+ * silently misattributed. Only targets whose address the daemon verified to
+ * be in a shared mapping (is_shared) are batched; the rest are read per-pid.
+ *
+ * Robustness (SMP-1): a TOTAL read failure (e.g. EPERM on process_vm_readv
+ * + fallback) is indistinguishable from an idle database in the data — so
+ * it must be loud out-of-band: first failure and persistent failure are
+ * logged, and the control-socket `status` carries sampler_healthy + reason.
  */
 #ifndef PGWT_SAMPLER_H
 #define PGWT_SAMPLER_H
@@ -38,18 +48,49 @@ struct pgwt_sample_target {
     pid_t    pid;
     uint64_t wait_event_addr; /* PGPROC->wait_event_info address */
     uint64_t query_id;        /* joined from the registry/state_map */
+    int      is_shared;       /* 1 = addr verified in a MAP_SHARED mapping
+                               * (batchable); anything else = per-pid read
+                               * only (SMP-2) */
+};
+
+/* Sampler read-health tracking (SMP-1). Pure state machine (unit-testable):
+ * a tick where n_targets > 0 but NOTHING could be read is a failure tick.
+ * The first failure logs immediately; persistent failure re-logs
+ * periodically; recovery logs once and clears the flag. */
+struct pgwt_sampler_health {
+    int      healthy;              /* starts true (1) */
+    uint64_t consec_failed_ticks;
+    uint64_t failed_ticks_total;
+    uint64_t last_log_ns;
+    int      last_errno;
+};
+
+/* What the caller should log after pgwt_sampler_health_note(). */
+enum pgwt_sampler_health_action {
+    PGWT_SAMPLER_LOG_NONE = 0,
+    PGWT_SAMPLER_LOG_DEGRADED,    /* first failure, or periodic re-log */
+    PGWT_SAMPLER_LOG_RECOVERED,
 };
 
 struct pgwt_sampler {
-    /* sample_period_ns is recorded in each SAMPLES block header (A3 weights
-     * each sample by it). Equal to 1e9 / sample_rate_hz. */
+    /* sample_period_ns is the NOMINAL tick interval (1e9 / sample_rate_hz).
+     * Each written SAMPLES block carries the EFFECTIVE period for that tick
+     * (measured inter-tick elapsed — SMP-3: missed/late ticks must not
+     * deflate sample weight vs wall time). */
     uint64_t sample_period_ns;
+    uint64_t last_tick_ns;        /* previous tick timestamp (0 = first) */
 
     /* Scratch buffers sized for MAX_BACKENDS, allocated once. */
-    struct iovec *local_iov;     /* MAX_BACKENDS */
-    struct iovec *remote_iov;    /* MAX_BACKENDS */
     uint32_t     *read_vals;     /* MAX_BACKENDS — wait_event_info per target */
     struct pgwt_trace_event *samples; /* MAX_BACKENDS — encoded batch */
+
+    /* Batched pid->query_id join scratch (SMP-4). qid_cap entries. */
+    uint32_t *qid_keys;           /* state_map key dump */
+    struct pgwt_pid_state *qid_vals; /* state_map value dump */
+    int       qid_cap;
+    int       qid_batch_supported; /* -1 unknown, 0 no (per-pid fallback), 1 yes */
+
+    struct pgwt_sampler_health health;   /* SMP-1 */
 
     uint64_t samples_total;       /* cumulative SAMPLES records written */
     uint64_t read_faults_total;   /* per-pid pread fallbacks taken */
@@ -63,21 +104,52 @@ void pgwt_sampler_metrics(struct pgwt_daemon *d, struct pgwt_metrics *m);
 
 /* ── Exposed for unit testing (no daemon, no BPF) ─────────────────────── */
 
-/* Read each target's wait_event_info from process memory. Issues one
- * process_vm_readv() with up to `n` iovec pairs; on a short read, retries
- * the missing entries with per-pid pread(/proc/<pid>/mem). Writes results
- * into out_vals[i] (0 left in place for entries that could not be read).
- * read_faults (may be NULL) is incremented once per pread fallback taken.
- * Returns the number of entries successfully read. */
+/* Read each target's wait_event_info from process memory. Targets marked
+ * is_shared are read in one batched process_vm_readv() sweep (per-pid pread
+ * fallback for entries that fault); all other targets are read individually
+ * via pread(/proc/<pid>/mem) — NEVER through another pid (SMP-2). Writes
+ * results into out_vals[i] (0 left in place for entries that could not be
+ * read). read_faults (may be NULL) is incremented once per pread fallback
+ * taken in the batched sweep. Returns the number of entries successfully
+ * read; errno is left at the last failing syscall's value when the return
+ * is short. */
 int pgwt_sampler_read_targets(const struct pgwt_sample_target *targets, int n,
                               uint32_t *out_vals, uint64_t *read_faults);
 
 /* Build the SAMPLES batch from targets + their freshly-read values. A target
- * whose value is on-CPU (event 0) is skipped (no wait to record). `tick_ts`
- * is the sample timestamp stamped on every record. Returns the number of
- * sample records written into out (<= n). */
+ * whose value is on-CPU (event 0) is skipped (no wait to record). A value
+ * with an INVALID class byte (CAP-2/5: garbage from a wrong offset) is
+ * skipped too and counted in *invalid_reads (may be NULL) — garbage must
+ * never be recorded as data. `tick_ts` is the sample timestamp stamped on
+ * every record. Returns the number of sample records written into out. */
 int pgwt_sampler_build_batch(const struct pgwt_sample_target *targets,
                              const uint32_t *vals, int n, uint64_t tick_ts,
-                             struct pgwt_trace_event *out);
+                             struct pgwt_trace_event *out,
+                             uint64_t *invalid_reads);
+
+/* SMP-3: effective sample period for the tick at `now_ns`, given the
+ * previous tick's timestamp (0 = first tick → nominal). Late/missed ticks
+ * yield a longer period so total sample weight tracks wall time; the result
+ * is clamped to [nominal, 60s] (a sampler can be late, never early). */
+uint64_t pgwt_sampler_effective_period(uint64_t nominal_ns,
+                                       uint64_t last_tick_ns,
+                                       uint64_t now_ns);
+
+/* SMP-1: note one tick's read outcome. n_targets == 0 ticks are neutral.
+ * Returns the log action the caller must perform (the state machine is
+ * pure; the logging side effect stays with the daemon). */
+enum pgwt_sampler_health_action
+pgwt_sampler_health_note(struct pgwt_sampler_health *h, int n_targets,
+                         int n_read, int err_no, uint64_t now_ns);
+
+/* SMP-4: pid -> query_id join index over a dumped state_map. Entries are
+ * sorted in place by pid; lookup is a binary search. */
+struct pgwt_qid_entry {
+    uint32_t pid;
+    uint64_t query_id;
+};
+void     pgwt_qid_index_sort(struct pgwt_qid_entry *entries, int n);
+uint64_t pgwt_qid_index_lookup(const struct pgwt_qid_entry *entries, int n,
+                               uint32_t pid);
 
 #endif /* PGWT_SAMPLER_H */

--- a/src/spawn.c
+++ b/src/spawn.c
@@ -1,0 +1,73 @@
+/* spawn.c — fork/execvp child-process helper (CAP-7). See spawn.h. */
+#define _GNU_SOURCE   /* pipe2 */
+#include "spawn.h"
+
+#include <stdlib.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <sys/wait.h>
+
+int pgwt_proc_open(struct pgwt_proc *p, char *const argv[])
+{
+    p->out = NULL;
+    p->pid = -1;
+
+    int fds[2];
+    if (pipe2(fds, O_CLOEXEC) != 0)
+        return -1;
+
+    pid_t pid = fork();
+    if (pid < 0) {
+        close(fds[0]);
+        close(fds[1]);
+        return -1;
+    }
+
+    if (pid == 0) {
+        /* Child: stdout -> pipe; stdin/stderr -> /dev/null (matches the
+         * "2>/dev/null" the old popen command lines used). dup2 clears
+         * O_CLOEXEC on the duplicated fd, so stdout survives the exec. */
+        int devnull = open("/dev/null", O_RDWR);
+        if (devnull >= 0) {
+            dup2(devnull, STDIN_FILENO);
+            dup2(devnull, STDERR_FILENO);
+            if (devnull > STDERR_FILENO)
+                close(devnull);
+        }
+        if (dup2(fds[1], STDOUT_FILENO) < 0)
+            _exit(127);
+        execvp(argv[0], argv);
+        _exit(127);   /* exec failed */
+    }
+
+    close(fds[1]);
+    FILE *f = fdopen(fds[0], "r");
+    if (!f) {
+        close(fds[0]);
+        /* Reap the child we can no longer talk to. */
+        int st;
+        while (waitpid(pid, &st, 0) < 0 && errno == EINTR)
+            ;
+        return -1;
+    }
+    p->out = f;
+    p->pid = pid;
+    return 0;
+}
+
+int pgwt_proc_close(struct pgwt_proc *p)
+{
+    if (!p->out)
+        return -1;
+    fclose(p->out);
+    p->out = NULL;
+
+    int status = 0;
+    pid_t r;
+    do {
+        r = waitpid(p->pid, &status, 0);
+    } while (r < 0 && errno == EINTR);
+    p->pid = -1;
+    return (r < 0) ? -1 : status;
+}

--- a/src/spawn.h
+++ b/src/spawn.h
@@ -1,0 +1,38 @@
+/* spawn.h — fork/execvp child-process helper (CAP-7)
+ *
+ * Replacement for popen(): the daemon runs as root, and popen() interpolates
+ * caller-derived strings (postgres binary path, pg_bindir, pg_user) into a
+ * shell command line — a path or user name containing shell metacharacters
+ * breaks quoting (at best) or injects commands (at worst). These helpers run
+ * the child directly via fork+execvp with an argv array: no shell, nothing
+ * to quote.
+ *
+ * Semantics mirror popen(cmd, "r") with "2>/dev/null":
+ *   - child's stdout is piped to p->out (read with stdio as before)
+ *   - child's stdin and stderr are /dev/null
+ *   - pgwt_proc_close() waits and returns the raw wait(2) status
+ *     (0 == clean exit 0, like pclose), or -1 on error.
+ */
+#ifndef PGWT_SPAWN_H
+#define PGWT_SPAWN_H
+
+#include <stdio.h>
+#include <sys/types.h>
+
+struct pgwt_proc {
+    FILE *out;   /* child's stdout (read end) */
+    pid_t pid;
+};
+
+/* Spawn argv[0] (PATH-resolved, like the shell popen used) with argv as its
+ * argument vector (NULL-terminated). Returns 0 on success (p->out readable),
+ * -1 on failure. exec failure in the child surfaces as exit status 127. */
+int pgwt_proc_open(struct pgwt_proc *p, char *const argv[]);
+
+/* Close p->out, reap the child. Returns the raw wait status (0 for a clean
+ * exit-0), or -1 on error. Safe to call after reading only part of the
+ * output (the child gets EPIPE/SIGPIPE, which is reported in the status —
+ * callers that close early must ignore the status, as with pclose). */
+int pgwt_proc_close(struct pgwt_proc *p);
+
+#endif /* PGWT_SPAWN_H */

--- a/src/wait_event.c
+++ b/src/wait_event.c
@@ -15,6 +15,7 @@
 #include "wait_event.h"
 #include "pg_wait_tracer.h"
 #include "cJSON.h"
+#include "spawn.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -767,22 +768,33 @@ static int load_names_from_fp(FILE *fp)
 int pgwt_load_event_names_from_pg(const char *pg_bindir, int pg_port,
                                   const char *pg_user)
 {
-    char cmd[512];
+    /* pg_wait_events view exists since PG17.
+     * CAP-7: psql is run via fork/execvp with an argv array — pg_bindir and
+     * pg_user are derived from the target process/system and must never be
+     * interpolated into a shell command line in a root daemon. */
+    char psql_path[512];
+    char port_str[16];
+    snprintf(psql_path, sizeof(psql_path), "%s/psql", pg_bindir);
+    snprintf(port_str, sizeof(port_str), "%d", pg_port);
 
-    /* pg_wait_events view exists since PG17 */
-    snprintf(cmd, sizeof(cmd),
-             "%s/psql -U %s -p %d -d postgres -tAF'|' "
-             "-c \"SELECT type, name FROM pg_wait_events ORDER BY type, name\" 2>/dev/null",
-             pg_bindir, pg_user, pg_port);
+    char *argv[] = {
+        psql_path,
+        "-U", (char *)pg_user,
+        "-p", port_str,
+        "-d", "postgres",
+        "-tAF|",
+        "-c", "SELECT type, name FROM pg_wait_events ORDER BY type, name",
+        NULL,
+    };
 
-    FILE *fp = popen(cmd, "r");
-    if (!fp)
+    struct pgwt_proc proc;
+    if (pgwt_proc_open(&proc, argv) != 0)
         return -1;
 
     dyn_clear();
-    int count = load_names_from_fp(fp);
+    int count = load_names_from_fp(proc.out);
 
-    int status = pclose(fp);
+    int status = pgwt_proc_close(&proc);
     if (status != 0 || count == 0) {
         dyn_clear();
         return -1;

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -32,7 +32,7 @@ check: all
 	done < unit_tests.list; \
 	exit $$fail
 
-test_wait_event: test_wait_event.c $(BUILD)/wait_event.o $(BUILD)/cJSON.o
+test_wait_event: test_wait_event.c $(BUILD)/wait_event.o $(BUILD)/spawn.o $(BUILD)/cJSON.o
 	$(CC) $(CFLAGS) -o $@ $^
 
 test_cmdline: test_cmdline.c $(BUILD)/cmdline.o
@@ -42,7 +42,7 @@ test_event_writer: test_event_writer.c $(BUILD)/event_writer.o
 	$(CC) $(CFLAGS) -o $@ $^ -llz4
 
 test_event_reader: test_event_reader.c $(BUILD)/event_reader.o $(BUILD)/event_writer.o \
-                   $(BUILD)/map_reader.o $(BUILD)/wait_event.o $(BUILD)/cJSON.o
+                   $(BUILD)/map_reader.o $(BUILD)/wait_event.o $(BUILD)/spawn.o $(BUILD)/cJSON.o
 	$(CC) $(CFLAGS) -o $@ $^ -llz4 $(LIBBPF_LIB) -lelf -lz
 
 test_bucket: test_bucket.c
@@ -52,7 +52,7 @@ test_bucket: test_bucket.c
 # garbage offset" validation guard. Compiles discovery.c directly (the helpers
 # under test are BPF-free; discovery.c only needs libelf). Runs anywhere — no
 # live PostgreSQL, no BPF skeleton.
-test_pg13_resolve: test_pg13_resolve.c ../src/discovery.c \
+test_pg13_resolve: test_pg13_resolve.c ../src/discovery.c ../src/spawn.c \
                    $(BUILD)/wait_event.o $(BUILD)/cJSON.o
 	$(CC) $(CFLAGS) -o $@ $^ -lelf -lz
 
@@ -63,7 +63,7 @@ test_pg13_resolve: test_pg13_resolve.c ../src/discovery.c \
 # each build asserts (via the ELF header) that the flag actually took effect.
 # Compiles discovery.c directly (BPF-free, needs libelf) — same pattern as
 # test_pg13_resolve.
-DISCOVERY_TEST_DEPS = test_discovery.c ../src/discovery.c \
+DISCOVERY_TEST_DEPS = test_discovery.c ../src/discovery.c ../src/spawn.c \
                       $(BUILD)/wait_event.o $(BUILD)/cJSON.o
 
 test_discovery_pie: $(DISCOVERY_TEST_DEPS)
@@ -101,7 +101,7 @@ test_coop: test_coop.c ../src/provider_coop.c
 
 # Server-build objects for gen_test_traces
 SERVER_OBJS = $(BUILD)/server_event_writer.o $(BUILD)/server_summary_writer.o \
-              $(BUILD)/server_wait_event.o $(BUILD)/server_cJSON.o
+              $(BUILD)/server_wait_event.o $(BUILD)/server_spawn.o $(BUILD)/server_cJSON.o
 
 gen_test_traces: gen_test_traces.c $(SERVER_OBJS)
 	$(CC) $(CFLAGS) -DPGWT_SERVER -o $@ $^ -llz4
@@ -110,7 +110,7 @@ gen_bench_traces: gen_bench_traces.c $(SERVER_OBJS)
 	$(CC) $(CFLAGS) -DPGWT_SERVER -o $@ $^ -llz4
 
 test_concurrent_rw: test_concurrent_rw.c $(BUILD)/event_reader.o $(BUILD)/event_writer.o \
-                    $(BUILD)/map_reader.o $(BUILD)/wait_event.o $(BUILD)/cJSON.o
+                    $(BUILD)/map_reader.o $(BUILD)/wait_event.o $(BUILD)/spawn.o $(BUILD)/cJSON.o
 	$(CC) $(CFLAGS) -o $@ $^ -llz4 $(LIBBPF_LIB) -lelf -lz
 
 # cross_validate: A4 sampled-vs-exact comparison tool. Server build
@@ -118,7 +118,7 @@ test_concurrent_rw: test_concurrent_rw.c $(BUILD)/event_reader.o $(BUILD)/event_
 # builds. Reads a tiered trace dir and reports estimator agreement.
 cross_validate: cross_validate.c $(BUILD)/server_event_reader.o \
                 $(BUILD)/server_event_writer.o $(BUILD)/server_wait_event.o \
-                $(BUILD)/server_cJSON.o
+                $(BUILD)/server_spawn.o $(BUILD)/server_cJSON.o
 	$(CC) $(CFLAGS) -DPGWT_SERVER -o $@ $^ -llz4 -lz
 
 # dump_markers: A5 helper — decode escalation-window markers (reason + length)
@@ -126,7 +126,7 @@ cross_validate: cross_validate.c $(BUILD)/server_event_reader.o \
 # window was recorded. Server build (no BPF skeleton).
 dump_markers: dump_markers.c $(BUILD)/server_event_reader.o \
               $(BUILD)/server_event_writer.o $(BUILD)/server_wait_event.o \
-              $(BUILD)/server_cJSON.o
+              $(BUILD)/server_spawn.o $(BUILD)/server_cJSON.o
 	$(CC) $(CFLAGS) -DPGWT_SERVER -o $@ $^ -llz4 -lz
 
 clean:

--- a/tests/ci_smoke.sh
+++ b/tests/ci_smoke.sh
@@ -153,6 +153,12 @@ run_section() {
 run_section "capture smoke: --mode tiered (live view + trace file)" \
     python3 "$SCRIPT_DIR/test_capture_smoke.py" --mode tiered --pid "$PM_PID"
 
+# ── T4/CAP-1: a full state_map must be loud (metrics + ERROR log). ──
+# Uses the PGWT_STATE_MAP_ENTRIES test hook to shrink the map, so the
+# loud path is proven with ~10 connections instead of >1024.
+run_section "state_map full is loud (CAP-1, --mode tiered)" \
+    python3 "$SCRIPT_DIR/test_state_map_loud.py" --pid "$PM_PID"
+
 # ── Full mode: hard when watchpoints exist; loud skip when they don't ──
 if [[ "$WP" == "yes" ]]; then
     run_section "capture smoke: --mode full (live view + trace file)" \

--- a/tests/fixtures/README.md
+++ b/tests/fixtures/README.md
@@ -16,10 +16,12 @@ captures — modeled on the layouts documented in the #24 fix history
   ELF-header page. Expected load base 0x55d4c1000000.
 - `maps_ubuntu_pie.txt` — Ubuntu PGDG deb (`/usr/lib/postgresql/17/bin/
   postgres`), PIE. Expected load base 0x5560d1a00000.
-- `maps_ext_below_binary.txt` — ADVERSARIAL (CAP-4, owned by Phase T4):
+- `maps_ext_below_binary.txt` — ADVERSARIAL (CAP-4, fixed in Phase T4):
   same Ubuntu layout, but `pg_stat_statements.so` is mapped BELOW the main
   binary. Its path `/usr/lib/postgresql/17/lib/...` contains the substring
-  "postgres", so the current whole-line `strstr()` match returns the .so's
+  "postgres", so the pre-T4 whole-line `strstr()` match returned the .so's
   base (0x4f2a80000000) instead of the binary's (0x5560d1a00000) — the #24
-  class one directory layout away from recurring. test_discovery.c pins the
-  current (wrong) behavior as an expected failure until T4 fixes it.
+  class one directory layout away from recurring. T4 replaced the substring
+  match with an EXACT pathname-field comparison (full path, or exact
+  basename); test_discovery.c hard-asserts the binary's base 0x5560d1a00000
+  on this fixture, in both match forms.

--- a/tests/mock_server.py
+++ b/tests/mock_server.py
@@ -419,6 +419,10 @@ class DaemonState:
             "escalation_seconds_remaining": self.seconds_remaining,
             "escalation_budget_remaining_s": self.budget_remaining_s,
             "escalation_reason": self.reason if self.tier == "escalated" else "none",
+            # Sampler read health (T4/SMP-1): false + reason means the sampler
+            # cannot read backend memory — "blind", not "idle".
+            "sampler_healthy": True,
+            "sampler_unhealthy_reason": "",
         }
 
     def metrics(self):
@@ -433,6 +437,13 @@ class DaemonState:
             "samples_total": 540000,
             "samples_per_sec": 60.0,
             "sample_read_faults_total": 0,
+            # Capture hardening counters (T4): non-zero = loudly-logged
+            # degradation (CAP-1/2/5/6, SMP-1/3).
+            "sampler_ticks_missed_total": 0,
+            "state_map_full_total": 0,
+            "seen_query_ids_full_total": 0,
+            "invalid_wait_reads_total": 0,
+            "sampler_healthy": True,
             "ringbuf_drops_total": 3,
             "trace_events_written_total": 1_250_000,
             "trace_bytes_written_total": 18_000_000,

--- a/tests/run_all.sh
+++ b/tests/run_all.sh
@@ -191,6 +191,8 @@ LIVE_TESTS=(
     # justified tiered as the default mode.
     "test_cross_validate_tiered|bash|test_cross_validate_tiered.sh"
     "test_anomaly_live|bash|test_anomaly_live.sh"
+    # T4/CAP-1: a full BPF state_map must be loud (metrics + ERROR log)
+    "test_state_map_loud|python3|test_state_map_loud.py"
 )
 
 # Step 4: integration + live-correctness tests (root + running PG)

--- a/tests/test_capture_smoke.py
+++ b/tests/test_capture_smoke.py
@@ -119,16 +119,20 @@ class Workload:
          waiter  — SELECT on the table when fire()d -> blocks on
                    Lock:relation until the phase ends
 
-    Sessions are opened BEFORE the tracer starts (the initial backend scan
-    finds them — same technique as test_deterministic.py: backends forked
-    after attach are subject to the fork->attach race, observed live on
-    Ubuntu 24.04/kernel 6.8 — a T4 hardening item, not smoke-test scope),
-    but the waits are fired AFTER the tracer attaches so their durations
-    are fully observed. release() commits the holder so the lock wait ENDS
-    inside the observation window — in full mode a transition is only
-    written to the trace when the wait ends, so a never-ending lock wait
-    would be absent from the trace file (the ESC-2/FID-class open-interval
-    gap, owned by T1/T3)."""
+    In phases 1-3, sessions are opened BEFORE the tracer starts (the
+    initial backend scan finds them — same technique as
+    test_deterministic.py). Phase 4 (fork-after-attach) opens them AFTER
+    the tracer attaches: backends forked post-attach used to be subject to
+    the fork->attach race (bootstrap watchpoint armed after the child had
+    already written its pointer -> never fires -> zero events, silently;
+    observed live on Ubuntu 24.04/kernel 6.8 by the T0 CI run, fixed in T4
+    by re-checking the pointer right after arming). The waits are fired
+    AFTER the tracer attaches so their durations are fully observed.
+    release() commits the holder so the lock wait ENDS inside the
+    observation window — in full mode a transition is only written to the
+    trace when the wait ends, so a never-ending lock wait would be absent
+    from the trace file (the ESC-2/FID-class open-interval gap, owned by
+    T1/T3)."""
 
     LOCK_TABLE = "_smoke_lock_wait"
 
@@ -346,9 +350,9 @@ def phase_live_query_event(pm_pid, mode):
           f"pgbench -i succeeded: {pgb_init.stderr[-200:]}")
     psql("SELECT pg_stat_statements_reset()")
 
-    # pgbench starts FIRST: its backends must exist when the tracer's
-    # initial scan runs (backends forked after attach are subject to the
-    # fork->attach race — see Workload docstring).
+    # pgbench starts FIRST so its backends are found by the initial scan
+    # (keeps this phase deterministic; the fork-after-attach path has its
+    # own dedicated phase 4).
     pgbench = subprocess.Popen(
         ["pgbench", "-U", "postgres", "-d", "postgres", "-c", "4", "-T", "14"],
         stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
@@ -386,8 +390,8 @@ def phase_trace_file(pm_pid, mode):
     wl = Workload()
     wl.open_sessions()
     psql("SELECT pg_stat_statements_reset()")
-    # pgbench backends must exist before the tracer attaches (fork->attach
-    # race, see Workload docstring).
+    # pgbench starts first so its backends are found by the initial scan
+    # (the fork-after-attach path is covered by phase 4).
     pgbench = subprocess.Popen(
         ["pgbench", "-U", "postgres", "-d", "postgres", "-c", "2", "-T", "16"],
         stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
@@ -437,6 +441,63 @@ def phase_trace_file(pm_pid, mode):
         subprocess.run(["rm", "-rf", trace_dir])
 
 
+def phase_fork_after_attach(pm_pid, mode):
+    """T4/CAP-8 regression: backends forked AFTER the tracer attached must
+    record events. The fork->attach race (bootstrap watchpoint armed after
+    the child already wrote its my_wait_event_info/MyProc pointer -> the
+    watchpoint never fires -> the backend records nothing for its whole
+    life, silently) was observed live in --mode full by the T0 CI run; the
+    T4 fix re-checks the pointer immediately after arming the bootstrap
+    watchpoint, closing the gap. In tiered mode the same phase guards the
+    sampler's lazy-resolve path for post-attach forks."""
+    print(f"--- Phase 4: fork-after-attach (--mode {mode}) ---")
+
+    tracer = subprocess.Popen(
+        [TRACER, "--mode", mode, "--pid", str(pm_pid),
+         "--interval", "14", "--duration", "17",
+         "--view", "system_event"],
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    time.sleep(2.5)   # BPF load + initial scan complete — NOW fork backends
+
+    wl = Workload()
+    try:
+        wl.open_sessions()     # all three backends fork post-attach
+        wl.fire(sleep_s=3)
+        time.sleep(5)
+        wl.release()
+        stdout, stderr = tracer.communicate(timeout=40)
+    except subprocess.TimeoutExpired:
+        tracer.kill()
+        stdout, stderr = tracer.communicate()
+    finally:
+        wl.stop()
+
+    out = STRIP_ANSI.sub('', stdout.decode('utf-8', errors='replace'))
+    err = stderr.decode('utf-8', errors='replace')
+    events = parse_system_events(out)
+    names = [e['name'] for e in events]
+    check(len(events) > 0,
+          "fork-after-attach: events captured from post-attach backends"
+          if events else
+          f"fork-after-attach: events captured from post-attach backends "
+          f"(stderr tail: {err[-300:]!r})")
+
+    sleep_ev = [e for e in events if e['name'] == 'Timeout:PgSleep']
+    check(len(sleep_ev) > 0,
+          f"fork-after-attach: Timeout:PgSleep from a post-attach backend "
+          f"(saw: {names}) [fork->attach race regression]")
+    if sleep_ev:
+        total = sleep_ev[0]['total_ms']
+        check(1200 <= total <= 7000,
+              f"fork-after-attach: PgSleep total = {total:.0f}ms "
+              f"(expect ~3000 ±tol)")
+
+    lock_ev = [e for e in events if e['name'] == 'Lock:relation']
+    check(len(lock_ev) > 0,
+          f"fork-after-attach: Lock:relation from a post-attach backend "
+          f"(saw: {names})")
+
+
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('--pid', type=int, help='Postmaster PID')
@@ -476,6 +537,7 @@ def main():
     phase_live_system_event(pm_pid, args.mode)
     phase_live_query_event(pm_pid, args.mode)
     phase_trace_file(pm_pid, args.mode)
+    phase_fork_after_attach(pm_pid, args.mode)
 
     print(f"\n{tests_passed}/{tests_run} checks passed")
     sys.exit(0 if tests_failed == 0 else 1)

--- a/tests/test_control.sh
+++ b/tests/test_control.sh
@@ -129,6 +129,9 @@ assert isinstance(r['uptime_s'], (int, float)) and r['uptime_s'] >= 0, r
 assert isinstance(r['backends'], int) and r['backends'] >= 0, r
 assert r['pg_pid'] == $PM_PID, r
 assert isinstance(r['version'], str) and r['version'], r
+# T4/SMP-1: sampler health must be present and healthy on a working box
+assert r['sampler_healthy'] is True, r
+assert r['sampler_unhealthy_reason'] == '', r
 "
 check $? "default mode is tiered, tier=sampled (no watchpoints until escalation)"
 
@@ -142,7 +145,10 @@ assert r['ok'] is True, r
 for k in ('events_total', 'events_per_sec', 'lifecycle_events_total',
           'wp_attach_failures_total', 'backends_tracked',
           'trace_events_written_total', 'trace_bytes_written_total',
-          'uptime_s'):
+          'uptime_s',
+          # T4 capture-hardening counters (CAP-1/2/5/6, SMP-1/3)
+          'state_map_full_total', 'seen_query_ids_full_total',
+          'invalid_wait_reads_total', 'sampler_ticks_missed_total'):
     assert k in r, 'missing ' + k
     assert isinstance(r[k], (int, float)), k
 "

--- a/tests/test_discovery.c
+++ b/tests/test_discovery.c
@@ -98,32 +98,38 @@ int main(void)
     CHECK(load_base_fixture("maps_ubuntu_pie.txt", "no_such_binary") == 0,
           "missing basename should return 0");
 
-    /* ── CAP-4 adversarial case (fix owned by Phase T4) ───────────────
+    /* ── CAP-4 adversarial case (fixed in Phase T4) ───────────────────
      * pg_stat_statements.so mapped BELOW the binary; its path
-     * "/usr/lib/postgresql/17/lib/..." contains the substring "postgres",
-     * so the current whole-line strstr() match picks the .so's base.
-     * Correct answer: 0x5560d1a00000 (the binary). Current answer:
-     * 0x4f2a80000000 (the .so). This test PINS the current wrong behavior
-     * as an expected failure so the hazard stays visible; when T4 lands
-     * the exact-pathname match, flip this to assert the correct base.
-     * TODO(T4/CAP-4): assert == 0x5560d1a00000 and drop the xfail. */
-    {
-        uint64_t got = load_base_fixture("maps_ext_below_binary.txt", "postgres");
-        if (got == 0x5560d1a00000ULL) {
-            printf("  XPASS(CAP-4): extension-.so-below-binary now resolves the\n"
-                   "  BINARY's base — T4 fix landed? Promote this to a hard assert.\n");
-            run++; ok++;
-        } else {
-            CHECK(got == 0x4f2a80000000ULL,
-                  "CAP-4 fixture: got 0x%llx, expected the known-wrong .so base "
-                  "0x4f2a80000000 (current strstr behavior) — behavior changed "
-                  "without updating this test", (unsigned long long)got);
-            printf("  XFAIL(CAP-4/T4): substring match returns the extension .so's "
-                   "base below the binary\n"
-                   "  (documented hazard — the #24 class; exact-path match is "
-                   "owned by Phase T4)\n");
-        }
-    }
+     * "/usr/lib/postgresql/17/lib/..." contains the substring "postgres".
+     * The old whole-line strstr() match picked the .so's base
+     * (0x4f2a80000000) → every symbol VA garbage → zero events, silently
+     * (the #24 class). The exact pathname-field match must resolve the
+     * BINARY's base. Hard assert — this was T0's pinned expected-failure. */
+    CHECK(load_base_fixture("maps_ext_below_binary.txt", "postgres")
+              == 0x5560d1a00000ULL,
+          "CAP-4: extension .so below binary must not win (exact-basename "
+          "match)");
+
+    /* Same fixture through the FULL-path match — the path the daemon
+     * actually uses (pgwt_resolve_symbol passes /proc/<pid>/exe). */
+    CHECK(load_base_fixture("maps_ext_below_binary.txt",
+                            "/usr/lib/postgresql/17/bin/postgres")
+              == 0x5560d1a00000ULL,
+          "CAP-4: full-path match resolves the binary's base");
+
+    /* A full path that names the EXTENSION resolves the extension —
+     * proving the comparison is exact-pathname, not basename-of-path. */
+    CHECK(load_base_fixture("maps_ext_below_binary.txt",
+                            "/usr/lib/postgresql/17/lib/pg_stat_statements.so")
+              == 0x4f2a80000000ULL,
+          "full-path match of the .so itself resolves the .so");
+
+    /* Substring of a basename must NOT match: "postgres" is a substring of
+     * "pg_stat_statements.so"'s path but of no basename in the EL9 fixture
+     * except the binary's own. A name that is a strict substring of the
+     * binary basename must find nothing. */
+    CHECK(load_base_fixture("maps_el9_pie.txt", "postgre") == 0,
+          "strict-substring basename must not match");
 
     /* ── 2. self-resolution: the #24 regression test proper ───────────
      * Resolve a known global in THIS binary through the real code path
@@ -151,11 +157,15 @@ int main(void)
         uint64_t sym_val = pgwt_find_symbol_offset(exe, "pgwt_test_fixture_symbol");
         CHECK(sym_val != 0, "pgwt_find_symbol_offset found nothing");
 
+        /* Both match forms must find the load base: exact basename (fixture
+         * form) and the full /proc/self/exe path (the daemon's form). */
         uint64_t load_base = pgwt_find_load_base(getpid(), base);
-        CHECK(load_base != 0, "pgwt_find_load_base(self) returned 0");
+        CHECK(load_base != 0, "pgwt_find_load_base(self, basename) returned 0");
+        CHECK(pgwt_find_load_base(getpid(), exe) == load_base,
+              "full-path and basename load base disagree");
 
         uint64_t va = pgwt_resolve_symbol(exe, "pgwt_test_fixture_symbol",
-                                          getpid(), base);
+                                          getpid());
         uint64_t actual = (uint64_t)(uintptr_t)&pgwt_test_fixture_symbol;
         CHECK(va == actual,
               "resolved VA 0x%llx != actual &symbol 0x%llx (load_base=0x%llx, "

--- a/tests/test_pg13_resolve.c
+++ b/tests/test_pg13_resolve.c
@@ -35,24 +35,52 @@ int main(void)
 
     pid_t self = getpid();
 
-    /* Valid values: CPU (0) and each known wait class byte must be accepted. */
-    volatile uint32_t v_cpu   = 0x00000000u;
+    /* Non-zero class-valid values: the ONLY readings that PROVE the offset
+     * (PGWT_WEI_VALID_NONZERO). */
     volatile uint32_t v_lock  = 0x03000000u;   /* Lock:relation */
     volatile uint32_t v_sleep = 0x09000001u;   /* Timeout:PgSleep */
     volatile uint32_t v_io    = 0x0A00000Du;   /* IO:DataFileRead (PG13) */
-    CHECK(pgwt_validate_wait_addr(self, (uint64_t)(uintptr_t)&v_cpu)   == 1, "CPU value valid");
-    CHECK(pgwt_validate_wait_addr(self, (uint64_t)(uintptr_t)&v_lock)  == 1, "Lock class valid");
-    CHECK(pgwt_validate_wait_addr(self, (uint64_t)(uintptr_t)&v_sleep) == 1, "Timeout class valid");
-    CHECK(pgwt_validate_wait_addr(self, (uint64_t)(uintptr_t)&v_io)    == 1, "IO class valid");
+    CHECK(pgwt_validate_wait_addr(self, (uint64_t)(uintptr_t)&v_lock)
+              == PGWT_WEI_VALID_NONZERO, "Lock class = proof");
+    CHECK(pgwt_validate_wait_addr(self, (uint64_t)(uintptr_t)&v_sleep)
+              == PGWT_WEI_VALID_NONZERO, "Timeout class = proof");
+    CHECK(pgwt_validate_wait_addr(self, (uint64_t)(uintptr_t)&v_io)
+              == PGWT_WEI_VALID_NONZERO, "IO class = proof");
+
+    /* CAP-2: ZEROED MEMORY MUST NOT VALIDATE. Zero (on-CPU) is consistent
+     * with a correct offset but is also exactly what a WRONG offset into
+     * zeroed memory reads — it must classify as inconclusive
+     * (PGWT_WEI_ZERO), never as proof. The old validator returned the same
+     * "1" for zero as for real proof, blessing wrong offsets forever. */
+    volatile uint32_t v_cpu = 0x00000000u;
+    CHECK(pgwt_validate_wait_addr(self, (uint64_t)(uintptr_t)&v_cpu)
+              == PGWT_WEI_ZERO, "zero reading is NOT proof (inconclusive)");
+    CHECK(pgwt_validate_wait_addr(self, (uint64_t)(uintptr_t)&v_cpu)
+              != PGWT_WEI_VALID_NONZERO, "zeroed memory must not validate");
 
     /* Garbage values (what a WRONG offset produces): class byte outside the
      * known 0x01..0x0B range must be REJECTED so the daemon refuses to attach. */
     volatile uint32_t v_garbage1 = 0xDEADBEEFu;  /* class 0xDE */
     volatile uint32_t v_garbage2 = 0x7F000000u;  /* class 0x7F (e.g. a pointer high byte) */
     volatile uint32_t v_garbage3 = 0x20000000u;  /* class 0x20 */
-    CHECK(pgwt_validate_wait_addr(self, (uint64_t)(uintptr_t)&v_garbage1) == 0, "garbage class rejected");
-    CHECK(pgwt_validate_wait_addr(self, (uint64_t)(uintptr_t)&v_garbage2) == 0, "high-byte pointer rejected");
-    CHECK(pgwt_validate_wait_addr(self, (uint64_t)(uintptr_t)&v_garbage3) == 0, "class 0x20 rejected");
+    CHECK(pgwt_validate_wait_addr(self, (uint64_t)(uintptr_t)&v_garbage1)
+              == PGWT_WEI_GARBAGE, "garbage class rejected");
+    CHECK(pgwt_validate_wait_addr(self, (uint64_t)(uintptr_t)&v_garbage2)
+              == PGWT_WEI_GARBAGE, "high-byte pointer rejected");
+    CHECK(pgwt_validate_wait_addr(self, (uint64_t)(uintptr_t)&v_garbage3)
+              == PGWT_WEI_GARBAGE, "class 0x20 rejected");
+
+    /* The shared pure classifier must agree (it is what the preseed and
+     * sampler backstops use — CAP-5 extends the check to every read path). */
+    CHECK(pgwt_classify_wei(0) == PGWT_WEI_ZERO, "classify: zero");
+    CHECK(pgwt_classify_wei(0x06000000u) == PGWT_WEI_VALID_NONZERO,
+          "classify: Client:ClientRead is proof");
+    CHECK(pgwt_classify_wei(0x0B000001u) == PGWT_WEI_VALID_NONZERO,
+          "classify: InjectionPoint (0x0B) valid");
+    CHECK(pgwt_classify_wei(0x0C000000u) == PGWT_WEI_GARBAGE,
+          "classify: class 0x0C is garbage");
+    CHECK(pgwt_classify_wei(0xDEADBEEFu) == PGWT_WEI_GARBAGE,
+          "classify: 0xDEADBEEF is garbage");
 
     /* Unreadable address -> -1 (transient read error, not a hard reject). */
     CHECK(pgwt_validate_wait_addr(self, 0x1) == -1, "unreadable addr -> -1");

--- a/tests/test_sampler.c
+++ b/tests/test_sampler.c
@@ -1,12 +1,21 @@
-/* test_sampler.c — Unit tests for the sampled provider's core (Phase A2)
+/* test_sampler.c — Unit tests for the sampled provider's core (A2, T4)
  *
  * Exercises the BPF-free sampler core (pgwt_sampler_read_targets and
  * pgwt_sampler_build_batch) against a controlled target: this process's own
- * memory (read via process_vm_readv on getpid()) and a child process with a
- * known 4-byte value at a known address (read via the per-pid pread
- * fallback). Built with -DPGWT_SERVER against the server objects so it needs
- * no BPF skeleton (buildable without bpftool, and in CI), matching
- * test_trace_v2.
+ * memory (read via process_vm_readv on getpid()) and child processes with
+ * known 4-byte values at known addresses. Built with -DPGWT_SERVER against
+ * the server objects so it needs no BPF skeleton (buildable without bpftool,
+ * and in CI), matching test_trace_v2.
+ *
+ * T4 additions:
+ *   - SMP-2: a process-LOCAL address (same VA in a forked child, private
+ *     pages) must be read per-pid, never batched through another pid — the
+ *     batched read SUCCEEDS with the wrong (reader's) value.
+ *   - CAP-2/5 backstop: garbage class-byte readings are dropped + counted.
+ *   - SMP-1: the read-health state machine (loud on first + persistent
+ *     failure, recovery).
+ *   - SMP-3: effective sample period compensates missed/late ticks.
+ *   - SMP-4: the pid->query_id join index.
  */
 #define _GNU_SOURCE
 #include "sampler.h"
@@ -37,15 +46,16 @@ static void test_self_read(void)
     printf("--- self-read via process_vm_readv ---\n");
 
     /* Three known values; one is 0 (on-CPU) to confirm reads, not just
-     * encoding, handle it. */
+     * encoding, handle it. Marked is_shared so the batch path is used
+     * (reading one's own memory through one's own pid is trivially sound). */
     volatile uint32_t v0 = WEI(PG_WAIT_IO, 0x12);     /* IO:something */
     volatile uint32_t v1 = 0;                          /* on CPU */
     volatile uint32_t v2 = WEI(PG_WAIT_LOCK, 0x03);   /* Lock:something */
 
     struct pgwt_sample_target targets[3] = {
-        { .pid = getpid(), .wait_event_addr = (uint64_t)(uintptr_t)&v0, .query_id = 111 },
-        { .pid = getpid(), .wait_event_addr = (uint64_t)(uintptr_t)&v1, .query_id = 222 },
-        { .pid = getpid(), .wait_event_addr = (uint64_t)(uintptr_t)&v2, .query_id = 333 },
+        { .pid = getpid(), .wait_event_addr = (uint64_t)(uintptr_t)&v0, .query_id = 111, .is_shared = 1 },
+        { .pid = getpid(), .wait_event_addr = (uint64_t)(uintptr_t)&v1, .query_id = 222, .is_shared = 1 },
+        { .pid = getpid(), .wait_event_addr = (uint64_t)(uintptr_t)&v2, .query_id = 333, .is_shared = 1 },
     };
 
     uint32_t vals[3] = { 0xdead, 0xdead, 0xdead };
@@ -80,7 +90,7 @@ static void test_build_batch(void)
     struct pgwt_trace_event out[3];
     memset(out, 0xAA, sizeof(out));
     uint64_t ts = 0x123456789ABCULL;
-    int n = pgwt_sampler_build_batch(targets, vals, 3, ts, out);
+    int n = pgwt_sampler_build_batch(targets, vals, 3, ts, out, NULL);
 
     CHECK(n == 2, "expected 2 records (1 on-CPU skipped), got %d", n);
 
@@ -102,6 +112,37 @@ static void test_build_batch(void)
           (unsigned long long)out[1].query_id);
 }
 
+/* ── Test 2b: build_batch drops + counts garbage readings (CAP-2/5) ───── */
+
+static void test_build_batch_garbage(void)
+{
+    printf("--- build_batch garbage class-byte filter (CAP-2/5) ---\n");
+
+    struct pgwt_sample_target targets[3] = {
+        { .pid = 2001, .wait_event_addr = 0x1000, .query_id = 1 },
+        { .pid = 2002, .wait_event_addr = 0x2000, .query_id = 2 },
+        { .pid = 2003, .wait_event_addr = 0x3000, .query_id = 3 },
+    };
+    uint32_t vals[3] = {
+        WEI(PG_WAIT_LOCK, 0x00),  /* valid — recorded */
+        0xDEADBEEFu,              /* garbage class 0xDE — dropped + counted */
+        0x7F000001u,              /* garbage class 0x7F — dropped + counted */
+    };
+
+    struct pgwt_trace_event out[3];
+    uint64_t invalid = 0;
+    int n = pgwt_sampler_build_batch(targets, vals, 3, 1, out, &invalid);
+
+    CHECK(n == 1, "expected 1 record (2 garbage dropped), got %d", n);
+    CHECK(out[0].pid == 2001, "the valid record survived");
+    CHECK(invalid == 2, "expected 2 invalid reads counted, got %llu",
+          (unsigned long long)invalid);
+
+    /* NULL counter must not crash and must still drop garbage. */
+    n = pgwt_sampler_build_batch(targets, vals, 3, 1, out, NULL);
+    CHECK(n == 1, "NULL invalid counter: still 1 record, got %d", n);
+}
+
 /* ── Test 3: per-pid pread fallback on a bad leading entry ────────────── */
 
 static void test_fallback(void)
@@ -120,8 +161,8 @@ static void test_fallback(void)
     munmap(bad, 4096);   /* now definitely unmapped */
 
     struct pgwt_sample_target targets[2] = {
-        { .pid = getpid(), .wait_event_addr = (uint64_t)(uintptr_t)bad, .query_id = 1 },
-        { .pid = getpid(), .wait_event_addr = (uint64_t)(uintptr_t)&good, .query_id = 2 },
+        { .pid = getpid(), .wait_event_addr = (uint64_t)(uintptr_t)bad, .query_id = 1, .is_shared = 1 },
+        { .pid = getpid(), .wait_event_addr = (uint64_t)(uintptr_t)&good, .query_id = 2, .is_shared = 1 },
     };
 
     uint32_t vals[2] = { 0xdead, 0xdead };
@@ -135,11 +176,11 @@ static void test_fallback(void)
           (unsigned long long)faults);
 }
 
-/* ── Test 4: child process read via fallback (different pid) ───────────── */
+/* ── Test 4: child process read (cross-pid, shared mapping) ───────────── */
 
 static void test_child_read(void)
 {
-    printf("--- read child process value (cross-pid) ---\n");
+    printf("--- read child process value (cross-pid, MAP_SHARED) ---\n");
 
     /* Shared anonymous mmap: parent writes a known value, child sees it at
      * its own (possibly different) virtual address, reports the address back
@@ -173,7 +214,7 @@ static void test_child_read(void)
     CHECK(r == (ssize_t)sizeof(child_addr), "did not get child address");
 
     struct pgwt_sample_target targets[1] = {
-        { .pid = child, .wait_event_addr = child_addr, .query_id = 7 },
+        { .pid = child, .wait_event_addr = child_addr, .query_id = 7, .is_shared = 1 },
     };
     uint32_t vals[1] = { 0xdead };
     uint64_t faults = 0;
@@ -190,12 +231,190 @@ static void test_child_read(void)
     munmap(page, 4096);
 }
 
+/* ── Test 5 (SMP-2): process-LOCAL addresses must be read per-pid ─────── */
+
+/* A .data global: after fork it exists at the SAME virtual address in the
+ * child, but the pages are PRIVATE (COW) — the child's value diverges from
+ * the parent's. The old batched sweep read the child's target through the
+ * PARENT pid (the batch's reader): the read SUCCEEDED and returned the
+ * PARENT's value, silently misattributed to the child. With is_shared unset
+ * the target must be read via /proc/<child>/mem and return the CHILD's
+ * value. */
+static volatile uint32_t smp2_local_slot = WEI(PG_WAIT_LOCK, 0x01);
+
+static void test_local_addr_not_batched(void)
+{
+    printf("--- SMP-2: process-local address read per-pid, not batched ---\n");
+
+    const uint32_t parent_val = WEI(PG_WAIT_LOCK, 0x01);
+    const uint32_t child_val  = WEI(PG_WAIT_IO, 0x05);
+
+    int pfd[2];
+    if (pipe(pfd) != 0) { CHECK(0, "pipe failed"); return; }
+
+    pid_t child = fork();
+    if (child == 0) {
+        /* Child: overwrite ITS OWN copy of the global (COW page), signal
+         * readiness, idle until killed. */
+        smp2_local_slot = child_val;
+        char ready = 1;
+        ssize_t w = write(pfd[1], &ready, 1);
+        (void)w;
+        for (;;) pause();
+        _exit(0);
+    }
+    CHECK(child > 0, "fork failed");
+
+    char ready = 0;
+    ssize_t r = read(pfd[0], &ready, 1);
+    CHECK(r == 1 && ready == 1, "child did not signal readiness");
+
+    /* Target 0: the parent's own slot (batched — its own pid is the batch
+     * reader, sound). Target 1: the CHILD's slot at the same VA, correctly
+     * marked NOT shared. Before the SMP-2 fix, target 1 was read through
+     * target 0's pid (the parent) and returned parent_val — this asserts
+     * the child's value comes back. */
+    struct pgwt_sample_target targets[2] = {
+        { .pid = getpid(), .query_id = 1, .is_shared = 1,
+          .wait_event_addr = (uint64_t)(uintptr_t)&smp2_local_slot },
+        { .pid = child, .query_id = 2, .is_shared = 0,
+          .wait_event_addr = (uint64_t)(uintptr_t)&smp2_local_slot },
+    };
+    uint32_t vals[2] = { 0xdead, 0xdead };
+    int got = pgwt_sampler_read_targets(targets, 2, vals, NULL);
+
+    CHECK(got == 2, "expected both targets read, got %d", got);
+    CHECK(vals[0] == parent_val, "parent slot = 0x%x expected 0x%x",
+          vals[0], parent_val);
+    CHECK(vals[1] == child_val,
+          "SMP-2: child's local slot = 0x%x expected the CHILD's value 0x%x "
+          "(reader-pid value = misattribution)", vals[1], child_val);
+
+    kill(child, SIGKILL);
+    waitpid(child, NULL, 0);
+    close(pfd[0]);
+    close(pfd[1]);
+}
+
+/* ── Test 6 (SMP-1): read-health state machine ────────────────────────── */
+
+static void test_health(void)
+{
+    printf("--- SMP-1: sampler read-health state machine ---\n");
+
+    const uint64_t SEC = 1000000000ULL;
+    struct pgwt_sampler_health h;
+    memset(&h, 0, sizeof(h));
+    h.healthy = 1;
+
+    /* Healthy ticks: no action, stays healthy. */
+    CHECK(pgwt_sampler_health_note(&h, 10, 10, 0, 1 * SEC)
+              == PGWT_SAMPLER_LOG_NONE, "healthy tick -> no log");
+    CHECK(h.healthy == 1, "still healthy");
+
+    /* Zero-target ticks are neutral (nothing to read != failure). */
+    CHECK(pgwt_sampler_health_note(&h, 0, 0, 0, 2 * SEC)
+              == PGWT_SAMPLER_LOG_NONE, "no-target tick is neutral");
+    CHECK(h.healthy == 1, "no-target tick must not flag unhealthy");
+
+    /* FIRST total failure: loud immediately + unhealthy. */
+    CHECK(pgwt_sampler_health_note(&h, 10, 0, 1 /*EPERM*/, 3 * SEC)
+              == PGWT_SAMPLER_LOG_DEGRADED, "first total failure logs");
+    CHECK(h.healthy == 0, "unhealthy after first total failure");
+    CHECK(h.last_errno == 1, "errno recorded");
+
+    /* Following failures within the re-log window: silent but counted. */
+    CHECK(pgwt_sampler_health_note(&h, 10, 0, 1, 4 * SEC)
+              == PGWT_SAMPLER_LOG_NONE, "repeat failure within window silent");
+    CHECK(h.consec_failed_ticks == 2, "consecutive failures counted");
+
+    /* Persistent failure: re-logs after the period (60s). */
+    CHECK(pgwt_sampler_health_note(&h, 10, 0, 1, 64 * SEC)
+              == PGWT_SAMPLER_LOG_DEGRADED, "persistent failure re-logs");
+
+    /* Recovery: logs once, healthy again, consec reset. */
+    CHECK(pgwt_sampler_health_note(&h, 10, 5, 0, 65 * SEC)
+              == PGWT_SAMPLER_LOG_RECOVERED, "recovery logs");
+    CHECK(h.healthy == 1, "healthy after recovery");
+    CHECK(h.consec_failed_ticks == 0, "consecutive counter reset");
+    CHECK(h.failed_ticks_total == 3, "total failed ticks preserved (got %llu)",
+          (unsigned long long)h.failed_ticks_total);
+
+    /* A partial read (some targets fail) is NOT a health failure — only a
+     * TOTAL failure is indistinguishable from idle. */
+    CHECK(pgwt_sampler_health_note(&h, 10, 1, 0, 66 * SEC)
+              == PGWT_SAMPLER_LOG_NONE, "partial read stays healthy");
+    CHECK(h.healthy == 1, "partial read keeps healthy");
+}
+
+/* ── Test 7 (SMP-3): effective sample period ──────────────────────────── */
+
+static void test_effective_period(void)
+{
+    printf("--- SMP-3: effective sample period (missed-tick weight) ---\n");
+
+    const uint64_t NOM = 100000000ULL;   /* 100ms nominal (10 Hz) */
+
+    /* First tick: nominal. */
+    CHECK(pgwt_sampler_effective_period(NOM, 0, 5000) == NOM,
+          "first tick uses nominal");
+
+    /* On-time tick: measured == nominal. */
+    CHECK(pgwt_sampler_effective_period(NOM, 1000, 1000 + NOM) == NOM,
+          "on-time tick = nominal");
+
+    /* Stalled daemon: 3 ticks coalesced -> weight = the real elapsed time
+     * (this is the SMP-3 fix: nominal weight would deflate AAS under load). */
+    CHECK(pgwt_sampler_effective_period(NOM, 1000, 1000 + 3 * NOM) == 3 * NOM,
+          "coalesced ticks weighted by measured elapsed");
+
+    /* Early/backwards clock never shrinks below nominal. */
+    CHECK(pgwt_sampler_effective_period(NOM, 1000, 1000 + NOM / 2) == NOM,
+          "early tick clamps to nominal");
+    CHECK(pgwt_sampler_effective_period(NOM, 5000, 1000) == NOM,
+          "non-monotonic input clamps to nominal");
+
+    /* Absurd stall clamps at 60s. */
+    CHECK(pgwt_sampler_effective_period(NOM, 0x1000, 0x1000 + 3600ULL * 1000000000ULL)
+              == 60ULL * 1000000000ULL,
+          "stall clamped to 60s");
+}
+
+/* ── Test 8 (SMP-4): pid -> query_id join index ───────────────────────── */
+
+static void test_qid_index(void)
+{
+    printf("--- SMP-4: qid join index sort + lookup ---\n");
+
+    struct pgwt_qid_entry e[5] = {
+        { .pid = 500, .query_id = 55 },
+        { .pid = 100, .query_id = 11 },
+        { .pid = 900, .query_id = 99 },
+        { .pid = 300, .query_id = 33 },
+        { .pid = 700, .query_id = 77 },
+    };
+    pgwt_qid_index_sort(e, 5);
+    for (int i = 1; i < 5; i++)
+        CHECK(e[i - 1].pid < e[i].pid, "sorted order at %d", i);
+
+    CHECK(pgwt_qid_index_lookup(e, 5, 100) == 11, "lookup first");
+    CHECK(pgwt_qid_index_lookup(e, 5, 900) == 99, "lookup last");
+    CHECK(pgwt_qid_index_lookup(e, 5, 300) == 33, "lookup middle");
+    CHECK(pgwt_qid_index_lookup(e, 5, 301) == 0, "missing pid -> 0");
+    CHECK(pgwt_qid_index_lookup(e, 0, 100) == 0, "empty index -> 0");
+}
+
 int main(void)
 {
     test_self_read();
     test_build_batch();
+    test_build_batch_garbage();
     test_fallback();
     test_child_read();
+    test_local_addr_not_batched();
+    test_health();
+    test_effective_period();
+    test_qid_index();
 
     printf("\n%d/%d checks passed\n", tests_passed, tests_run);
     return tests_passed == tests_run ? 0 : 1;

--- a/tests/test_state_map_loud.py
+++ b/tests/test_state_map_loud.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""test_state_map_loud.py — CAP-1 (T4): a full BPF state_map must be LOUD.
+
+Before T4, state_map had max_entries=512 (< MAX_BACKENDS < common
+max_connections) and every insert past capacity failed with an UNCHECKED
+return: backends beyond the map size never recorded a single event, with no
+error anywhere. T4 sizes the map to MAX_BACKENDS, checks every insert, and
+surfaces failures as `state_map_full_total` on the control socket plus a
+loud ERROR log.
+
+Proving the loud path must not require >1024 real connections on a CI
+runner, so the daemon honors PGWT_STATE_MAP_ENTRIES (test hook) to shrink
+the map before load. This test:
+
+  1. runs the tracer in --mode tiered with PGWT_STATE_MAP_ENTRIES=4 and
+     opens ~10 sessions -> asserts metrics.state_map_full_total > 0 and the
+     ERROR log line fired (the loud path works);
+  2. runs the tracer at DEFAULT sizing with the same sessions -> asserts
+     state_map_full_total == 0 (no false positives at real capacity).
+
+Also asserts the T4 health/observability fields exist in `status` and
+`metrics` (sampler_healthy, invalid_wait_reads_total, ...) — the daemon side
+of what tests/mock_server.py mirrors.
+
+Usage: sudo python3 tests/test_state_map_loud.py [--pid POSTMASTER_PID]
+"""
+import argparse
+import json
+import os
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from testutil import find_postmaster
+
+PROJECT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+TRACER = os.path.join(PROJECT_DIR, "pg_wait_tracer")
+
+tests_run = 0
+tests_failed = 0
+
+
+def check(cond, msg):
+    global tests_run, tests_failed
+    tests_run += 1
+    if cond:
+        print(f"  PASS: {msg}")
+    else:
+        tests_failed += 1
+        print(f"  FAIL: {msg}")
+
+
+def ctl(sock_path, cmd, timeout=5):
+    """One JSON-line request against the daemon control socket."""
+    s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    s.settimeout(timeout)
+    try:
+        s.connect(sock_path)
+        s.sendall((json.dumps(cmd) + "\n").encode())
+        data = b""
+        while not data.endswith(b"\n"):
+            chunk = s.recv(65536)
+            if not chunk:
+                break
+            data += chunk
+    finally:
+        s.close()
+    return json.loads(data)
+
+
+def open_sessions(n):
+    procs = []
+    for _ in range(n):
+        procs.append(subprocess.Popen(
+            ["psql", "-U", "postgres", "-d", "postgres"],
+            stdin=subprocess.PIPE, stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL, text=True))
+    return procs
+
+
+def close_sessions(procs):
+    for p in procs:
+        p.terminate()
+    for p in procs:
+        try:
+            p.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            p.kill()
+
+
+def run_case(pm_pid, sessions, shrink_env, duration=20):
+    """Run the tracer against `sessions` open backends; return
+    (metrics, status, stderr)."""
+    trace_dir = tempfile.mkdtemp(prefix="pgwt_smf_")
+    os.chmod(trace_dir, 0o755)
+    env = dict(os.environ)
+    if shrink_env:
+        env["PGWT_STATE_MAP_ENTRIES"] = str(shrink_env)
+
+    tracer = subprocess.Popen(
+        [TRACER, "--mode", "tiered", "--pid", str(pm_pid),
+         "-T", trace_dir, "--duration", str(duration),
+         "--interval", "5", "--quiet"],
+        stdout=subprocess.DEVNULL, stderr=subprocess.PIPE, env=env)
+    metrics = status = None
+    try:
+        sock = os.path.join(trace_dir, "pgwt.sock")
+        deadline = time.time() + 10
+        while time.time() < deadline and not os.path.exists(sock):
+            time.sleep(0.25)
+        # Give the sampler time to lazily resolve + seed every backend.
+        time.sleep(6)
+        metrics = ctl(sock, {"cmd": "metrics"})
+        status = ctl(sock, {"cmd": "status"})
+    finally:
+        tracer.terminate()
+        try:
+            _, stderr = tracer.communicate(timeout=15)
+        except subprocess.TimeoutExpired:
+            tracer.kill()
+            _, stderr = tracer.communicate()
+        subprocess.run(["rm", "-rf", trace_dir])
+    return metrics, status, stderr.decode("utf-8", errors="replace")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--pid', type=int, help='Postmaster PID')
+    args = parser.parse_args()
+
+    if os.geteuid() != 0:
+        print("ERROR: must run as root (sudo)")
+        sys.exit(1)
+    if not os.path.exists(TRACER):
+        print(f"ERROR: {TRACER} not built")
+        sys.exit(1)
+    pm_pid = args.pid or find_postmaster()
+    if not pm_pid:
+        print("ERROR: cannot find PostgreSQL postmaster PID")
+        sys.exit(1)
+
+    print(f"=== test_state_map_loud (postmaster PID {pm_pid}) ===")
+
+    sessions = open_sessions(10)
+    time.sleep(2)   # backends connected (idle -> ClientRead)
+    try:
+        # ── Case 1: shrunken map (4 entries) — the loud path must fire ──
+        print("--- shrunken state_map (PGWT_STATE_MAP_ENTRIES=4) ---")
+        metrics, status, err = run_case(pm_pid, sessions, shrink_env=4)
+        check(metrics is not None and metrics.get("ok") is True,
+              "metrics reachable over the control socket")
+        full = int(metrics.get("state_map_full_total", 0)) if metrics else 0
+        check(full > 0,
+              f"state_map_full_total > 0 with 10+ backends vs 4 slots "
+              f"(got {full}) [CAP-1 loud path]")
+        check("state_map is FULL" in err,
+              "daemon stderr carries the loud state_map-full ERROR")
+        check("PGWT_STATE_MAP_ENTRIES" in err,
+              "test-hook shrink is itself announced on stderr")
+
+        # T4 observability fields must exist on the daemon side (the mock
+        # mirrors them; protocol drift between the two is caught here).
+        for key in ("state_map_full_total", "seen_query_ids_full_total",
+                    "invalid_wait_reads_total", "sampler_ticks_missed_total",
+                    "sampler_healthy"):
+            check(metrics is not None and key in metrics,
+                  f"metrics carries '{key}'")
+        for key in ("sampler_healthy", "sampler_unhealthy_reason"):
+            check(status is not None and key in status,
+                  f"status carries '{key}'")
+        check(status is not None and status.get("sampler_healthy") is True,
+              "sampler_healthy=true on a working system")
+        inv = int(metrics.get("invalid_wait_reads_total", -1)) if metrics else -1
+        check(inv == 0, f"invalid_wait_reads_total == 0 on a healthy system "
+              f"(got {inv})")
+
+        # ── Case 2: default sizing — no false positives ──────────────────
+        print("--- default state_map sizing (no shrink) ---")
+        metrics2, _, err2 = run_case(pm_pid, sessions, shrink_env=None,
+                                     duration=14)
+        full2 = int(metrics2.get("state_map_full_total", -1)) if metrics2 else -1
+        check(full2 == 0,
+              f"state_map_full_total == 0 at default sizing (got {full2})")
+        check("state_map is FULL" not in err2,
+              "no state_map-full ERROR at default sizing")
+    finally:
+        close_sessions(sessions)
+
+    print(f"\n{tests_run - tests_failed}/{tests_run} checks passed")
+    sys.exit(0 if tests_failed == 0 else 1)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Phase T4 of the Trust Milestone (docs/TRUST_MILESTONE_PLAN.md). Owns CAP-1..12 and SMP-1..4: after this PR there is no known path where the daemon records wrong-or-nothing without a loud signal (log + control-socket health + metric).

## Per-finding summary

| Finding | Fix | Regression test |
|---|---|---|
| **CAP-1** 🔴 state_map=512 silently drops backends | map sized to MAX_BACKENDS; every insert checked (BPF fail_counters + userspace counter); `state_map_full_total` metric + log-once ERROR; `PGWT_STATE_MAP_ENTRIES` test hook shrinks the map at load | `tests/test_state_map_loud.py` (CI smoke section): 10 sessions vs 4 slots → counter>0 + ERROR log; default sizing → 0 |
| **CAP-2** 🟠 `wei==0` blessed a wrong offset forever | zero is never proof (`pgwt_classify_wei`); validation across all scanned backends; `pgwt_confirm_wait_offset()` re-poll, refuse-to-attach on PG<17 if unconfirmed; scan garbage now actually ABORTS daemon_init (the old FATAL degraded to WARN and kept running); continuous re-validation on preseed + every sampler read | `test_pg13_resolve` (zero-not-proof, classifier), CI PG16 refusal cell |
| **CAP-3** 🟠 PG13 offsets trusted per build | rides on CAP-2; constraint documented at the offset table | — |
| **CAP-4** 🟠 `strstr(line,"postgres")` load base | exact pathname-field match (full path / exact basename, `(deleted)`-tolerant); `pgwt_resolve_symbol` matches the full `/proc/<pid>/exe` path | T0's expected-fail adversarial fixture **flipped to a hard pass** + full-path cases |
| **CAP-5** 🟠 PG17+ never validated | scan/init/preseed/sampler validation now version-independent; garbage readings dropped + `invalid_wait_reads_total` | `test_sampler` garbage-filter test |
| **CAP-7** 🟡 popen with unquoted paths in a root daemon | `src/spawn.c` fork/execvp argv helpers; readelf awk pipeline ported to a C streaming parser; psql via argv | behavior-identical; covered by existing DWARF/name-loading paths in CI |
| **CAP-8** 🟡 ENABLE before preseed | open DISABLED → preseed → enable; `handle_init` unified onto the preseeding attach helper | CI smoke (escalation + full attach paths) |
| **fork→attach race** (T0 live finding) | root cause: bootstrap watchpoint armed *after* the child already wrote its pointer → never fires → backend records nothing for life; fixed by re-checking the pointer right after arming — where "initialized" means the pointer targets SHARED memory (on PG17+ it is non-zero from birth, statically pointing at the process-local dummy `local_my_wait_event_info`; only a shm target proves InitProcess ran). Same class fixed in the sampler's lazy resolve (non-shared addresses are re-resolved until they land in shm) | new smoke **phase 4: fork-after-attach** (both modes) |
| **CAP-12** 🟡 EMFILE looks like ESRCH | RLIMIT_NOFILE raised at startup; EMFILE/ENFILE-specific loud ERROR | — (log-path) |
| **CAP-6/9/10/11** 🟡 | seen_query_ids-full counted + log-once WARN; PID reuse covered by BPF_ANY preseed refresh (documented); PID-ns + postmaster-restart contracts documented in INSTALL.md (systemd `Restart=`/`LimitNOFILE=`) | — |
| **SMP-1** 🟠 silent total read failure = fake idle DB | loud ERROR on first + persistent (60s) failure, recovery INFO; `status.sampler_healthy` + `sampler_unhealthy_reason` | `test_sampler` health state-machine test |
| **SMP-2** 🟠 batched sweep returns reader-pid values for process-local addrs | targets classified via `/proc/<pid>/maps` MAP_SHARED bit; only verified-shared addresses batched, rest per-pid | `test_sampler` COW-child test (misattribution empirically reproduced against old code) |
| **SMP-3** 🟡 missed ticks deflate sample weight | ticks weighted by measured inter-tick elapsed (clamped [nominal,60s]) carried in the existing per-block `sample_period_ns` — format unchanged; `sampler_ticks_missed_total` | `test_sampler` effective-period test |
| **SMP-4** 🟡 one map-lookup syscall per backend per tick | one `BPF_MAP_LOOKUP_BATCH` dump + sorted join index per tick, per-pid fallback; dead iovec fields removed | `test_sampler` qid-index test |

## Control-socket additions (mirrored in `tests/mock_server.py`)

- `metrics`: `state_map_full_total`, `seen_query_ids_full_total`, `invalid_wait_reads_total`, `sampler_ticks_missed_total`, `sampler_healthy`
- `status`: `sampler_healthy`, `sampler_unhealthy_reason`

Asserted daemon-side in `test_control.sh` and `test_state_map_loud.py`.

## Testing

- Unit: `test_sampler` 64 checks, `test_pg13_resolve` 25, `test_discovery_{pie,nopie}` 15 each — all green locally.
- SMP-2 verified fail-before/pass-after: the old batched read empirically returns the parent's value for the child's target.
- Live: CI capture-smoke (all 4 PG cells) now also runs the fork-after-attach phase and the CAP-1 loud-path test.

## Scope notes

- `--max-backends` as a user flag was NOT added: the backend registry is a compile-time array (MAX_BACKENDS), so a runtime flag would be cosmetic; the map is sized to the registry and the `PGWT_STATE_MAP_ENTRIES` env hook provides the load-time resizing machinery for tests.
- AAS semantics untouched (T2): the sampler still records only non-CPU waits; T4 changed only how robustly/loudly it records them.
