### PR TITLE
T1: Fidelity merge & summary honesty (FID-1..7)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,8 @@ tests/gen_test_traces
 tests/gen_bench_traces
 tests/cross_validate
 tests/test_concurrent_rw
+tests/test_replay_fidelity
+tests/map_reader_core.o
 tests/__pycache__/
 
 # Visual-snapshot diff/actual artifacts (transient — only baselines are tracked)

--- a/src/compute.c
+++ b/src/compute.c
@@ -147,6 +147,16 @@ int pgwt_wait_class_index(uint32_t event_id)
 int pgwt_filter_matches(const struct pgwt_filter *f,
                         const struct pgwt_trace_event *ev)
 {
+    /* Markers (exec/plan/escalation) are structural records, never wait
+     * data: duration 0, sentinel event ids, and — for escalation markers —
+     * a PGWT_ESC_PACK payload in query_id. Excluding them here is the
+     * single chokepoint for every raw compute path (FID-4): top_events,
+     * top_queries, heatmap, sessions, AAS, time model, timeline,
+     * fingerprints, concurrency, lock chains, interference. Consumers that
+     * legitimately READ markers (variants, the exec/plan lifecycle stats)
+     * handle them before calling the filter. */
+    if (PGWT_IS_MARKER(ev->old_event))
+        return 0;
     if (f->class_name[0] != '\0') {
         const char *cls = pgwt_class_name(ev->old_event);
         if (strcasecmp(cls, f->class_name) != 0)
@@ -523,6 +533,10 @@ struct top_event_accum {
     uint32_t event_id;
     uint64_t count;
     uint64_t total_ns;
+    /* Exact-only accumulation for the latency columns (FID-3): samples do
+     * not carry real durations and must not feed avg/max/percentiles. */
+    uint64_t exact_count;
+    uint64_t exact_total_ns;
     uint64_t max_ns;
     uint64_t hist[HISTOGRAM_BUCKETS];
 };
@@ -590,9 +604,14 @@ void pgwt_compute_top_events(const struct pgwt_trace_event *events, int count,
         }
         ht[h].count++;
         ht[h].total_ns += ev->duration_ns;
-        if (ev->duration_ns > ht[h].max_ns)
-            ht[h].max_ns = ev->duration_ns;
-        ht[h].hist[compute_duration_to_bucket(ev->duration_ns)]++;
+        /* Latency stats from exact records only (FID-3). */
+        if (!(ev->flags & PGWT_EVENT_FLAG_SAMPLE)) {
+            ht[h].exact_count++;
+            ht[h].exact_total_ns += ev->duration_ns;
+            if (ev->duration_ns > ht[h].max_ns)
+                ht[h].max_ns = ev->duration_ns;
+            ht[h].hist[compute_duration_to_bucket(ev->duration_ns)]++;
+        }
     }
 
     double db_time_ms = (double)db_time_ns / 1e6;
@@ -609,13 +628,16 @@ void pgwt_compute_top_events(const struct pgwt_trace_event *events, int count,
         r->event_id = ht[i].event_id;
         r->count    = ht[i].count;
         r->total_ms = (double)ht[i].total_ns / 1e6;
-        r->avg_us   = ht[i].count > 0
-                     ? (double)ht[i].total_ns / (double)ht[i].count / 1000.0
+        /* Latency columns from exact data only; exact_count == 0 flags
+         * them as unavailable (sampled-only row). */
+        r->exact_count = ht[i].exact_count;
+        r->avg_us   = ht[i].exact_count > 0
+                     ? (double)ht[i].exact_total_ns / (double)ht[i].exact_count / 1000.0
                      : 0;
         r->max_us   = (double)ht[i].max_ns / 1000.0;
-        r->p50_us   = hist_percentile(ht[i].hist, ht[i].count, 0.50);
-        r->p95_us   = hist_percentile(ht[i].hist, ht[i].count, 0.95);
-        r->p99_us   = hist_percentile(ht[i].hist, ht[i].count, 0.99);
+        r->p50_us   = hist_percentile(ht[i].hist, ht[i].exact_count, 0.50);
+        r->p95_us   = hist_percentile(ht[i].hist, ht[i].exact_count, 0.95);
+        r->p99_us   = hist_percentile(ht[i].hist, ht[i].exact_count, 0.99);
         /* Idle-but-visible events have time but no meaningful share of DB
          * Time; flag their %DB with a sentinel so it renders as "—". */
         if (pgwt_is_idle_event(ht[i].event_id))
@@ -928,6 +950,10 @@ void pgwt_compute_heatmap(const struct pgwt_trace_event *events, int count,
         /* Visibility filter: keep Client:ClientRead in the latency heatmap. */
         if (!pgwt_filter_matches(f, ev) || pgwt_is_hidden_event(ev->old_event))
             continue;
+        /* Samples carry no real durations — a latency distribution built
+         * from normalized sample periods is fabricated (FID-3). */
+        if (ev->flags & PGWT_EVENT_FLAG_SAMPLE)
+            continue;
 
         uint64_t ev_ts = ev->timestamp_ns;
         if (ev_ts < from_ns || ev_ts >= to_ns)
@@ -963,10 +989,14 @@ void pgwt_compute_heatmap(const struct pgwt_trace_event *events, int count,
  * Each pgwt_summary_accum record represents 1 second of pre-aggregated data.
  * ══════════════════════════════════════════════════════════════ */
 
-/* Helper: check if a summary event matches a filter */
+/* Helper: check if a summary event matches a filter.
+ * Marker event ids are rejected outright: summaries written before the
+ * FID-4 write-side fix may still contain accumulated marker rows. */
 static int summary_event_matches_filter(const struct pgwt_filter *f,
                                          uint32_t event_id)
 {
+    if (PGWT_IS_MARKER(event_id))
+        return 0;
     if (f->class_name[0] != '\0') {
         const char *cls = pgwt_class_name(event_id);
         if (strcasecmp(cls, f->class_name) != 0)
@@ -1371,6 +1401,9 @@ static int te_summary_visitor(const struct pgwt_summary_accum *rec, void *arg)
                 }
                 ctx->ht[h].count += sq->top_events[j].count;
                 ctx->ht[h].total_ns += sq->top_events[j].total_ns;
+                /* Summaries are built from exact records only. */
+                ctx->ht[h].exact_count += sq->top_events[j].count;
+                ctx->ht[h].exact_total_ns += sq->top_events[j].total_ns;
             }
             break;
         }
@@ -1397,6 +1430,9 @@ static int te_summary_visitor(const struct pgwt_summary_accum *rec, void *arg)
         }
         ctx->ht[h].count += se->count;
         ctx->ht[h].total_ns += se->total_ns;
+        /* Summaries are built from exact records only. */
+        ctx->ht[h].exact_count += se->count;
+        ctx->ht[h].exact_total_ns += se->total_ns;
         if (se->max_ns > ctx->ht[h].max_ns)
             ctx->ht[h].max_ns = se->max_ns;
         for (int b = 0; b < HISTOGRAM_BUCKETS; b++)
@@ -1434,12 +1470,13 @@ void pgwt_compute_top_events_from_summaries(
         row->event_id = ctx.ht[i].event_id;
         row->count    = ctx.ht[i].count;
         row->total_ms = (double)ctx.ht[i].total_ns / 1e6;
-        row->avg_us   = ctx.ht[i].count > 0
-                       ? (double)ctx.ht[i].total_ns / (double)ctx.ht[i].count / 1000.0 : 0;
+        row->exact_count = ctx.ht[i].exact_count;
+        row->avg_us   = ctx.ht[i].exact_count > 0
+                       ? (double)ctx.ht[i].exact_total_ns / (double)ctx.ht[i].exact_count / 1000.0 : 0;
         row->max_us   = (double)ctx.ht[i].max_ns / 1000.0;
-        row->p50_us   = hist_percentile(ctx.ht[i].hist, ctx.ht[i].count, 0.50);
-        row->p95_us   = hist_percentile(ctx.ht[i].hist, ctx.ht[i].count, 0.95);
-        row->p99_us   = hist_percentile(ctx.ht[i].hist, ctx.ht[i].count, 0.99);
+        row->p50_us   = hist_percentile(ctx.ht[i].hist, ctx.ht[i].exact_count, 0.50);
+        row->p95_us   = hist_percentile(ctx.ht[i].hist, ctx.ht[i].exact_count, 0.95);
+        row->p99_us   = hist_percentile(ctx.ht[i].hist, ctx.ht[i].exact_count, 0.99);
         /* Idle-but-visible events have time but no meaningful share of DB
          * Time; flag their %DB with a sentinel so it renders as "—". */
         if (pgwt_is_idle_event(ctx.ht[i].event_id))

--- a/src/compute.h
+++ b/src/compute.h
@@ -186,6 +186,13 @@ struct pgwt_event_row {
     char     name[64];
     uint64_t count;
     double   total_ms;
+    /* Latency statistics (avg/max/percentiles) are computed from EXACT
+     * (transition) records only — samples carry no real durations, so
+     * feeding their normalized sample_period_ns durations into these
+     * columns fabricates percentiles (FID-3). exact_count == 0 means the
+     * row is sampled-only and the latency columns must be gated (rendered
+     * as null / "—"); count and total_ms stay valid via ASH math. */
+    uint64_t exact_count;
     double   avg_us;
     double   max_us;
     double   p50_us;

--- a/src/event_reader.c
+++ b/src/event_reader.c
@@ -483,13 +483,21 @@ done_relative:
     return -1;
 }
 
-/* ── Replay accumulation ───────────────────────────────── */
+/* ── Replay accumulation (fidelity-aware — T1/FID-5) ────── */
 
 #ifndef PGWT_SERVER
 void pgwt_replay_events(struct pgwt_accumulator *acc,
                          const struct pgwt_trace_event *events, int count,
-                         uint64_t from_mono_ns, uint64_t to_mono_ns)
+                         uint64_t from_mono_ns, uint64_t to_mono_ns,
+                         const struct pgwt_block_info *bi,
+                         struct pgwt_replay_stats *st)
 {
+    int is_samples = bi && bi->block_type == PGWT_BLOCK_SAMPLES;
+    uint64_t period = is_samples ? bi->sample_period_ns : 0;
+
+    if (st && is_samples && period)
+        st->sample_period_ns = period;
+
     for (int i = 0; i < count; i++) {
         const struct pgwt_trace_event *evt = &events[i];
 
@@ -498,8 +506,34 @@ void pgwt_replay_events(struct pgwt_accumulator *acc,
         if (to_mono_ns > 0 && evt->timestamp_ns > to_mono_ns)
             break;  /* events are sorted by timestamp */
 
-        uint32_t we = evt->old_event;
-        uint64_t dur = evt->duration_ns;
+        uint32_t we;
+        uint64_t dur;
+        int exact;
+
+        if (is_samples || (evt->flags & PGWT_EVENT_FLAG_SAMPLE)) {
+            /* A sample is a point observation of the CURRENT wait
+             * (new_event); it is worth one sample period of estimated
+             * time, and carries no real duration. */
+            we = evt->new_event;
+            dur = period;
+            exact = 0;
+        } else {
+            we = evt->old_event;
+            dur = evt->duration_ns;
+            exact = 1;
+
+            /* Markers (exec/plan/escalation) are structural records —
+             * never wait data (FID-4/5). */
+            if (PGWT_IS_MARKER(we)) {
+                if (st) st->markers_skipped++;
+                continue;
+            }
+        }
+
+        if (st) {
+            if (exact) st->transitions++;
+            else       st->samples++;
+        }
 
         /* Per-PID accumulation */
         struct pgwt_pid_accum *pa = pgwt_get_or_create_pid(acc, evt->pid);
@@ -508,11 +542,13 @@ void pgwt_replay_events(struct pgwt_accumulator *acc,
             if (es) {
                 es->count++;
                 es->total_ns += dur;
-                if (dur < es->min_ns) es->min_ns = dur;
-                if (dur > es->max_ns) es->max_ns = dur;
-                uint32_t bucket = pgwt_duration_to_bucket(dur);
-                if (bucket < HISTOGRAM_BUCKETS)
-                    es->histogram[bucket]++;
+                if (exact) {
+                    if (dur < es->min_ns) es->min_ns = dur;
+                    if (dur > es->max_ns) es->max_ns = dur;
+                    uint32_t bucket = pgwt_duration_to_bucket(dur);
+                    if (bucket < HISTOGRAM_BUCKETS)
+                        es->histogram[bucket]++;
+                }
             }
             if (we == 0)
                 pa->cpu_time_ns += dur;
@@ -527,11 +563,13 @@ void pgwt_replay_events(struct pgwt_accumulator *acc,
         if (se) {
             se->count++;
             se->total_ns += dur;
-            if (dur < se->min_ns) se->min_ns = dur;
-            if (dur > se->max_ns) se->max_ns = dur;
-            uint32_t bucket = pgwt_duration_to_bucket(dur);
-            if (bucket < HISTOGRAM_BUCKETS)
-                se->histogram[bucket]++;
+            if (exact) {
+                if (dur < se->min_ns) se->min_ns = dur;
+                if (dur > se->max_ns) se->max_ns = dur;
+                uint32_t bucket = pgwt_duration_to_bucket(dur);
+                if (bucket < HISTOGRAM_BUCKETS)
+                    se->histogram[bucket]++;
+            }
         }
 
         /* Time model */
@@ -544,8 +582,10 @@ void pgwt_replay_events(struct pgwt_accumulator *acc,
             if (qe) {
                 qe->count++;
                 qe->total_ns += dur;
-                if (dur < qe->min_ns) qe->min_ns = dur;
-                if (dur > qe->max_ns) qe->max_ns = dur;
+                if (exact) {
+                    if (dur < qe->min_ns) qe->min_ns = dur;
+                    if (dur > qe->max_ns) qe->max_ns = dur;
+                }
             }
         }
     }

--- a/src/event_reader.h
+++ b/src/event_reader.h
@@ -94,13 +94,32 @@ int pgwt_scan_trace_files(const char *trace_dir,
  * Supports: ISO 8601 ("2025-02-25T14:30:00"), relative ("1h", "30m"), "now". */
 int pgwt_parse_time(const char *str, uint64_t *wall_ns);
 
-/* ── Replay accumulation ───────────────────────────────── */
+/* ── Replay accumulation (fidelity-aware — T1/FID-5) ────── */
 
 struct pgwt_accumulator;
 
-/* Replay decoded events into an accumulator, filtering by time range. */
+/* Counters replay maintains so the caller can report honestly what the
+ * accumulated numbers are made of. */
+struct pgwt_replay_stats {
+    uint64_t transitions;       /* exact records accumulated */
+    uint64_t samples;           /* sampled records accumulated (ASH math) */
+    uint64_t markers_skipped;   /* structural markers skipped */
+    uint64_t sample_period_ns;  /* sample period seen (0 if none) */
+};
+
+/* Replay one decoded block into an accumulator, filtering by time range.
+ * `bi` is the block's header info (required):
+ *   - TRANSITIONS records accumulate exactly (durations, histograms);
+ *     markers (exec/plan/escalation) are structural and skipped.
+ *   - SAMPLES records are point observations: each is worth one
+ *     sample_period_ns of time (ASH estimate) for counts/time-model/query
+ *     totals, but contributes NOTHING to min/max/histograms — those are
+ *     real-latency-only and would be fabricated from samples.
+ * `st` (optional) is updated with what was accumulated. */
 void pgwt_replay_events(struct pgwt_accumulator *acc,
                          const struct pgwt_trace_event *events, int count,
-                         uint64_t from_mono_ns, uint64_t to_mono_ns);
+                         uint64_t from_mono_ns, uint64_t to_mono_ns,
+                         const struct pgwt_block_info *bi,
+                         struct pgwt_replay_stats *st);
 
 #endif /* PGWT_EVENT_READER_H */

--- a/src/event_stream.c
+++ b/src/event_stream.c
@@ -30,7 +30,10 @@ int pgwt_handle_trace_event(void *ctx, void *data, size_t data_sz)
     if (d->event_writer)
         pgwt_writer_push_event(d->event_writer, evt);
 
-    /* Write to summary file if recording is enabled */
+    /* Write to summary file if recording is enabled. Markers pass through
+     * here too, but the summary writer's accum_event filters them (FID-4):
+     * they must land in the trace (variants / lifecycle / escalation
+     * coverage need them) while never entering wait accounting. */
     if (d->summary_writer)
         pgwt_summary_push_event(d->summary_writer, evt);
 

--- a/src/map_reader.c
+++ b/src/map_reader.c
@@ -1,12 +1,20 @@
-/* map_reader.c — Read BPF state_map for open intervals, accumulator helpers */
+/* map_reader.c — Read BPF state_map for open intervals, accumulator helpers
+ *
+ * The accumulator core (get-or-create helpers, time model, histogram
+ * bucketing) is pure and BPF-free; the map-reading functions need libbpf
+ * and the skeleton. Guarded by !PGWT_SERVER — same pattern as sampler.c /
+ * anomaly.c — so unit tests (e.g. test_replay_fidelity) can link the pure
+ * core on a box without bpftool. */
 #include "map_reader.h"
-#include "daemon.h"
 #include "wait_event.h"
 
 #include <string.h>
 #include <stdio.h>
 #include <stdbool.h>
 #include <time.h>
+
+#ifndef PGWT_SERVER
+#include "daemon.h"
 #include <bpf/libbpf.h>
 #include <bpf/bpf.h>
 #include "pg_wait_tracer.skel.h"
@@ -18,6 +26,7 @@ static uint64_t now_ns(void)
     clock_gettime(CLOCK_MONOTONIC, &ts);
     return (uint64_t)ts.tv_sec * 1000000000ULL + ts.tv_nsec;
 }
+#endif /* !PGWT_SERVER */
 
 void pgwt_accum_init(struct pgwt_accumulator *acc)
 {
@@ -151,6 +160,7 @@ uint32_t pgwt_duration_to_bucket(uint64_t ns)
     return 15;
 }
 
+#ifndef PGWT_SERVER
 void pgwt_read_state_map(struct pgwt_daemon *d)
 {
     int state_fd = bpf_map__fd(d->skel->maps.state_map);
@@ -299,3 +309,4 @@ uint64_t pgwt_read_bpf_fail_counter(struct pgwt_daemon *d, uint32_t slot)
         total += per_cpu[i];
     return total;
 }
+#endif /* !PGWT_SERVER */

--- a/src/replay.c
+++ b/src/replay.c
@@ -72,6 +72,7 @@ int pgwt_run_replay(struct pgwt_daemon *d, const char *from_str,
     uint64_t total_events = 0;
     int files_read = 0;
     bool pg_version_set = false;
+    struct pgwt_replay_stats rstats = {0};
 
     for (int fi = 0; fi < nfiles; fi++) {
         /* Quick filter: skip files that end before our --from time */
@@ -116,12 +117,15 @@ int pgwt_run_replay(struct pgwt_daemon *d, const char *from_str,
                 reader.block_index[bi].timestamp_ns > to_mono)
                 break;
 
-            int count = pgwt_reader_decode_block(&reader, bi, events,
-                                                  PGWT_BLOCK_EVENTS);
+            struct pgwt_block_info binfo;
+            int count = pgwt_reader_decode_block_info(&reader, bi, events,
+                                                      PGWT_BLOCK_EVENTS,
+                                                      &binfo);
             if (count <= 0)
                 continue;
 
-            pgwt_replay_events(&d->accum, events, count, from_mono, to_mono);
+            pgwt_replay_events(&d->accum, events, count, from_mono, to_mono,
+                               &binfo, &rstats);
             total_events += count;
         }
 
@@ -146,11 +150,34 @@ int pgwt_run_replay(struct pgwt_daemon *d, const char *from_str,
         fprintf(stderr, "INFO: replayed %lu events from %d file(s)\n",
                 (unsigned long)total_events, files_read);
 
+    /* Fidelity notice (FID-5): a tiered trace is mostly SAMPLES records.
+     * Their time contributions are ASH estimates (count × sample period),
+     * and they carry no real latencies — say so loudly instead of quietly
+     * rendering near-zero activity or fabricated histograms. */
+    if (rstats.samples > 0) {
+        printf("NOTE: this trace contains sampled data "
+               "(%llu samples at %.1f ms period, %llu exact transitions).\n"
+               "      Sampled wait durations are ASH estimates "
+               "(sample count x period);\n"
+               "      histograms/min/max reflect exact data only. "
+               "For merged analysis use pgwt-server (--view).\n\n",
+               (unsigned long long)rstats.samples,
+               rstats.sample_period_ns / 1e6,
+               (unsigned long long)rstats.transitions);
+    }
+
     /* Display results using existing output functions */
     d->tick = 1;  /* pretend we have one interval for display */
     d->interval = 0;  /* suppress "interval" display */
 
     pgwt_print_header(d);
+    if (d->view == PGWT_VIEW_HISTOGRAM &&
+        rstats.samples > 0 && rstats.transitions == 0) {
+        printf("Latency histogram unavailable: this window contains only "
+               "sampled data,\nwhich carries no real durations. "
+               "Escalate to full fidelity to capture latencies.\n");
+        return 0;
+    }
     switch (d->view) {
     case PGWT_VIEW_TIME_MODEL:   pgwt_print_time_model(d);   break;
     case PGWT_VIEW_SYSTEM_EVENT: pgwt_print_system_event(d);  break;

--- a/src/server.c
+++ b/src/server.c
@@ -102,33 +102,96 @@ struct bm_entry {
 
 /* ── Server state ─────────────────────────────────────────── */
 
-/* A time range [start, end] in wall ns covered by a TRANSITIONS block.
- * Used for the exact-wins merge (D3): samples inside a transition-covered
- * range are dropped at read time so a sampler running through a
- * full-fidelity window does not double-count. */
-struct trans_range {
-    uint64_t start_wall_ns;
-    uint64_t end_wall_ns;
+/* ═══ Exact-coverage & clock domains (T1: FID-1/2/6/7) ═══════
+ *
+ * The exact-wins merge needs to know WHERE full-fidelity (transition) data
+ * is authoritative, so overlapping samples can be dropped without double
+ * counting. Coverage is derived per file:
+ *
+ *   1. Escalation-marker windows are the authority (FID-1). The daemon
+ *      writes PGWT_MARKER_ESCALATE_START/END into the trace; a window
+ *      covers [START_ts, END_ts]. Transition timestamps are wait-END
+ *      times, so per-block ranges have a hole exactly over a long wait —
+ *      markers do not.
+ *   2. START with no matching END (daemon crash, or the window is still
+ *      open in current.trace): the window is clamped to the LAST
+ *      TRANSITIONS-block timestamp committed in its clock generation —
+ *      exact coverage never extends past the last exact evidence, so
+ *      samples beyond it (e.g. of a still-running wait whose transition
+ *      has not landed yet) survive and remain visible.
+ *   3. END with no earlier START (window opened before this file; older
+ *      file rotated away/deleted): the window starts at that file's first
+ *      block timestamp.
+ *   4. A file with transitions and NO SAMPLES blocks (--mode full) is
+ *      covered whole-file: [first_block_ts, last_block_ts].
+ *   5. Legacy fallback: a file with samples + transitions but no
+ *      escalation markers anywhere keeps the old per-TRANSITIONS-block
+ *      coverage.
+ *
+ * Boundary rule (FID-6): a sample represents the interval
+ * (ts − period, ts]. It is dropped iff its MIDPOINT (ts − period/2) falls
+ * inside a covered span (inclusive); worst-case error per window edge is
+ * period/2, zero-mean.
+ *
+ * Clock domain (FID-7): all coverage comparison happens in the MONOTONIC
+ * domain. Files written by one daemon run share the monotonic clock; their
+ * per-file mono→wall offsets differ whenever NTP steps the wall clock
+ * between file opens, so comparing wall times derived from different
+ * files' offsets can misplace coverage by the step size. Files are grouped
+ * into clock "generations" (monotonic strictly increases across a run;
+ * a backwards jump or a large offset change means reboot/restart), the
+ * merge runs in mono within each generation, and event timestamps are
+ * re-anchored to wall using ONE canonical offset per generation — the
+ * newest file's, so "last 15 minutes from now" lines up with the data that
+ * is actually newest. */
+
+struct pgwt_span { uint64_t start_ns, end_ns; };    /* mono ns */
+
+struct pgwt_cov_mark {
+    uint64_t ts;        /* mono */
+    int      is_start;  /* 1 = ESCALATE_START, 0 = ESCALATE_END */
 };
 
-/* Per-file event cache — for immutable .trace.lz4 files only */
+struct pgwt_file_cov {
+    char     path[512];
+    int      present;              /* seen in the latest directory scan */
+    int      valid;                /* readable, has at least one block */
+    int      is_current;
+    uint64_t hdr_start_wall_ns;    /* identity: header fields change when */
+    uint64_t hdr_mono_ns;          /* the daemon restarts + truncates */
+    int64_t  own_offset;           /* this file's mono→wall offset */
+    uint64_t mono_first, mono_last;
+    int      has_samples, has_transitions;
+    uint64_t sample_period_ns;
+    int      blocks_scanned;       /* header-scan watermark (incremental) */
+    struct pgwt_span *s_spans; int n_s, cap_s;   /* SAMPLES block spans */
+    struct pgwt_span *t_spans; int n_t, cap_t;   /* TRANSITIONS block spans */
+    struct pgwt_cov_mark *marks; int n_marks, cap_marks;
+    int     *pending_tb; int n_pending, cap_pending;  /* blocks awaiting
+                                                         marker decode */
+    int      gen;                  /* clock-domain generation */
+    int64_t  canon_offset;         /* generation-canonical mono→wall */
+};
+
+/* Assembled per-generation coverage, rebuilt on every refresh. */
+struct pgwt_gen_cov {
+    int      gen;
+    int64_t  canon_offset;
+    struct pgwt_span *exact;   int n_exact;    /* sorted, merged */
+    struct pgwt_span *sampled; int n_sampled;  /* sorted, merged */
+    uint64_t sample_period_ns;
+};
+
+/* Per-file event cache — for immutable .trace.lz4 files only.
+ * Timestamps are kept MONOTONIC; the wall conversion happens at query time
+ * with the generation-canonical offset (FID-7). */
 struct file_cache_entry {
     char     path[512];
     struct pgwt_trace_event *events;
     int      count;
     int      immutable;
-    uint64_t first_wall_ns;  /* earliest event timestamp (for range skip) */
-    uint64_t last_wall_ns;   /* latest event timestamp */
-
-    /* Fidelity (trace format v2). Samples are stored already normalized:
-     * old_event = sampled event, duration_ns = sample_period_ns, with the
-     * PGWT_EVENT_FLAG_SAMPLE bit set so estimators apply ASH math and the
-     * exact-wins merge can identify them. */
-    int       has_transitions;
-    int       has_samples;
-    uint64_t  sample_period_ns;
-    struct trans_range *trans_ranges;  /* malloc'd; TRANSITIONS block ranges */
-    int       num_trans_ranges;
+    uint64_t first_mono_ns;  /* earliest event timestamp (for range skip) */
+    uint64_t last_mono_ns;   /* latest event timestamp */
 };
 
 /* Fidelity summary of a loaded window, returned alongside the event array
@@ -151,6 +214,13 @@ struct pgwt_server {
     /* Per-file event cache */
     struct file_cache_entry cache[256];
     int  cache_count;
+
+    /* Coverage / clock-domain state (refreshed per request) */
+    struct pgwt_file_cov cov[256];
+    int  cov_count;
+    int  any_samples;              /* any file has SAMPLES blocks */
+    struct pgwt_gen_cov *gens;
+    int  num_gens;
 
     /* Query text map: query_id → SQL text (dynamic, power-of-2 sized) */
     struct qt_entry *qt_map;
@@ -473,8 +543,6 @@ static void cache_evict_oldest(struct pgwt_server *srv)
     /* Evict the first (oldest) cached entry */
     free(srv->cache[0].events);
     srv->cache[0].events = NULL;
-    free(srv->cache[0].trans_ranges);
-    srv->cache[0].trans_ranges = NULL;
     memmove(&srv->cache[0], &srv->cache[1],
             (srv->cache_count - 1) * sizeof(srv->cache[0]));
     srv->cache_count--;
@@ -530,42 +598,17 @@ get_cached_immutable(struct pgwt_server *srv, const char *path)
     ce->events = malloc(cap * sizeof(*ce->events));
     struct pgwt_trace_event block_buf[PGWT_BLOCK_EVENTS];
 
-    /* Store time range for this file */
+    /* Store time range for this file (monotonic) */
     if (reader.num_blocks > 0) {
-        ce->first_wall_ns = pgwt_reader_mono_to_wall(&reader,
-            reader.block_index[0].timestamp_ns);
-        ce->last_wall_ns = pgwt_reader_mono_to_wall(&reader,
-            reader.block_index[reader.num_blocks - 1].timestamp_ns);
+        ce->first_mono_ns = reader.block_index[0].timestamp_ns;
+        ce->last_mono_ns = reader.block_index[reader.num_blocks - 1].timestamp_ns;
     }
 
-    int tr_cap = 0;
     for (int b = 0; b < reader.num_blocks; b++) {
         struct pgwt_block_info bi;
         int n = pgwt_reader_decode_block_info(&reader, b, block_buf,
                                               PGWT_BLOCK_EVENTS, &bi);
         if (n < 0) continue;
-
-        if (bi.block_type == PGWT_BLOCK_SAMPLES) {
-            ce->has_samples = 1;
-            if (bi.sample_period_ns)
-                ce->sample_period_ns = bi.sample_period_ns;
-        } else {
-            ce->has_transitions = 1;
-            /* Record this transition block's wall range for the merge. */
-            if (ce->num_trans_ranges >= tr_cap) {
-                tr_cap = tr_cap ? tr_cap * 2 : 16;
-                struct trans_range *tmp = realloc(ce->trans_ranges,
-                                                  tr_cap * sizeof(*tmp));
-                if (tmp) ce->trans_ranges = tmp;
-            }
-            if (ce->trans_ranges && ce->num_trans_ranges < tr_cap) {
-                ce->trans_ranges[ce->num_trans_ranges].start_wall_ns =
-                    pgwt_reader_mono_to_wall(&reader, bi.first_timestamp_ns);
-                ce->trans_ranges[ce->num_trans_ranges].end_wall_ns =
-                    pgwt_reader_mono_to_wall(&reader, bi.last_timestamp_ns);
-                ce->num_trans_ranges++;
-            }
-        }
 
         for (int i = 0; i < n; i++) {
             if (ce->count >= cap) {
@@ -577,13 +620,13 @@ get_cached_immutable(struct pgwt_server *srv, const char *path)
             ce->events[ce->count] = block_buf[i];
             /* Normalize samples into interval shape so the duration-based
              * estimators apply ASH math (each sample worth sample_period_ns).
-             * Keep the SAMPLE flag for the exact-wins merge and fidelity. */
+             * Keep the SAMPLE flag for the exact-wins merge and fidelity.
+             * Timestamps stay MONOTONIC in the cache; the wall conversion
+             * happens per query with the generation-canonical offset. */
             if (block_buf[i].flags & PGWT_EVENT_FLAG_SAMPLE) {
                 ce->events[ce->count].old_event = block_buf[i].new_event;
                 ce->events[ce->count].duration_ns = bi.sample_period_ns;
             }
-            ce->events[ce->count].timestamp_ns =
-                pgwt_reader_mono_to_wall(&reader, block_buf[i].timestamp_ns);
             ce->count++;
         }
     }
@@ -606,44 +649,21 @@ get_cached_immutable(struct pgwt_server *srv, const char *path)
     return ce;
 }
 
-/* Append one transition range to a growable collector. */
-static void trans_ranges_add(struct trans_range **ranges, int *count, int *cap,
-                             uint64_t start_wall_ns, uint64_t end_wall_ns)
-{
-    if (*count >= *cap) {
-        int newcap = *cap ? *cap * 2 : 16;
-        struct trans_range *tmp = realloc(*ranges, newcap * sizeof(**ranges));
-        if (!tmp) return;
-        *ranges = tmp;
-        *cap = newcap;
-    }
-    (*ranges)[*count].start_wall_ns = start_wall_ns;
-    (*ranges)[*count].end_wall_ns   = end_wall_ns;
-    (*count)++;
-}
-
-/* Read events from a trace file for a time range — on demand, no caching.
- * Opens file, seeks to the right blocks via block index, decodes only
- * the blocks that overlap [from_wall_ns, to_wall_ns].
- * Appends events at *total (growing as needed) and, for the exact-wins
- * merge, appends each TRANSITIONS block's wall range to *ranges. Sets
- * fidelity flags / sample period in *info. SAMPLES records are normalized
- * to interval shape (old_event = sampled event, duration_ns =
- * sample_period_ns) so the duration-based estimators apply ASH math. */
-static void load_current_trace_range(const char *path,
-                                      uint64_t from_wall_ns, uint64_t to_wall_ns,
-                                      struct pgwt_trace_event **events,
-                                      int *total, int *cap,
-                                      struct trans_range **ranges,
-                                      int *nranges, int *ranges_cap,
-                                      struct pgwt_load_info *info)
+/* Read events from a trace file for a MONO time range — on demand, no
+ * caching. Opens file, seeks to the right blocks via block index, decodes
+ * only the blocks that overlap [from_mono, to_mono]. Appends events at
+ * *total (growing as needed) with timestamps left MONOTONIC. SAMPLES
+ * records are normalized to interval shape (old_event = sampled event,
+ * duration_ns = sample_period_ns) so the duration-based estimators apply
+ * ASH math. */
+static void load_file_range_mono(const char *path,
+                                 uint64_t from_mono, uint64_t to_mono,
+                                 struct pgwt_trace_event **events,
+                                 int *total, int *cap)
 {
     struct pgwt_event_reader reader;
     if (pgwt_reader_open(&reader, path) != 0)
         return;
-
-    uint64_t from_mono = pgwt_reader_wall_to_mono(&reader, from_wall_ns);
-    uint64_t to_mono   = pgwt_reader_wall_to_mono(&reader, to_wall_ns);
 
     int first_block = pgwt_reader_find_block(&reader, from_mono);
     struct pgwt_trace_event block_buf[PGWT_BLOCK_EVENTS];
@@ -656,15 +676,6 @@ static void load_current_trace_range(const char *path,
         int n = pgwt_reader_decode_block_info(&reader, b, block_buf,
                                               PGWT_BLOCK_EVENTS, &bi);
         if (n < 0) continue;
-
-        if (bi.block_type == PGWT_BLOCK_SAMPLES) {
-            if (info && bi.sample_period_ns)
-                info->sample_period_ns = bi.sample_period_ns;
-        } else if (ranges) {
-            trans_ranges_add(ranges, nranges, ranges_cap,
-                pgwt_reader_mono_to_wall(&reader, bi.first_timestamp_ns),
-                pgwt_reader_mono_to_wall(&reader, bi.last_timestamp_ns));
-        }
 
         for (int i = 0; i < n; i++) {
             uint64_t ts_mono = block_buf[i].timestamp_ns;
@@ -683,43 +694,543 @@ static void load_current_trace_range(const char *path,
                 (*events)[*total].old_event = block_buf[i].new_event;
                 (*events)[*total].duration_ns = bi.sample_period_ns;
             }
-            (*events)[*total].timestamp_ns =
-                pgwt_reader_mono_to_wall(&reader, ts_mono);
             (*total)++;
         }
     }
     pgwt_reader_close(&reader);
 }
 
-/* Get latest wall-clock timestamp from current.trace — quick, O(1).
- * Opens file, reads last block header, converts, closes. */
-static uint64_t get_current_trace_latest(const char *path)
+/* ── Coverage & clock-domain refresh (T1) ─────────────────── */
+
+static void span_list_add(struct pgwt_span **spans, int *n, int *cap,
+                          uint64_t start, uint64_t end, uint64_t merge_gap)
+{
+    if (end < start) end = start;
+    /* Coalesce with the previous span (blocks arrive in file/time order) */
+    if (*n > 0 && start <= (*spans)[*n - 1].end_ns + merge_gap) {
+        if (end > (*spans)[*n - 1].end_ns)
+            (*spans)[*n - 1].end_ns = end;
+        return;
+    }
+    if (*n >= *cap) {
+        int newcap = *cap ? *cap * 2 : 16;
+        struct pgwt_span *tmp = realloc(*spans, newcap * sizeof(**spans));
+        if (!tmp) return;
+        *spans = tmp;
+        *cap = newcap;
+    }
+    (*spans)[*n].start_ns = start;
+    (*spans)[*n].end_ns = end;
+    (*n)++;
+}
+
+static void cov_reset(struct pgwt_file_cov *fc)
+{
+    free(fc->s_spans);
+    free(fc->t_spans);
+    free(fc->marks);
+    free(fc->pending_tb);
+    char path[512];
+    memcpy(path, fc->path, sizeof(path));
+    memset(fc, 0, sizeof(*fc));
+    memcpy(fc->path, path, sizeof(path));
+}
+
+static struct pgwt_file_cov *cov_find_or_add(struct pgwt_server *srv,
+                                             const char *path)
+{
+    for (int i = 0; i < srv->cov_count; i++)
+        if (strcmp(srv->cov[i].path, path) == 0)
+            return &srv->cov[i];
+    if (srv->cov_count >= 256)
+        return NULL;
+    struct pgwt_file_cov *fc = &srv->cov[srv->cov_count++];
+    memset(fc, 0, sizeof(*fc));
+    snprintf(fc->path, sizeof(fc->path), "%s", path);
+    return fc;
+}
+
+/* Decode the pending TRANSITIONS blocks of a file, collecting escalation
+ * markers. Committed blocks are immutable, so this is incremental-safe. */
+static void cov_decode_markers(struct pgwt_file_cov *fc,
+                               struct pgwt_event_reader *reader)
+{
+    struct pgwt_trace_event buf[PGWT_BLOCK_EVENTS];
+
+    for (int p = 0; p < fc->n_pending; p++) {
+        int b = fc->pending_tb[p];
+        if (b >= reader->num_blocks)
+            continue;
+        int n = pgwt_reader_decode_block(reader, b, buf, PGWT_BLOCK_EVENTS);
+        for (int i = 0; i < n; i++) {
+            uint32_t m = buf[i].old_event;
+            if (m != PGWT_MARKER_ESCALATE_START &&
+                m != PGWT_MARKER_ESCALATE_END)
+                continue;
+            if (fc->n_marks >= fc->cap_marks) {
+                int newcap = fc->cap_marks ? fc->cap_marks * 2 : 8;
+                struct pgwt_cov_mark *tmp =
+                    realloc(fc->marks, newcap * sizeof(*tmp));
+                if (!tmp) return;
+                fc->marks = tmp;
+                fc->cap_marks = newcap;
+            }
+            fc->marks[fc->n_marks].ts = buf[i].timestamp_ns;
+            fc->marks[fc->n_marks].is_start =
+                (m == PGWT_MARKER_ESCALATE_START);
+            fc->n_marks++;
+        }
+    }
+    fc->n_pending = 0;
+}
+
+/* Incrementally scan one file's block headers into its coverage entry.
+ * Marker decode is deferred (cov_decode_markers) so full-mode dirs — where
+ * no samples exist and coverage is never consulted — never pay for it. */
+static void cov_scan_file(struct pgwt_server *srv, struct pgwt_file_cov *fc)
 {
     struct pgwt_event_reader reader;
-    if (pgwt_reader_open(&reader, path) != 0)
-        return 0;
+    if (pgwt_reader_open(&reader, fc->path) != 0) {
+        fc->valid = 0;
+        return;
+    }
 
-    uint64_t latest = 0;
-    if (reader.num_blocks > 0)
-        latest = pgwt_reader_mono_to_wall(&reader,
-            reader.block_index[reader.num_blocks - 1].timestamp_ns);
+    fc->is_current = is_current_trace(fc->path);
+
+    /* Identity check: a daemon restart truncates + rewrites current.trace
+     * (new header clocks); a shrunken block count means the same. */
+    if (fc->blocks_scanned > 0 &&
+        (fc->hdr_start_wall_ns != reader.header.start_time_ns ||
+         fc->hdr_mono_ns != reader.header.clock_offset_ns ||
+         reader.num_blocks < fc->blocks_scanned)) {
+        cov_reset(fc);
+        fc->is_current = is_current_trace(fc->path);
+    }
+
+    fc->hdr_start_wall_ns = reader.header.start_time_ns;
+    fc->hdr_mono_ns = reader.header.clock_offset_ns;
+    fc->own_offset = (int64_t)reader.header.start_time_ns
+                   - (int64_t)reader.header.clock_offset_ns;
+
+    if (reader.num_blocks <= 0) {
+        fc->valid = 0;
+        pgwt_reader_close(&reader);
+        return;
+    }
+    fc->valid = 1;
+    if (fc->blocks_scanned == 0) {
+        /* block-index timestamps are block FIRST timestamps; mono_last is
+         * extended block by block below (bi.last_timestamp_ns). */
+        fc->mono_first = reader.block_index[0].timestamp_ns;
+        fc->mono_last = reader.block_index[0].timestamp_ns;
+    }
+
+    for (int b = fc->blocks_scanned; b < reader.num_blocks; b++) {
+        struct pgwt_block_info bi;
+        if (pgwt_reader_block_info(&reader, b, &bi) != 0)
+            continue;
+        if (bi.last_timestamp_ns > fc->mono_last)
+            fc->mono_last = bi.last_timestamp_ns;
+        if (bi.block_type == PGWT_BLOCK_SAMPLES) {
+            fc->has_samples = 1;
+            if (bi.sample_period_ns)
+                fc->sample_period_ns = bi.sample_period_ns;
+            /* Merge adjacent sample spans (gap up to 2 periods) */
+            span_list_add(&fc->s_spans, &fc->n_s, &fc->cap_s,
+                          bi.first_timestamp_ns, bi.last_timestamp_ns,
+                          fc->sample_period_ns * 2);
+        } else {
+            fc->has_transitions = 1;
+            span_list_add(&fc->t_spans, &fc->n_t, &fc->cap_t,
+                          bi.first_timestamp_ns, bi.last_timestamp_ns, 0);
+            if (fc->n_pending >= fc->cap_pending) {
+                int newcap = fc->cap_pending ? fc->cap_pending * 2 : 16;
+                int *tmp = realloc(fc->pending_tb, newcap * sizeof(int));
+                if (tmp) { fc->pending_tb = tmp; fc->cap_pending = newcap; }
+            }
+            if (fc->n_pending < fc->cap_pending)
+                fc->pending_tb[fc->n_pending++] = b;
+        }
+    }
+    fc->blocks_scanned = reader.num_blocks;
+
+    /* Markers matter only when the merge has samples to arbitrate. */
+    if (srv->any_samples || fc->has_samples)
+        cov_decode_markers(fc, &reader);
 
     pgwt_reader_close(&reader);
-    return latest;
+}
+
+/* Sort + merge a span list in place; returns new count. */
+static int spans_normalize(struct pgwt_span *s, int n)
+{
+    if (n <= 1) return n;
+    /* insertion sort by start (lists are small and mostly sorted) */
+    for (int i = 1; i < n; i++) {
+        struct pgwt_span tmp = s[i];
+        int j = i - 1;
+        while (j >= 0 && s[j].start_ns > tmp.start_ns) {
+            s[j + 1] = s[j];
+            j--;
+        }
+        s[j + 1] = tmp;
+    }
+    int w = 0;
+    for (int i = 1; i < n; i++) {
+        if (s[i].start_ns <= s[w].end_ns) {
+            if (s[i].end_ns > s[w].end_ns)
+                s[w].end_ns = s[i].end_ns;
+        } else {
+            s[++w] = s[i];
+        }
+    }
+    return w + 1;
+}
+
+static void gens_free(struct pgwt_server *srv)
+{
+    for (int g = 0; g < srv->num_gens; g++) {
+        free(srv->gens[g].exact);
+        free(srv->gens[g].sampled);
+    }
+    free(srv->gens);
+    srv->gens = NULL;
+    srv->num_gens = 0;
+}
+
+/* Build one generation's assembled coverage from its files' entries. */
+static void gen_cov_build(struct pgwt_server *srv, struct pgwt_gen_cov *gc)
+{
+    int ex_cap = 0, sm_cap = 0;
+    gc->exact = NULL; gc->n_exact = 0;
+    gc->sampled = NULL; gc->n_sampled = 0;
+    gc->sample_period_ns = 0;
+
+    /* Gather all escalation marks of the generation, tagged with the mono
+     * start of their file (for the END-without-START rule). */
+    struct gmark { uint64_t ts; int is_start; uint64_t file_first; };
+    struct gmark *gm = NULL;
+    int n_gm = 0, gm_cap = 0;
+    uint64_t last_trans_end = 0;   /* latest exact evidence in the gen */
+
+    for (int i = 0; i < srv->cov_count; i++) {
+        struct pgwt_file_cov *fc = &srv->cov[i];
+        if (!fc->present || !fc->valid || fc->gen != gc->gen)
+            continue;
+
+        if (fc->sample_period_ns > gc->sample_period_ns)
+            gc->sample_period_ns = fc->sample_period_ns;
+
+        for (int s = 0; s < fc->n_s; s++)
+            span_list_add(&gc->sampled, &gc->n_sampled, &sm_cap,
+                          fc->s_spans[s].start_ns, fc->s_spans[s].end_ns, 0);
+
+        if (fc->has_transitions && fc->n_t > 0 &&
+            fc->t_spans[fc->n_t - 1].end_ns > last_trans_end)
+            last_trans_end = fc->t_spans[fc->n_t - 1].end_ns;
+
+        if (!fc->has_samples && fc->has_transitions) {
+            /* Rule 4: --mode full file → whole-file exact coverage. */
+            span_list_add(&gc->exact, &gc->n_exact, &ex_cap,
+                          fc->mono_first, fc->mono_last, 0);
+            continue;
+        }
+
+        if (fc->has_samples && fc->has_transitions && fc->n_marks == 0) {
+            /* Rule 5: legacy tiered file without markers — per-block spans. */
+            for (int s = 0; s < fc->n_t; s++)
+                span_list_add(&gc->exact, &gc->n_exact, &ex_cap,
+                              fc->t_spans[s].start_ns, fc->t_spans[s].end_ns,
+                              0);
+            continue;
+        }
+
+        for (int m = 0; m < fc->n_marks; m++) {
+            if (n_gm >= gm_cap) {
+                gm_cap = gm_cap ? gm_cap * 2 : 16;
+                struct gmark *tmp = realloc(gm, gm_cap * sizeof(*tmp));
+                if (!tmp) { free(gm); return; }
+                gm = tmp;
+            }
+            gm[n_gm].ts = fc->marks[m].ts;
+            gm[n_gm].is_start = fc->marks[m].is_start;
+            gm[n_gm].file_first = fc->mono_first;
+            n_gm++;
+        }
+    }
+
+    /* Marker state machine over the generation's mark stream (Rules 1-3) */
+    if (n_gm > 0) {
+        /* sort by ts (insertion, small) */
+        for (int i = 1; i < n_gm; i++) {
+            struct gmark tmp = gm[i];
+            int j = i - 1;
+            while (j >= 0 && gm[j].ts > tmp.ts) {
+                gm[j + 1] = gm[j];
+                j--;
+            }
+            gm[j + 1] = tmp;
+        }
+        uint64_t open_start = 0;
+        int have_open = 0;
+        for (int i = 0; i < n_gm; i++) {
+            if (gm[i].is_start) {
+                if (!have_open) {
+                    open_start = gm[i].ts;
+                    have_open = 1;
+                }
+            } else {
+                uint64_t start = have_open ? open_start : gm[i].file_first;
+                span_list_add(&gc->exact, &gc->n_exact, &ex_cap,
+                              start, gm[i].ts, 0);
+                have_open = 0;
+            }
+        }
+        if (have_open) {
+            /* Rule 2: unclosed window (crash / still open) — clamp to the
+             * last committed exact evidence, never beyond. */
+            uint64_t end = last_trans_end > open_start
+                         ? last_trans_end : open_start;
+            span_list_add(&gc->exact, &gc->n_exact, &ex_cap,
+                          open_start, end, 0);
+        }
+    }
+    free(gm);
+
+    gc->n_exact = spans_normalize(gc->exact, gc->n_exact);
+    gc->n_sampled = spans_normalize(gc->sampled, gc->n_sampled);
+}
+
+/* Refresh the coverage table and clock-domain generations. Called at the
+ * start of every load / summary decision (cheap: incremental block-header
+ * scans; marker decode only for files that can affect a merge). */
+static void coverage_refresh(struct pgwt_server *srv)
+{
+    srv->num_files = pgwt_scan_trace_files(srv->trace_dir, srv->files, 256);
+
+    for (int i = 0; i < srv->cov_count; i++)
+        srv->cov[i].present = 0;
+
+    int had_samples = srv->any_samples;
+    for (int i = 0; i < srv->num_files; i++) {
+        struct pgwt_file_cov *fc = cov_find_or_add(srv, srv->files[i].path);
+        if (!fc) continue;
+        fc->present = 1;
+        cov_scan_file(srv, fc);
+        if (fc->has_samples)
+            srv->any_samples = 1;
+    }
+
+    /* If samples appeared for the first time, files scanned earlier may
+     * have skipped marker decode — finish them now. */
+    if (srv->any_samples && !had_samples) {
+        for (int i = 0; i < srv->cov_count; i++) {
+            struct pgwt_file_cov *fc = &srv->cov[i];
+            if (!fc->present || !fc->valid || fc->n_pending == 0)
+                continue;
+            struct pgwt_event_reader reader;
+            if (pgwt_reader_open(&reader, fc->path) != 0)
+                continue;
+            cov_decode_markers(fc, &reader);
+            pgwt_reader_close(&reader);
+        }
+    }
+
+    /* Drop entries for deleted files (compact the array). */
+    int w = 0;
+    for (int i = 0; i < srv->cov_count; i++) {
+        if (srv->cov[i].present) {
+            if (w != i) srv->cov[w] = srv->cov[i];
+            w++;
+        } else {
+            cov_reset(&srv->cov[i]);
+        }
+    }
+    srv->cov_count = w;
+
+    /* Sort by own wall start so generation assignment sees run order. */
+    for (int i = 1; i < srv->cov_count; i++) {
+        struct pgwt_file_cov tmp = srv->cov[i];
+        int64_t key = tmp.own_offset + (int64_t)tmp.mono_first;
+        int j = i - 1;
+        while (j >= 0 &&
+               srv->cov[j].own_offset + (int64_t)srv->cov[j].mono_first > key) {
+            srv->cov[j + 1] = srv->cov[j];
+            j--;
+        }
+        srv->cov[j + 1] = tmp;
+    }
+
+    /* Assign clock-domain generations: within one daemon run/boot the
+     * monotonic clock strictly increases across files. A backwards jump —
+     * or an offset change too large to be an NTP step — means a new
+     * domain. Canonical offset per generation = the newest file's. */
+    int gen = -1;
+    uint64_t prev_mono_last = 0;
+    int64_t prev_offset = 0;
+    for (int i = 0; i < srv->cov_count; i++) {
+        struct pgwt_file_cov *fc = &srv->cov[i];
+        if (!fc->valid) { fc->gen = gen < 0 ? 0 : gen; continue; }
+        int64_t doff = fc->own_offset - prev_offset;
+        if (gen < 0 ||
+            fc->mono_first < prev_mono_last ||
+            doff > 300LL * 1000000000LL || doff < -300LL * 1000000000LL)
+            gen++;
+        fc->gen = gen;
+        if (fc->mono_last > prev_mono_last)
+            prev_mono_last = fc->mono_last;
+        prev_offset = fc->own_offset;
+    }
+    int num_gens = gen + 1;
+    if (num_gens < 1) num_gens = srv->cov_count > 0 ? 1 : 0;
+
+    /* canonical offset: newest (max mono_last) file of each generation */
+    for (int g = 0; g < num_gens; g++) {
+        uint64_t best_last = 0;
+        int64_t canon = 0;
+        int found = 0;
+        for (int i = 0; i < srv->cov_count; i++) {
+            if (srv->cov[i].gen != g || !srv->cov[i].valid) continue;
+            if (!found || srv->cov[i].mono_last >= best_last) {
+                best_last = srv->cov[i].mono_last;
+                canon = srv->cov[i].own_offset;
+                found = 1;
+            }
+        }
+        for (int i = 0; i < srv->cov_count; i++)
+            if (srv->cov[i].gen == g)
+                srv->cov[i].canon_offset = canon;
+    }
+
+    /* Rebuild the assembled per-generation coverage. */
+    gens_free(srv);
+    if (num_gens > 0) {
+        srv->gens = calloc(num_gens, sizeof(*srv->gens));
+        if (srv->gens) {
+            srv->num_gens = num_gens;
+            for (int g = 0; g < num_gens; g++) {
+                srv->gens[g].gen = g;
+                for (int i = 0; i < srv->cov_count; i++)
+                    if (srv->cov[i].gen == g && srv->cov[i].valid)
+                        srv->gens[g].canon_offset = srv->cov[i].canon_offset;
+                gen_cov_build(srv, &srv->gens[g]);
+            }
+        }
+    }
+
+    /* Overall wall range from the canonical offsets (re-anchored) and the
+     * approximate total event count (block-count based, as before). */
+    uint64_t earliest = 0, latest = 0;
+    int64_t total = 0;
+    for (int i = 0; i < srv->cov_count; i++) {
+        struct pgwt_file_cov *fc = &srv->cov[i];
+        if (!fc->valid) continue;
+        uint64_t fw = (uint64_t)((int64_t)fc->mono_first + fc->canon_offset);
+        uint64_t lw = (uint64_t)((int64_t)fc->mono_last + fc->canon_offset);
+        if (earliest == 0 || fw < earliest) earliest = fw;
+        if (lw > latest) latest = lw;
+        total += (int64_t)fc->blocks_scanned * PGWT_BLOCK_EVENTS;
+    }
+    if (earliest) srv->earliest_wall_ns = earliest;
+    if (latest) srv->latest_wall_ns = latest;
+    srv->total_events = total;
+}
+
+/* True if mono_ns falls inside any span (spans sorted, merged). */
+static int spans_contain(const struct pgwt_span *s, int n, uint64_t mono_ns)
+{
+    int lo = 0, hi = n;
+    while (lo < hi) {
+        int mid = (lo + hi) / 2;
+        if (s[mid].end_ns < mono_ns)
+            lo = mid + 1;
+        else
+            hi = mid;
+    }
+    return lo < n && mono_ns >= s[lo].start_ns && mono_ns <= s[lo].end_ns;
+}
+
+static const struct pgwt_gen_cov *gen_cov_get(const struct pgwt_server *srv,
+                                              int gen)
+{
+    for (int g = 0; g < srv->num_gens; g++)
+        if (srv->gens[g].gen == gen)
+            return &srv->gens[g];
+    return NULL;
+}
+
+/* ── Window fidelity from coverage metadata (FID-2) ───────── */
+
+struct pgwt_wfid {
+    enum pgwt_fidelity fid;
+    uint64_t sample_period_ns;
+};
+
+/* Overlap length of [a1,a2] with [b1,b2]. */
+static uint64_t span_overlap(uint64_t a1, uint64_t a2, uint64_t b1, uint64_t b2)
+{
+    uint64_t s = a1 > b1 ? a1 : b1;
+    uint64_t e = a2 < b2 ? a2 : b2;
+    return e > s ? e - s : 0;
+}
+
+/* Classify a wall window from coverage metadata WITHOUT loading events:
+ * EXACT   — exact coverage overlaps and no sampled data lies outside it;
+ * SAMPLED — only sampled data overlaps;
+ * MIXED   — exact coverage plus sampled data outside it;
+ * NONE    — nothing overlaps.
+ * Used to gate the summary fast path: summaries are fed by exact records
+ * only, so they are valid iff the window is EXACT (or NONE — empty). */
+static struct pgwt_wfid window_fidelity(struct pgwt_server *srv,
+                                        uint64_t from_wall, uint64_t to_wall)
+{
+    struct pgwt_wfid wf = { PGWT_FIDELITY_NONE, 0 };
+    int has_exact = 0, has_uncovered_samples = 0;
+
+    for (int g = 0; g < srv->num_gens; g++) {
+        const struct pgwt_gen_cov *gc = &srv->gens[g];
+        int64_t off = gc->canon_offset;
+        if ((int64_t)to_wall - off <= 0)
+            continue;
+        uint64_t fm = ((int64_t)from_wall - off) > 0
+                    ? (uint64_t)((int64_t)from_wall - off) : 0;
+        uint64_t tm = (uint64_t)((int64_t)to_wall - off);
+
+        for (int i = 0; i < gc->n_exact; i++)
+            if (span_overlap(gc->exact[i].start_ns, gc->exact[i].end_ns,
+                             fm, tm) > 0)
+                has_exact = 1;
+
+        /* Sampled data outside exact coverage? Tolerate up to one sample
+         * period of slop at span/window edges. */
+        uint64_t slop = gc->sample_period_ns ? gc->sample_period_ns
+                                             : 1000000000ULL;
+        for (int i = 0; i < gc->n_sampled; i++) {
+            uint64_t s = gc->sampled[i].start_ns > fm
+                       ? gc->sampled[i].start_ns : fm;
+            uint64_t e = gc->sampled[i].end_ns < tm
+                       ? gc->sampled[i].end_ns : tm;
+            if (e <= s) continue;
+            wf.sample_period_ns = gc->sample_period_ns;
+            uint64_t covered = 0;
+            for (int j = 0; j < gc->n_exact; j++)
+                covered += span_overlap(gc->exact[j].start_ns,
+                                        gc->exact[j].end_ns, s, e);
+            if (e - s > covered + slop)
+                has_uncovered_samples = 1;
+        }
+    }
+
+    if (has_exact && has_uncovered_samples) wf.fid = PGWT_FIDELITY_MIXED;
+    else if (has_exact)                     wf.fid = PGWT_FIDELITY_EXACT;
+    else if (has_uncovered_samples)         wf.fid = PGWT_FIDELITY_SAMPLED;
+    else                                    wf.fid = PGWT_FIDELITY_NONE;
+    if (wf.fid == PGWT_FIDELITY_EXACT)
+        wf.sample_period_ns = 0;
+    return wf;
 }
 
 /* ── Event loading ────────────────────────────────────────── */
-
-/* True if wall_ns falls inside any collected transition range [start,end]. */
-static int ts_in_trans_range(const struct trans_range *ranges, int n,
-                             uint64_t wall_ns)
-{
-    for (int i = 0; i < n; i++)
-        if (wall_ns >= ranges[i].start_wall_ns &&
-            wall_ns <= ranges[i].end_wall_ns)
-            return 1;
-    return 0;
-}
 
 /*
  * Load events in [from_wall_ns, to_wall_ns] from trace files.
@@ -727,10 +1238,14 @@ static int ts_in_trans_range(const struct trans_range *ranges, int n,
  * current.trace: on-demand block reads (no caching, no memory growth).
  * Returns malloc'd array. Caller must free(). Sets *out_count.
  *
- * Fidelity (trace format v2, D3): SAMPLES records are normalized so the
- * duration-based estimators apply ASH math. The exact-wins merge drops any
- * sample whose timestamp falls inside a TRANSITIONS block's range, so a
- * sampler running through a full-fidelity window does not double-count.
+ * Fidelity (trace format v2, D3 + T1): SAMPLES records are normalized so
+ * the duration-based estimators apply ASH math. The exact-wins merge drops
+ * any sample whose interval midpoint falls inside the exact coverage
+ * (escalation-marker windows — see the coverage block comment above), so a
+ * sampler running through a full-fidelity window does not double-count —
+ * including across long waits whose single transition lands only at
+ * wait-end (FID-1), and across files whose wall offsets disagree (FID-7:
+ * the merge runs in the monotonic domain per clock generation).
  * When `info` is non-NULL it is filled with what actually contributed
  * (has_transitions / has_samples / sample_period_ns).
  */
@@ -742,8 +1257,8 @@ server_load_events_fi(struct pgwt_server *srv,
     *out_count = 0;
     if (info) memset(info, 0, sizeof(*info));
 
-    /* Quick rescan for new files (directory listing only, no file opens) */
-    srv->num_files = pgwt_scan_trace_files(srv->trace_dir, srv->files, 256);
+    /* Rescan directory + refresh coverage/clock-domain state. */
+    coverage_refresh(srv);
 
     if (from_wall_ns == 0)
         from_wall_ns = srv->earliest_wall_ns;
@@ -755,88 +1270,97 @@ server_load_events_fi(struct pgwt_server *srv,
     if (!events) return NULL;
     int total = 0;
 
-    /* Build the set of transition-covered ranges first, across ALL files,
-     * so the exact-wins merge sees a sampler in one file overlapping an
-     * escalation window in another. */
-    struct trans_range *ranges = NULL;
-    int nranges = 0, ranges_cap = 0;
+    /* Per-segment bookkeeping: each file contributes one contiguous run of
+     * events; merge + wall conversion need its generation and offset. */
+    struct load_seg { int start, count, gen; int64_t off; };
+    struct load_seg segs[256];
+    int n_segs = 0;
     uint64_t sample_period_ns = 0;
 
-    for (int fi = 0; fi < srv->num_files; fi++) {
-        const char *path = srv->files[fi].path;
+    for (int ci = 0; ci < srv->cov_count && n_segs < 256; ci++) {
+        struct pgwt_file_cov *fc = &srv->cov[ci];
+        if (!fc->valid)
+            continue;
 
-        if (is_current_trace(path)) {
+        /* Query window in this file's mono domain (canonical offset). */
+        if ((int64_t)to_wall_ns - fc->canon_offset <= 0)
+            continue;
+        uint64_t from_m = ((int64_t)from_wall_ns - fc->canon_offset) > 0
+                        ? (uint64_t)((int64_t)from_wall_ns - fc->canon_offset)
+                        : 0;
+        uint64_t to_m = (uint64_t)((int64_t)to_wall_ns - fc->canon_offset);
+
+        if (fc->mono_first > to_m || fc->mono_last < from_m)
+            continue;
+
+        if (fc->sample_period_ns)
+            sample_period_ns = fc->sample_period_ns;
+
+        int seg_start = total;
+
+        if (fc->is_current) {
             /* On-demand: read only blocks in [from, to] */
-            struct pgwt_load_info fileinfo = {0};
-            load_current_trace_range(path, from_wall_ns, to_wall_ns,
-                                     &events, &total, &cap,
-                                     &ranges, &nranges, &ranges_cap, &fileinfo);
-            if (fileinfo.sample_period_ns)
-                sample_period_ns = fileinfo.sample_period_ns;
+            load_file_range_mono(fc->path, from_m, to_m,
+                                 &events, &total, &cap);
         } else {
-            /* Immutable: try cache, fall back to on-demand for large files */
-            struct file_cache_entry *ce = get_cached_immutable(srv, path);
+            struct file_cache_entry *ce = get_cached_immutable(srv, fc->path);
             if (!ce || !ce->events) {
-                /* Cache miss (file too large or alloc failed) — read on demand */
-                struct pgwt_load_info fileinfo = {0};
-                load_current_trace_range(path, from_wall_ns, to_wall_ns,
-                                         &events, &total, &cap,
-                                         &ranges, &nranges, &ranges_cap,
-                                         &fileinfo);
-                if (fileinfo.sample_period_ns)
-                    sample_period_ns = fileinfo.sample_period_ns;
-                continue;
-            }
+                /* Cache miss (file too large or alloc failed) */
+                load_file_range_mono(fc->path, from_m, to_m,
+                                     &events, &total, &cap);
+            } else {
+                for (int i = 0; i < ce->count; i++) {
+                    uint64_t ts = ce->events[i].timestamp_ns;
+                    if (ts < from_m) continue;
+                    if (ts > to_m) break;
 
-            /* Skip file entirely if its time range doesn't overlap */
-            if (ce->last_wall_ns > 0 && ce->first_wall_ns > to_wall_ns)
-                continue;
-            if (ce->last_wall_ns > 0 && ce->last_wall_ns < from_wall_ns)
-                continue;
-
-            if (ce->sample_period_ns)
-                sample_period_ns = ce->sample_period_ns;
-
-            /* Contribute this file's transition ranges to the merge set */
-            for (int r = 0; r < ce->num_trans_ranges; r++)
-                trans_ranges_add(&ranges, &nranges, &ranges_cap,
-                                 ce->trans_ranges[r].start_wall_ns,
-                                 ce->trans_ranges[r].end_wall_ns);
-
-            /* Filter cached events by time range */
-            for (int i = 0; i < ce->count; i++) {
-                uint64_t ts = ce->events[i].timestamp_ns;
-                if (ts < from_wall_ns) continue;
-                if (ts > to_wall_ns) break;
-
-                if (total >= cap) {
-                    cap *= 2;
-                    struct pgwt_trace_event *tmp = realloc(events, cap * sizeof(*tmp));
-                    if (!tmp) { free(ranges); *out_count = total; return events; }
-                    events = tmp;
+                    if (total >= cap) {
+                        cap *= 2;
+                        struct pgwt_trace_event *tmp =
+                            realloc(events, cap * sizeof(*tmp));
+                        if (!tmp) { *out_count = total; return events; }
+                        events = tmp;
+                    }
+                    events[total++] = ce->events[i];
                 }
-                events[total++] = ce->events[i];
             }
+        }
+
+        if (total > seg_start) {
+            segs[n_segs].start = seg_start;
+            segs[n_segs].count = total - seg_start;
+            segs[n_segs].gen = fc->gen;
+            segs[n_segs].off = fc->canon_offset;
+            n_segs++;
         }
     }
 
-    /* Exact-wins merge: drop samples inside any transition range, then
+    /* Exact-wins merge (mono, per generation) + wall re-anchoring, then
      * derive what actually contributed for the fidelity indicator. */
     int has_transitions = 0, has_samples = 0;
     int kept = 0;
-    for (int i = 0; i < total; i++) {
-        if (events[i].flags & PGWT_EVENT_FLAG_SAMPLE) {
-            if (nranges > 0 &&
-                ts_in_trans_range(ranges, nranges, events[i].timestamp_ns))
-                continue;  /* transition data is authoritative here */
-            has_samples = 1;
-        } else {
-            has_transitions = 1;
+    for (int s = 0; s < n_segs; s++) {
+        const struct pgwt_gen_cov *gc = gen_cov_get(srv, segs[s].gen);
+        for (int i = segs[s].start; i < segs[s].start + segs[s].count; i++) {
+            if (events[i].flags & PGWT_EVENT_FLAG_SAMPLE) {
+                /* Boundary rule (FID-6): drop iff the sample's interval
+                 * midpoint lies inside exact coverage. */
+                uint64_t mid = events[i].timestamp_ns
+                             - events[i].duration_ns / 2;
+                if (gc && gc->n_exact > 0 &&
+                    spans_contain(gc->exact, gc->n_exact, mid))
+                    continue;   /* exact data is authoritative here */
+                has_samples = 1;
+            } else {
+                has_transitions = 1;
+            }
+            events[kept] = events[i];
+            events[kept].timestamp_ns = (uint64_t)
+                ((int64_t)events[kept].timestamp_ns + segs[s].off);
+            kept++;
         }
-        events[kept++] = events[i];
     }
     total = kept;
-    free(ranges);
 
     if (info) {
         info->has_transitions = has_transitions;
@@ -848,13 +1372,20 @@ server_load_events_fi(struct pgwt_server *srv,
     return events;
 }
 
-/* Backward-compatible wrapper for callers that don't need fidelity info. */
-static struct pgwt_trace_event *
-server_load_events(struct pgwt_server *srv,
-                   uint64_t from_wall_ns, uint64_t to_wall_ns,
-                   int *out_count)
+/* Free everything the server owns (cache, coverage, metadata maps) so
+ * sanitizer/valgrind runs end clean. */
+static void server_destroy(struct pgwt_server *srv)
 {
-    return server_load_events_fi(srv, from_wall_ns, to_wall_ns, out_count, NULL);
+    for (int i = 0; i < srv->cache_count; i++)
+        free(srv->cache[i].events);
+    srv->cache_count = 0;
+    for (int i = 0; i < srv->cov_count; i++)
+        cov_reset(&srv->cov[i]);
+    srv->cov_count = 0;
+    gens_free(srv);
+    qt_map_clear(srv);
+    free(srv->bm_map);
+    srv->bm_map = NULL;
 }
 
 /* ── Server init ──────────────────────────────────────────── */
@@ -881,34 +1412,12 @@ static int server_init(struct pgwt_server *srv, const char *trace_dir)
         return -1;
     }
 
-    /* Determine time range by opening first and last files */
+    /* Scan block headers, build the coverage table + clock generations,
+     * and derive the (re-anchored) wall time range. */
     srv->earliest_wall_ns = 0;
     srv->latest_wall_ns   = 0;
     srv->total_events     = 0;
-
-    for (int i = 0; i < srv->num_files; i++) {
-        struct pgwt_event_reader reader;
-        if (pgwt_reader_open(&reader, srv->files[i].path) != 0)
-            continue;
-
-        if (reader.num_blocks > 0) {
-            uint64_t first_mono = reader.block_index[0].timestamp_ns;
-            uint64_t last_mono  = reader.block_index[reader.num_blocks - 1].timestamp_ns;
-
-            uint64_t first_wall = pgwt_reader_mono_to_wall(&reader, first_mono);
-            uint64_t last_wall  = pgwt_reader_mono_to_wall(&reader, last_mono);
-
-            if (srv->earliest_wall_ns == 0 || first_wall < srv->earliest_wall_ns)
-                srv->earliest_wall_ns = first_wall;
-            if (last_wall > srv->latest_wall_ns)
-                srv->latest_wall_ns = last_wall;
-
-            /* Approximate event count from block count */
-            srv->total_events += reader.num_blocks * PGWT_BLOCK_EVENTS;
-        }
-
-        pgwt_reader_close(&reader);
-    }
+    coverage_refresh(srv);
 
     fprintf(stderr, "pgwt-server: %d trace files, %d CPUs, ~%lld events\n",
             srv->num_files, srv->num_cpus, (long long)srv->total_events);
@@ -919,21 +1428,36 @@ static int server_init(struct pgwt_server *srv, const char *trace_dir)
     return 0;
 }
 
-/* ── Summary threshold ────────────────────────────────────── */
+/* ── Summary threshold (coverage-aware — FID-2) ───────────── */
 
-/* Use summary path for ranges >= 120s (instant response, ~300KB peak memory).
- * Raw events used for ranges < 120s (exact per-event resolution).
- * Force raw events when pid filter is active — summaries don't have
- * per-PID event/class breakdown. query_id is handled via v2 per-query data. */
-static int should_use_summaries(struct pgwt_server *srv, struct pgwt_request *req)
+/* Use the summary fast path for ranges >= 120 s (instant response, ~300KB
+ * peak memory) — but ONLY when the window is fully exact-covered (or
+ * empty): summaries are fed by the exact (watchpoint) path alone, so over
+ * a window with uncovered sampled data they would silently drop it — in
+ * default tiered mode that made "last 15 minutes" return escalation
+ * slivers (or nothing) labeled "exact". Such windows fall back to the raw
+ * path, which merges samples with ASH math and labels honestly.
+ * Force raw events when a pid filter is active — summaries don't have
+ * per-PID event/class breakdown. query_id is handled via v2 per-query
+ * data. *wf is always filled with the window's coverage-derived fidelity
+ * so the summary-path response can carry an honest label. */
+static int should_use_summaries(struct pgwt_server *srv,
+                                struct pgwt_request *req,
+                                struct pgwt_wfid *wf)
 {
-    if (req->filter.pid != 0)
-        return 0;
+    coverage_refresh(srv);
     uint64_t from = req->from_ns ? req->from_ns : srv->earliest_wall_ns;
     uint64_t to   = req->to_ns   ? req->to_ns   : srv->latest_wall_ns;
+    *wf = window_fidelity(srv, from, to);
+
+    if (req->filter.pid != 0)
+        return 0;
     if (to <= from) return 0;
-    uint64_t range_ns = to - from;
-    return (range_ns >= 120ULL * 1000000000ULL);
+    if (to - from < 120ULL * 1000000000ULL)
+        return 0;
+    /* Summaries are only honest when exact data covers everything the
+     * window contains (EXACT), or the window is empty (NONE). */
+    return wf->fid == PGWT_FIDELITY_EXACT || wf->fid == PGWT_FIDELITY_NONE;
 }
 
 /* ── Fidelity (trace format v2, D3) ───────────────────────── */
@@ -954,11 +1478,14 @@ static void add_fidelity(cJSON *root, const struct pgwt_load_info *info)
         cjson_add_uint64(root, "sample_period_ns", info->sample_period_ns);
 }
 
-/* When summaries are used the window is full-fidelity transition data
- * (summaries are derived from the watchpoint path). */
-static void add_fidelity_exact(cJSON *root)
+/* Label for a summary-path response: derived from coverage, never
+ * hardcoded (FID-2). The summary path is only taken for EXACT or NONE. */
+static void add_fidelity_window(cJSON *root, const struct pgwt_wfid *wf)
 {
-    cJSON_AddStringToObject(root, "fidelity", "exact");
+    cJSON_AddStringToObject(root, "fidelity", pgwt_fidelity_str(wf->fid));
+    if (wf->sample_period_ns &&
+        (wf->fid == PGWT_FIDELITY_SAMPLED || wf->fid == PGWT_FIDELITY_MIXED))
+        cjson_add_uint64(root, "sample_period_ns", wf->sample_period_ns);
 }
 
 /* Emit the structured "unavailable" response for an EXACT-required view over
@@ -977,8 +1504,9 @@ static void emit_unavailable(uint64_t req_id, enum pgwt_fidelity fid)
 
 static void handle_info(struct pgwt_server *srv, struct pgwt_request *req)
 {
-    /* Refresh: rescan directory, reload metadata, update latest_wall_ns. */
-    srv->num_files = pgwt_scan_trace_files(srv->trace_dir, srv->files, 256);
+    /* Refresh: rescan directory + coverage (updates earliest/latest with
+     * the re-anchored canonical offsets), reload metadata. */
+    coverage_refresh(srv);
 
     /* Reload query texts and backend metadata (daemon appends new entries
      * as it discovers backends/queries). These files are small — fast. */
@@ -989,15 +1517,6 @@ static void handle_info(struct pgwt_server *srv, struct pgwt_request *req)
     srv->bm_capacity = 0;
     srv->bm_count = 0;
     server_load_backends(srv);
-
-    /* Update latest_wall_ns from current.trace (one quick open+close) */
-    for (int i = 0; i < srv->num_files; i++) {
-        if (is_current_trace(srv->files[i].path)) {
-            uint64_t t = get_current_trace_latest(srv->files[i].path);
-            if (t > srv->latest_wall_ns)
-                srv->latest_wall_ns = t;
-        }
-    }
 
     cJSON *root = cJSON_CreateObject();
     cJSON_AddNumberToObject(root, "id", (double)req->id);
@@ -1026,10 +1545,11 @@ static void handle_aas(struct pgwt_server *srv, struct pgwt_request *req)
 
     struct pgwt_aas_result aas;
     struct pgwt_load_info linfo = {0};
+    struct pgwt_wfid wfid = {0};
     int from_summaries = 0;
 
     /* Event-detail mode always uses raw events (no summary path yet) */
-    if (!detail_events && should_use_summaries(srv, req)) {
+    if (!detail_events && should_use_summaries(srv, req, &wfid)) {
         pgwt_compute_aas_from_summaries(srv->trace_dir, from, to,
                                          &req->filter, num_buckets, &aas);
         from_summaries = 1;
@@ -1044,7 +1564,7 @@ static void handle_aas(struct pgwt_server *srv, struct pgwt_request *req)
 
     cJSON *root = cJSON_CreateObject();
     cJSON_AddNumberToObject(root, "id", (double)req->id);
-    if (from_summaries) add_fidelity_exact(root);
+    if (from_summaries) add_fidelity_window(root, &wfid);
     else                add_fidelity(root, &linfo);
 
     if (aas.num_event_series > 0) {
@@ -1100,9 +1620,10 @@ static void handle_time_model(struct pgwt_server *srv, struct pgwt_request *req)
 
     struct pgwt_tm_result tm;
     struct pgwt_load_info linfo = {0};
+    struct pgwt_wfid wfid = {0};
     int from_summaries = 0;
 
-    if (should_use_summaries(srv, req)) {
+    if (should_use_summaries(srv, req, &wfid)) {
         pgwt_compute_time_model_from_summaries(srv->trace_dir, from, to,
                                                 &req->filter, wall_ms, &tm);
         from_summaries = 1;
@@ -1116,7 +1637,7 @@ static void handle_time_model(struct pgwt_server *srv, struct pgwt_request *req)
 
     cJSON *root = cJSON_CreateObject();
     cJSON_AddNumberToObject(root, "id", (double)req->id);
-    if (from_summaries) add_fidelity_exact(root);
+    if (from_summaries) add_fidelity_window(root, &wfid);
     else                add_fidelity(root, &linfo);
 
     cJSON *rows = cJSON_AddArrayToObject(root, "rows");
@@ -1147,9 +1668,10 @@ static void handle_top_events(struct pgwt_server *srv, struct pgwt_request *req)
 
     struct pgwt_events_result res;
     struct pgwt_load_info linfo = {0};
+    struct pgwt_wfid wfid = {0};
     int from_summaries = 0;
 
-    if (should_use_summaries(srv, req)) {
+    if (should_use_summaries(srv, req, &wfid)) {
         pgwt_compute_top_events_from_summaries(srv->trace_dir, from, to,
                                                 &req->filter, wall_ms, &res);
         from_summaries = 1;
@@ -1163,7 +1685,7 @@ static void handle_top_events(struct pgwt_server *srv, struct pgwt_request *req)
 
     cJSON *root = cJSON_CreateObject();
     cJSON_AddNumberToObject(root, "id", (double)req->id);
-    if (from_summaries) add_fidelity_exact(root);
+    if (from_summaries) add_fidelity_window(root, &wfid);
     else                add_fidelity(root, &linfo);
 
     cJSON *rows = cJSON_AddArrayToObject(root, "rows");
@@ -1175,11 +1697,23 @@ static void handle_top_events(struct pgwt_server *srv, struct pgwt_request *req)
                                 pgwt_class_name(res.rows[i].event_id));
         cjson_add_uint64(r, "count", res.rows[i].count);
         cJSON_AddNumberToObject(r, "total_ms", res.rows[i].total_ms);
-        cJSON_AddNumberToObject(r, "avg_us", res.rows[i].avg_us);
-        cJSON_AddNumberToObject(r, "p50_us", res.rows[i].p50_us);
-        cJSON_AddNumberToObject(r, "p95_us", res.rows[i].p95_us);
-        cJSON_AddNumberToObject(r, "p99_us", res.rows[i].p99_us);
-        cJSON_AddNumberToObject(r, "max_us", res.rows[i].max_us);
+        /* Latency statistics exist only where exact records contributed:
+         * over sampled data they would be fabrications (p95 ≈ sample
+         * period), so sampled-only rows carry null and render as "—"
+         * (FID-3). count/total_ms stay valid via ASH math. */
+        if (res.rows[i].exact_count > 0) {
+            cJSON_AddNumberToObject(r, "avg_us", res.rows[i].avg_us);
+            cJSON_AddNumberToObject(r, "p50_us", res.rows[i].p50_us);
+            cJSON_AddNumberToObject(r, "p95_us", res.rows[i].p95_us);
+            cJSON_AddNumberToObject(r, "p99_us", res.rows[i].p99_us);
+            cJSON_AddNumberToObject(r, "max_us", res.rows[i].max_us);
+        } else {
+            cJSON_AddNullToObject(r, "avg_us");
+            cJSON_AddNullToObject(r, "p50_us");
+            cJSON_AddNullToObject(r, "p95_us");
+            cJSON_AddNullToObject(r, "p99_us");
+            cJSON_AddNullToObject(r, "max_us");
+        }
         /* Idle-but-visible events (Client:ClientRead) have no meaningful
          * share of DB Time; emit null so the client renders "—". */
         if (PGWT_PCT_DB_IS_IDLE(res.rows[i].pct_db))
@@ -1204,10 +1738,11 @@ static void handle_top_sessions(struct pgwt_server *srv, struct pgwt_request *re
 
     struct pgwt_sessions_result res;
     struct pgwt_load_info linfo = {0};
+    struct pgwt_wfid wfid = {0};
     int from_summaries = 0;
 
     /* Sessions + query_id: summaries lack per-session query data, use raw events */
-    if (should_use_summaries(srv, req) && req->filter.query_id == 0) {
+    if (should_use_summaries(srv, req, &wfid) && req->filter.query_id == 0) {
         pgwt_compute_top_sessions_from_summaries(srv->trace_dir, from, to,
                                                   &req->filter, wall_ms, &res);
         from_summaries = 1;
@@ -1221,7 +1756,7 @@ static void handle_top_sessions(struct pgwt_server *srv, struct pgwt_request *re
 
     cJSON *root = cJSON_CreateObject();
     cJSON_AddNumberToObject(root, "id", (double)req->id);
-    if (from_summaries) add_fidelity_exact(root);
+    if (from_summaries) add_fidelity_window(root, &wfid);
     else                add_fidelity(root, &linfo);
 
     cJSON *rows = cJSON_AddArrayToObject(root, "rows");
@@ -1262,6 +1797,7 @@ static void handle_top_queries(struct pgwt_server *srv, struct pgwt_request *req
     struct pgwt_trace_event *all_events = NULL;
     struct pgwt_queries_result res;
     struct pgwt_load_info linfo = {0};
+    struct pgwt_wfid wfid = {0};
     int from_summaries = 0;
 
     /* Use summaries for large ranges (>120s) for the class breakdown.
@@ -1269,7 +1805,7 @@ static void handle_top_queries(struct pgwt_server *srv, struct pgwt_request *req
      * Large files are read on-demand (not cached) so this is safe. */
     all_events = server_load_events_fi(srv, req->from_ns, req->to_ns, &ecount,
                                        &linfo);
-    if (!has_event_filter && should_use_summaries(srv, req)) {
+    if (!has_event_filter && should_use_summaries(srv, req, &wfid)) {
         pgwt_compute_top_queries_from_summaries(srv->trace_dir, from, to,
                                                  &req->filter, wall_ms, &res);
         from_summaries = 1;
@@ -1365,7 +1901,7 @@ static void handle_top_queries(struct pgwt_server *srv, struct pgwt_request *req
 
     cJSON *root = cJSON_CreateObject();
     cJSON_AddNumberToObject(root, "id", (double)req->id);
-    if (from_summaries) add_fidelity_exact(root);
+    if (from_summaries) add_fidelity_window(root, &wfid);
     else                add_fidelity(root, &linfo);
 
     cJSON *rows = cJSON_AddArrayToObject(root, "rows");
@@ -1504,14 +2040,18 @@ static void handle_heatmap(struct pgwt_server *srv, struct pgwt_request *req)
     int num_buckets = req->num_buckets > 0 ? req->num_buckets : 200;
 
     struct pgwt_heatmap_result res;
+    struct pgwt_wfid wfid = {0};
     int from_summaries = 0;
+    enum pgwt_fidelity out_fid = PGWT_FIDELITY_EXACT;
 
     /* Heatmap (latency distribution) is EXACT-required: it needs real
-     * per-event durations, which samples do not carry. */
-    if (should_use_summaries(srv, req) && req->filter.query_id == 0) {
+     * per-event durations, which samples do not carry (the compute skips
+     * sample records, so mixed windows show exact cells only). */
+    if (should_use_summaries(srv, req, &wfid) && req->filter.query_id == 0) {
         pgwt_compute_heatmap_from_summaries(srv->trace_dir, from, to,
                                              &req->filter, num_buckets, &res);
         from_summaries = 1;
+        out_fid = wfid.fid;
     } else {
         int count;
         struct pgwt_load_info linfo = {0};
@@ -1526,6 +2066,7 @@ static void handle_heatmap(struct pgwt_server *srv, struct pgwt_request *req)
         pgwt_compute_heatmap(events, count, &req->filter,
                              from, to, num_buckets, &res);
         free(events);
+        out_fid = fid;
     }
 
     /* Latency bucket labels (UTF-8: µ = \xc2\xb5, ≥ = \xe2\x89\xa5) */
@@ -1538,7 +2079,7 @@ static void handle_heatmap(struct pgwt_server *srv, struct pgwt_request *req)
 
     cJSON *root = cJSON_CreateObject();
     cJSON_AddNumberToObject(root, "id", (double)req->id);
-    add_fidelity_exact(root);
+    cJSON_AddStringToObject(root, "fidelity", pgwt_fidelity_str(out_fid));
     (void)from_summaries;
 
     cJSON *times_arr = cJSON_AddArrayToObject(root, "times");
@@ -2426,14 +2967,19 @@ static void dump_summary(struct pgwt_server *srv)
     int n = ev.num_rows < 15 ? ev.num_rows : 15;
     for (int i = 0; i < n; i++) {
         struct pgwt_event_row *r = &ev.rows[i];
-        char pctbuf[16];
+        char pctbuf[16], avgbuf[16];
         /* Idle-but-visible events: time but no meaningful %DB share. */
         if (PGWT_PCT_DB_IS_IDLE(r->pct_db))
             snprintf(pctbuf, sizeof(pctbuf), "%8s", "—");
         else
             snprintf(pctbuf, sizeof(pctbuf), "%7.1f%%", r->pct_db);
-        printf("  %-28s %10llu %12.1f %10.1f %s\n",
-               r->name, (unsigned long long)r->count, r->total_ms, r->avg_us, pctbuf);
+        /* Sampled-only rows have no real latency measurements (FID-3). */
+        if (r->exact_count > 0)
+            snprintf(avgbuf, sizeof(avgbuf), "%10.1f", r->avg_us);
+        else
+            snprintf(avgbuf, sizeof(avgbuf), "%10s", "—");
+        printf("  %-28s %10llu %12.1f %s %s\n",
+               r->name, (unsigned long long)r->count, r->total_ms, avgbuf, pctbuf);
     }
     free(ev.rows);
 
@@ -2503,6 +3049,7 @@ int main(int argc, char **argv)
     if (dump_mode) {
         dump_daemon_status(srv.trace_dir);
         dump_summary(&srv);
+        server_destroy(&srv);
         return 0;
     }
 
@@ -2522,5 +3069,6 @@ int main(int argc, char **argv)
         dispatch(&srv, &req, line);
     }
 
+    server_destroy(&srv);
     return 0;
 }

--- a/src/summary_writer.c
+++ b/src/summary_writer.c
@@ -161,6 +161,14 @@ static void accum_event(struct pgwt_summary_accum *acc,
     if (old_ev == PGWT_EVENT_EXIT)
         return;
 
+    /* Markers must never be accumulated (FID-4): exec/plan markers inflate
+     * per-query counts (skewing avg low) and escalation markers insert
+     * bogus PGWT_ESC_PACK query_ids. This is the write-side chokepoint —
+     * event_stream pushes every record (markers included, so they land in
+     * the trace) before its own marker check. */
+    if (PGWT_IS_MARKER(old_ev))
+        return;
+
     acc->total_events++;
 
     /* Time model: classify old_event into wait class */

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -13,6 +13,7 @@ LIBBPF_LIB ?= -lbpf
 TESTS     = test_wait_event test_cmdline test_event_writer test_event_reader \
             test_trace_v2 test_sampler test_anomaly test_coop test_bucket \
             test_pg13_resolve test_discovery_pie test_discovery_nopie \
+            test_replay_fidelity \
             gen_test_traces gen_bench_traces test_concurrent_rw cross_validate \
             dump_markers
 
@@ -99,6 +100,20 @@ test_anomaly: test_anomaly.c ../src/anomaly.c
 test_coop: test_coop.c ../src/provider_coop.c
 	$(CC) $(CFLAGS) -DPGWT_SERVER -o $@ $^
 
+# test_replay_fidelity: fidelity-aware --replay accumulation (T1/FID-5) —
+# samples contribute ASH-estimated time (never fabricated histograms),
+# markers are skipped. Links the daemon-flavor event_reader.c (which holds
+# pgwt_replay_events) against the BPF-free accumulator core: map_reader.c
+# compiled with -DPGWT_SERVER strips its libbpf/skeleton half (same pattern
+# as sampler.c/anomaly.c), so no bpftool is needed.
+map_reader_core.o: ../src/map_reader.c ../src/map_reader.h
+	$(CC) $(CFLAGS) -DPGWT_SERVER -c -o $@ $<
+
+test_replay_fidelity: test_replay_fidelity.c ../src/event_reader.c \
+                      map_reader_core.o $(BUILD)/server_event_writer.o \
+                      $(BUILD)/server_wait_event.o $(BUILD)/server_cJSON.o
+	$(CC) $(CFLAGS) -o $@ $^ -llz4 -lz
+
 # Server-build objects for gen_test_traces
 SERVER_OBJS = $(BUILD)/server_event_writer.o $(BUILD)/server_summary_writer.o \
               $(BUILD)/server_wait_event.o $(BUILD)/server_spawn.o $(BUILD)/server_cJSON.o
@@ -130,4 +145,4 @@ dump_markers: dump_markers.c $(BUILD)/server_event_reader.o \
 	$(CC) $(CFLAGS) -DPGWT_SERVER -o $@ $^ -llz4 -lz
 
 clean:
-	rm -f $(TESTS)
+	rm -f $(TESTS) map_reader_core.o

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -111,7 +111,8 @@ map_reader_core.o: ../src/map_reader.c ../src/map_reader.h
 
 test_replay_fidelity: test_replay_fidelity.c ../src/event_reader.c \
                       map_reader_core.o $(BUILD)/server_event_writer.o \
-                      $(BUILD)/server_wait_event.o $(BUILD)/server_cJSON.o
+                      $(BUILD)/server_wait_event.o $(BUILD)/server_spawn.o \
+                      $(BUILD)/server_cJSON.o
 	$(CC) $(CFLAGS) -o $@ $^ -llz4 -lz
 
 # Server-build objects for gen_test_traces

--- a/tests/gen_test_traces.c
+++ b/tests/gen_test_traces.c
@@ -28,6 +28,23 @@
  *             100000000 = 10 Hz) is stored in the block header. Samples must
  *             be sorted by ts ascending. A scenario may have events, samples,
  *             or both. Both arrays produce A3 fixtures.
+ * "interleave": 1 (top-level, optional) → events and samples are written in
+ *             global timestamp order, so the file's block structure matches
+ *             a real tiered capture: a transitions block is flushed whenever
+ *             the sample stream catches up, sample blocks land between
+ *             transition blocks. Without it, all events are written first,
+ *             then all samples (one big transitions block — NOT what the
+ *             tiered daemon produces).
+ *
+ * Extra options (T1 fidelity tests):
+ *   --wall-offset <ns>  patch headers so mono→wall offset = <ns> instead of 0
+ *                       (simulates an NTP step between file opens — FID-7).
+ *   --rotate <name>     after writing, rename current.trace →
+ *                       <name>.trace.lz4 and current.summary →
+ *                       <name>.summary.lz4 (footers are present because the
+ *                       writers are closed first) and remove the .meta files.
+ *                       Lets a test build a multi-file trace dir by invoking
+ *                       the generator several times with the same -o dir.
  *
  * Event IDs: old_event/new_event/event are uint32 wait_event_info values.
  *   CPU = 0, IO:DataFileRead = 0x0A000001, Lock:relation = 0x03000001, etc.
@@ -74,6 +91,7 @@ struct scenario {
     struct pgwt_trace_event samples[MAX_EVENTS];
     int num_samples;
     uint64_t sample_period_ns;
+    int interleave;   /* write events+samples in global ts order */
 
     struct test_backend backends[MAX_TEST_BACKENDS];
     int num_backends;
@@ -270,6 +288,8 @@ static int parse_scenario(const char *json, struct scenario *sc)
         sc->sample_period_ns = strtoull(v, NULL, 10);
     if ((v = find_key(json, "samples")))
         parse_samples(v, sc);
+    if ((v = find_key(json, "interleave")))
+        sc->interleave = (int)strtol(v, NULL, 10);
 
     return 0;
 }
@@ -330,10 +350,46 @@ static int write_query_texts(const char *dir, struct scenario *sc)
     return 0;
 }
 
-static int write_traces(const char *dir, struct scenario *sc)
+/* Earliest timestamp in the scenario — the synthetic "mono" clock anchor. */
+static uint64_t scenario_first_ts(const struct scenario *sc)
+{
+    uint64_t first = UINT64_MAX;
+    for (int i = 0; i < sc->num_events; i++)
+        if (sc->events[i].timestamp_ns < first)
+            first = sc->events[i].timestamp_ns;
+    for (int i = 0; i < sc->num_samples; i++)
+        if (sc->samples[i].timestamp_ns < first)
+            first = sc->samples[i].timestamp_ns;
+    return first == UINT64_MAX ? 0 : first;
+}
+
+/* Re-anchor the (lazily opened) summary writer's clocks to the synthetic
+ * timestamp domain, so summary block wall timestamps come out as
+ * scenario_ts + wall_offset — coherent with the patched trace headers.
+ * Must run after the first push (which opens the file) and before the first
+ * second-boundary flush. Without this, summary blocks carry wall values
+ * derived from the real machine clocks and the summary path is untestable
+ * with synthetic data. */
+static void anchor_summary_clock(struct pgwt_summary_writer *sw,
+                                 uint64_t anchor_mono, uint64_t wall_offset_ns)
+{
+    if (!sw->fp)
+        return;
+    sw->clock_offset_mono_ns = anchor_mono;
+    sw->clock_offset_wall_ns = anchor_mono + wall_offset_ns;
+    /* Fix up the accumulator second opened by the first push. */
+    if (sw->accum_active)
+        sw->accum.second_wall_ns = sw->accum.second_mono_ns + wall_offset_ns;
+}
+
+static int write_traces(const char *dir, struct scenario *sc,
+                        uint64_t wall_offset_ns)
 {
     struct pgwt_event_writer ew;
     struct pgwt_summary_writer sw;
+    uint64_t anchor_mono = scenario_first_ts(sc);
+    anchor_mono = (anchor_mono / 1000000000ULL) * 1000000000ULL;
+    int summary_anchored = 0;
 
     if (pgwt_writer_init(&ew, dir, 18, 24, NULL) != 0) {
         fprintf(stderr, "Failed to init event writer\n");
@@ -345,24 +401,63 @@ static int write_traces(const char *dir, struct scenario *sc)
         pgwt_writer_destroy(&ew);
         return -1;
     }
+    #define PUSH_SUMMARY(evp) do { \
+        pgwt_summary_push_event(&sw, (evp)); \
+        if (!summary_anchored) { \
+            anchor_summary_clock(&sw, anchor_mono, wall_offset_ns); \
+            summary_anchored = 1; \
+        } \
+    } while (0)
 
-    /* TRANSITIONS block(s): the "events" array. Also feeds the summary
-     * writer (summaries are transition-based; sampled summaries are A3). */
-    for (int i = 0; i < sc->num_events; i++) {
-        if (pgwt_writer_push_event(&ew, &sc->events[i]) != 0) {
-            fprintf(stderr, "Failed to write event %d\n", i);
-            break;
+    if (sc->interleave) {
+        /* Realistic tiered block structure: walk events and samples in
+         * global timestamp order. Contiguous runs of samples are pushed as
+         * SAMPLES blocks; pgwt_writer_push_samples flushes any buffered
+         * transitions first, so transition blocks are split exactly where
+         * the sample stream interleaves — like the live daemon. */
+        int ei = 0, si = 0;
+        while (ei < sc->num_events || si < sc->num_samples) {
+            if (si >= sc->num_samples ||
+                (ei < sc->num_events &&
+                 sc->events[ei].timestamp_ns <= sc->samples[si].timestamp_ns)) {
+                if (pgwt_writer_push_event(&ew, &sc->events[ei]) != 0) {
+                    fprintf(stderr, "Failed to write event %d\n", ei);
+                    break;
+                }
+                PUSH_SUMMARY(&sc->events[ei]);
+                ei++;
+            } else {
+                /* Collect the contiguous run of samples before the next event */
+                int run = si;
+                while (run < sc->num_samples &&
+                       (ei >= sc->num_events ||
+                        sc->samples[run].timestamp_ns < sc->events[ei].timestamp_ns))
+                    run++;
+                if (pgwt_writer_push_samples(&ew, &sc->samples[si], run - si,
+                                             sc->sample_period_ns) != 0)
+                    fprintf(stderr, "Failed to write samples %d..%d\n", si, run);
+                si = run;
+            }
         }
-        pgwt_summary_push_event(&sw, &sc->events[i]);
-    }
+    } else {
+        /* TRANSITIONS block(s): the "events" array. Also feeds the summary
+         * writer (summaries are transition-based; sampled summaries are A3). */
+        for (int i = 0; i < sc->num_events; i++) {
+            if (pgwt_writer_push_event(&ew, &sc->events[i]) != 0) {
+                fprintf(stderr, "Failed to write event %d\n", i);
+                break;
+            }
+            PUSH_SUMMARY(&sc->events[i]);
+        }
 
-    /* SAMPLES block: the "samples" array (trace format v2). Written after
-     * the transitions so a scenario with both produces a transition block
-     * followed by a sample block. */
-    if (sc->num_samples > 0) {
-        if (pgwt_writer_push_samples(&ew, sc->samples, sc->num_samples,
-                                     sc->sample_period_ns) != 0)
-            fprintf(stderr, "Failed to write %d samples\n", sc->num_samples);
+        /* SAMPLES block: the "samples" array (trace format v2). Written after
+         * the transitions so a scenario with both produces a transition block
+         * followed by a sample block. */
+        if (sc->num_samples > 0) {
+            if (pgwt_writer_push_samples(&ew, sc->samples, sc->num_samples,
+                                         sc->sample_period_ns) != 0)
+                fprintf(stderr, "Failed to write %d samples\n", sc->num_samples);
+        }
     }
 
     /* Flush summary */
@@ -378,9 +473,10 @@ static int write_traces(const char *dir, struct scenario *sc)
     return 0;
 }
 
-/* ── Patch file headers so mono_to_wall = 0 ────────────────── */
+/* ── Patch file headers so mono_to_wall = wall_offset ─────── */
 
-static int patch_file_header(const char *path)
+static int patch_file_header(const char *path, uint64_t anchor_mono,
+                             uint64_t wall_offset_ns)
 {
     FILE *f = fopen(path, "r+b");
     if (!f) return -1;
@@ -391,10 +487,14 @@ static int patch_file_header(const char *path)
         return -1;
     }
 
-    /* Set start_time_ns = clock_offset_ns so mono_to_wall = 0
-     * This makes wall-clock timestamps equal to monotonic timestamps,
-     * allowing test scenarios to use known timestamp values. */
-    hdr.start_time_ns = hdr.clock_offset_ns;
+    /* Anchor the header clocks to the synthetic timestamp domain:
+     * clock_offset_ns (mono at open) = first scenario timestamp,
+     * start_time_ns (wall at open)   = same + wall_offset,
+     * so mono_to_wall = wall_offset (0 by default: wall == mono and test
+     * scenarios can use known values). A non-zero offset simulates an NTP
+     * step between file opens (FID-7). */
+    hdr.clock_offset_ns = anchor_mono;
+    hdr.start_time_ns = anchor_mono + wall_offset_ns;
 
     fseek(f, 0, SEEK_SET);
     if (fwrite(&hdr, sizeof(hdr), 1, f) != 1) {
@@ -406,17 +506,21 @@ static int patch_file_header(const char *path)
     return 0;
 }
 
-static int patch_trace_headers(const char *dir)
+static int patch_trace_headers(const char *dir, uint64_t anchor_mono,
+                               uint64_t wall_offset_ns)
 {
     DIR *d = opendir(dir);
     if (!d) return -1;
 
     struct dirent *ent;
     while ((ent = readdir(d)) != NULL) {
-        if (strstr(ent->d_name, ".trace") || strstr(ent->d_name, ".summary")) {
+        /* Only the files this run just wrote (current.*): repeated runs into
+         * one dir must not re-patch already-rotated files. */
+        if (strcmp(ent->d_name, "current.trace") == 0 ||
+            strcmp(ent->d_name, "current.summary") == 0) {
             char path[512];
             snprintf(path, sizeof(path), "%s/%s", dir, ent->d_name);
-            if (patch_file_header(path) != 0) {
+            if (patch_file_header(path, anchor_mono, wall_offset_ns) != 0) {
                 fprintf(stderr, "WARN: failed to patch header of %s\n", ent->d_name);
             }
         }
@@ -424,6 +528,28 @@ static int patch_trace_headers(const char *dir)
 
     closedir(d);
     return 0;
+}
+
+/* ── --rotate: turn current.* into archived hourly files ──── */
+
+static int rotate_output(const char *dir, const char *name)
+{
+    char oldp[600], newp[700];
+    int rc = 0;
+
+    snprintf(oldp, sizeof(oldp), "%s/current.trace", dir);
+    snprintf(newp, sizeof(newp), "%s/%s.trace.lz4", dir, name);
+    if (rename(oldp, newp) != 0) { perror(newp); rc = -1; }
+    snprintf(oldp, sizeof(oldp), "%s/current.trace.meta", dir);
+    unlink(oldp);
+
+    snprintf(oldp, sizeof(oldp), "%s/current.summary", dir);
+    snprintf(newp, sizeof(newp), "%s/%s.summary.lz4", dir, name);
+    rename(oldp, newp);   /* summary may not exist (samples-only scenario) */
+    snprintf(oldp, sizeof(oldp), "%s/current.summary.meta", dir);
+    unlink(oldp);
+
+    return rc;
 }
 
 /* ── Main ──────────────────────────────────────────────────── */
@@ -439,21 +565,27 @@ int main(int argc, char **argv)
     const char *outdir = NULL;
     const char *scenario_file = NULL;
     const char *inline_json = NULL;
+    const char *rotate_name = NULL;
+    uint64_t wall_offset_ns = 0;
 
     static struct option long_opts[] = {
-        {"output",  required_argument, NULL, 'o'},
-        {"scenario", required_argument, NULL, 's'},
-        {"inline",  required_argument, NULL, 'i'},
-        {"help",    no_argument,       NULL, 'h'},
+        {"output",      required_argument, NULL, 'o'},
+        {"scenario",    required_argument, NULL, 's'},
+        {"inline",      required_argument, NULL, 'i'},
+        {"wall-offset", required_argument, NULL, 'w'},
+        {"rotate",      required_argument, NULL, 'r'},
+        {"help",        no_argument,       NULL, 'h'},
         {NULL, 0, NULL, 0}
     };
 
     int opt;
-    while ((opt = getopt_long(argc, argv, "o:s:i:h", long_opts, NULL)) != -1) {
+    while ((opt = getopt_long(argc, argv, "o:s:i:w:r:h", long_opts, NULL)) != -1) {
         switch (opt) {
         case 'o': outdir = optarg; break;
         case 's': scenario_file = optarg; break;
         case 'i': inline_json = optarg; break;
+        case 'w': wall_offset_ns = strtoull(optarg, NULL, 10); break;
+        case 'r': rotate_name = optarg; break;
         default:  usage(argv[0]); return 1;
         }
     }
@@ -493,12 +625,21 @@ int main(int argc, char **argv)
     int rc = 0;
     if (write_backends_jsonl(outdir, sc) != 0) rc = 1;
     if (write_query_texts(outdir, sc) != 0) rc = 1;
-    if (write_traces(outdir, sc) != 0) rc = 1;
+    if (write_traces(outdir, sc, wall_offset_ns) != 0) rc = 1;
 
-    /* Patch file headers so mono_to_wall = 0 (wall timestamps == mono timestamps).
-     * This is essential for test correctness: synthetic events use known monotonic
-     * timestamps, and we need the server to treat them as-is without offset. */
-    patch_trace_headers(outdir);
+    /* Patch file headers so mono_to_wall = wall_offset (default 0: wall
+     * timestamps == mono timestamps). Synthetic events use known monotonic
+     * timestamps; --wall-offset simulates an NTP step between files (FID-7). */
+    {
+        uint64_t anchor = scenario_first_ts(sc);
+        anchor = (anchor / 1000000000ULL) * 1000000000ULL;
+        patch_trace_headers(outdir, anchor, wall_offset_ns);
+    }
+
+    /* Optionally rotate this run's output aside so the next run can add
+     * another file to the same trace dir. */
+    if (rotate_name && rotate_output(outdir, rotate_name) != 0)
+        rc = 1;
 
     free(sc);
     return rc;

--- a/tests/mock_server.py
+++ b/tests/mock_server.py
@@ -556,6 +556,18 @@ def handle_request(msg):
         resp["fidelity"] = _FID.fidelity
         if _FID.fidelity in ("sampled", "mixed"):
             resp["sample_period_ns"] = _FID.sample_period_ns
+    # FID-3 (T1): over a sampled-only window the real server gates the
+    # latency columns — samples carry no real durations, so avg/percentiles
+    # are null and the UI renders "—". Mirror it so the web tests exercise
+    # the same shape.
+    if cmd == "top_events" and _FID.fidelity == "sampled" and "rows" in resp:
+        gated = []
+        for row in resp["rows"]:
+            row = dict(row)
+            for col in ("avg_us", "p50_us", "p95_us", "p99_us", "max_us"):
+                row[col] = None
+            gated.append(row)
+        resp["rows"] = gated
     return resp
 
 

--- a/tests/run_all.sh
+++ b/tests/run_all.sh
@@ -118,6 +118,9 @@ if [[ -x "$PROJECT_DIR/pgwt-server" ]] && [[ -x "$SCRIPT_DIR/gen_test_traces" ]]
     run_test "test_data_transitions" python3 "$SCRIPT_DIR/test_data_transitions.py"
     run_test "test_data_lock_chains" python3 "$SCRIPT_DIR/test_data_lock_chains.py"
     run_test "test_data_fidelity" python3 "$SCRIPT_DIR/test_data_fidelity.py"
+    run_test "test_data_esc_coverage" python3 "$SCRIPT_DIR/test_data_esc_coverage.py"
+    run_test "test_data_summary_honesty" python3 "$SCRIPT_DIR/test_data_summary_honesty.py"
+    run_test "test_data_markers" python3 "$SCRIPT_DIR/test_data_markers.py"
     run_test "test_current_trace" python3 "$SCRIPT_DIR/test_current_trace.py"
     run_test "test_protocol_drift" python3 "$SCRIPT_DIR/test_protocol_drift.py"
 else

--- a/tests/server_harness.py
+++ b/tests/server_harness.py
@@ -106,12 +106,17 @@ class ServerHarness:
         return json.loads(resp_line)
 
 
-def generate_traces(scenario, output_dir=None):
+def generate_traces(scenario, output_dir=None, wall_offset_ns=None, rotate=None):
     """Generate trace files from a scenario dict.
 
     Args:
         scenario: Dict with 'backends', 'queries', 'events' keys.
         output_dir: Directory to write to (created if None, using tempdir).
+        wall_offset_ns: mono→wall offset patched into this run's file headers
+            (default 0 — wall == mono). Simulates an NTP step between files.
+        rotate: if set (e.g. "2025-01-01_10"), rename this run's current.*
+            to <rotate>.trace.lz4 / <rotate>.summary.lz4 so another run can
+            add a second file to the same dir.
 
     Returns:
         Path to the trace directory.
@@ -125,10 +130,12 @@ def generate_traces(scenario, output_dir=None):
         )
 
     scenario_json = json.dumps(scenario)
-    result = subprocess.run(
-        [GEN_BIN, "-o", output_dir, "--inline", scenario_json],
-        capture_output=True, text=True,
-    )
+    cmd = [GEN_BIN, "-o", output_dir, "--inline", scenario_json]
+    if wall_offset_ns is not None:
+        cmd += ["--wall-offset", str(wall_offset_ns)]
+    if rotate is not None:
+        cmd += ["--rotate", rotate]
+    result = subprocess.run(cmd, capture_output=True, text=True)
     if result.returncode != 0:
         raise RuntimeError(
             f"gen_test_traces failed:\nstdout: {result.stdout}\nstderr: {result.stderr}"

--- a/tests/test_data_esc_coverage.py
+++ b/tests/test_data_esc_coverage.py
@@ -1,0 +1,382 @@
+#!/usr/bin/env python3
+"""test_data_esc_coverage.py — T1/FID-1/6/7: escalation markers are the
+exact-wins coverage authority.
+
+The rework's headline claim — "the exact-wins merge prevents double
+counting" — was violated whenever a long wait spanned an escalation window:
+transition timestamps are wait-END times, so a 60 s lock wait emits nothing
+until it ends. Coverage derived from TRANSITIONS-block [first_ts, last_ts]
+ranges therefore had a hole exactly over the wait, the interior samples
+survived the merge, AND the exact 60 s interval landed → up to 2×.
+
+The fix derives coverage from the PGWT_MARKER_ESCALATE_START/END markers the
+daemon already writes:
+
+  * closed window  [START_ts, END_ts]
+  * START with no END (daemon crash / window still open): coverage extends to
+    the last TRANSITIONS-block timestamp actually committed — never beyond.
+  * END with no START (window opened before this file / older file deleted):
+    coverage starts at the file's first block timestamp.
+  * boundary rule (FID-6): a sample represents (ts − period, ts]; it is
+    dropped iff its interval MIDPOINT (ts − period/2) falls inside a covered
+    span (inclusive). Worst-case error per window edge ≤ period/2.
+  * files with transitions and no SAMPLES blocks (--mode full) are covered
+    whole-file; files with samples+transitions but no markers anywhere fall
+    back to per-block spans (legacy traces).
+  * the merge runs in the monotonic clock domain (FID-7): per-file mono→wall
+    offsets (NTP steps between file opens) cannot shift coverage against
+    samples from another file of the same daemon run.
+
+All scenarios use interleave=1 so the trace has the block structure the real
+tiered daemon produces (transitions blocks split around sample blocks).
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(__file__))
+from server_harness import (
+    ServerHarness, generate_traces, cleanup_traces, TestRunner,
+    CPU, IO_DATA_FILE_READ, LOCK_RELATION,
+)
+
+BASE = 10_000_000_000_000   # 10000 s in ns
+S = 1_000_000_000
+PERIOD = 100_000_000        # 100 ms = 10 Hz
+
+MARKER_ESC_START = 0xFFFFFFF4
+MARKER_ESC_END   = 0xFFFFFFF5
+
+
+def esc_pack(secs, reason):
+    return (secs << 8) | reason
+
+
+def esc_marker(ts, marker, secs=60, reason=0):
+    return {"pid": 0, "ts": ts, "dur": 0, "old": marker, "new": marker,
+            "qid": esc_pack(secs, reason)}
+
+
+def sample_at(pid, ts, event, qid=0):
+    return {"pid": pid, "ts": ts, "event": event, "qid": qid}
+
+
+def sample_range(pid, start_ts, end_ts, event, qid=0):
+    """Samples every PERIOD in (start_ts, end_ts] inclusive of both ends
+    where they land on the grid."""
+    out = []
+    ts = start_ts
+    while ts <= end_ts:
+        out.append(sample_at(pid, ts, event, qid))
+        ts += PERIOD
+    return out
+
+
+def dropped_by_rule(samples, spans):
+    """Apply the documented boundary rule: drop iff midpoint in any span."""
+    n = 0
+    for smp in samples:
+        mid = smp["ts"] - PERIOD // 2
+        if any(s <= mid <= e for (s, e) in spans):
+            n += 1
+    return n
+
+
+def lock_ms(resp):
+    rows = {r["name"]: r for r in resp["rows"]}
+    return rows.get("Lock", {}).get("ms", 0.0)
+
+
+# ── 1. FID-1: long wait spanning a whole escalation window ────────────
+
+def test_long_wait_window(t):
+    print("\n### 1. FID-1: 60s lock inside an escalation window (no 2x) ###")
+    w0 = BASE + 1 * S
+    w1 = w0 + 60 * S      # END marker ts
+
+    events = [
+        esc_marker(w0, MARKER_ESC_START, 60, 0),
+        # The long wait: ONE transition at wait-END time, dur = 60 s.
+        {"pid": 1000, "ts": w1, "dur": 60 * S,
+         "old": LOCK_RELATION, "new": CPU, "qid": 100},
+        esc_marker(w1 + 1000, MARKER_ESC_END, 60, 2),
+    ]
+    # Sampler runs through the window: pid 1000's lock is sampled the whole
+    # time. These samples MUST be dropped (the exact interval covers them).
+    in_window = sample_range(1000, w0 + PERIOD, w1, LOCK_RELATION, 100)
+    # Samples after the window (sampled-only period) MUST survive.
+    after = sample_range(1001, w1 + 5 * S, w1 + 10 * S, LOCK_RELATION, 200)
+    samples = sorted(in_window + after, key=lambda s: s["ts"])
+
+    n_after = len(after)
+    expected_lock_ms = 60_000.0 + n_after * (PERIOD / 1e6)
+    double_counted_ms = expected_lock_ms + len(in_window) * (PERIOD / 1e6)
+
+    scenario = {
+        "backends": [{"pid": 1000, "type": "client", "user": "u", "db": "d"},
+                     {"pid": 1001, "type": "client", "user": "u", "db": "d"}],
+        "queries": [{"id": 100, "text": "SELECT 1"},
+                    {"id": 200, "text": "SELECT 2"}],
+        "events": events,
+        "sample_period_ns": PERIOD,
+        "samples": samples,
+        "interleave": 1,
+    }
+    trace_dir = generate_traces(scenario)
+    try:
+        with ServerHarness(trace_dir) as srv:
+            tm = srv.query("time_model")
+            got = lock_ms(tm)
+            t.check_approx(got, expected_lock_ms, 0.001,
+                           f"Lock total = {expected_lock_ms:.0f}ms "
+                           f"(60s exact + {n_after} post-window samples), "
+                           f"NOT {double_counted_ms:.0f}ms (2x bug)")
+            t.check_eq(tm.get("fidelity"), "mixed", "window fidelity = mixed")
+
+            ev = srv.query("top_events")
+            rows = {r["name"]: r for r in ev["rows"]}
+            t.check_approx(rows.get("Lock:relation", {}).get("total_ms", -1),
+                           expected_lock_ms, 0.001,
+                           "top_events Lock:relation matches ground truth")
+    finally:
+        cleanup_traces(trace_dir)
+
+
+# ── 2. FID-6: boundary rule at window edges ───────────────────────────
+
+def test_boundary_rule(t):
+    print("\n### 2. FID-6: sample-interval midpoint rule at window edges ###")
+    w0 = BASE + 10 * S
+    w1 = w0 + 10 * S
+
+    events = [
+        esc_marker(w0, MARKER_ESC_START, 10, 0),
+        # One small exact interval inside the window (different class so the
+        # sampled event's total is isolated).
+        {"pid": 1000, "ts": w0 + 1 * S, "dur": 500_000_000,
+         "old": IO_DATA_FILE_READ, "new": CPU, "qid": 100},
+        esc_marker(w1, MARKER_ESC_END, 10, 2),
+    ]
+    # Samples straddling both edges: from w0-2s to w1+2s.
+    samples = sample_range(1001, w0 - 2 * S, w1 + 2 * S, LOCK_RELATION, 200)
+
+    n_dropped = dropped_by_rule(samples, [(w0, w1)])
+    n_kept = len(samples) - n_dropped
+    expected_lock_ms = n_kept * (PERIOD / 1e6)
+
+    # Sanity of the rule itself: a sample AT w0 has midpoint w0 - period/2,
+    # outside the window → kept; a sample at w0+period has midpoint inside →
+    # dropped; a sample at w1+period has midpoint w1+period/2 → kept.
+    t.check(dropped_by_rule([sample_at(1, w0, 0)], [(w0, w1)]) == 0,
+            "rule: sample exactly at window start is kept (mass before w0)")
+    t.check(dropped_by_rule([sample_at(1, w0 + PERIOD, 0)], [(w0, w1)]) == 1,
+            "rule: first sample inside the window is dropped")
+    t.check(dropped_by_rule([sample_at(1, w1 + PERIOD, 0)], [(w0, w1)]) == 0,
+            "rule: first sample after window end is kept")
+
+    scenario = {
+        "backends": [{"pid": 1000, "type": "client", "user": "u", "db": "d"},
+                     {"pid": 1001, "type": "client", "user": "u", "db": "d"}],
+        "queries": [{"id": 100, "text": "Q1"}, {"id": 200, "text": "Q2"}],
+        "events": events,
+        "sample_period_ns": PERIOD,
+        "samples": samples,
+        "interleave": 1,
+    }
+    trace_dir = generate_traces(scenario)
+    try:
+        with ServerHarness(trace_dir) as srv:
+            tm = srv.query("time_model")
+            t.check_approx(lock_ms(tm), expected_lock_ms, 0.001,
+                           f"Lock = {expected_lock_ms:.0f}ms "
+                           f"({n_kept} samples kept by the midpoint rule)")
+            rows = {r["name"]: r for r in tm["rows"]}
+            t.check_approx(rows.get("IO", {}).get("ms", -1), 500.0, 0.001,
+                           "exact IO interval inside the window = 500ms")
+    finally:
+        cleanup_traces(trace_dir)
+
+
+# ── 3. Crash mid-window: START with no END ────────────────────────────
+
+def test_crash_mid_window(t):
+    print("\n### 3. START with no END (crash): clamp to last exact data ###")
+    w0 = BASE + 5 * S
+    t_last = w0 + 10 * S   # last committed exact transition
+
+    # Exact IO chain w0 .. t_last (100 intervals of 100ms)
+    events = [esc_marker(w0, MARKER_ESC_START, 60, 1)]
+    ts = w0 + PERIOD
+    while ts <= t_last:
+        events.append({"pid": 1000, "ts": ts, "dur": PERIOD,
+                       "old": IO_DATA_FILE_READ, "new": CPU, "qid": 100})
+        ts += PERIOD
+    # NO END marker — daemon crashed. Samples continue for 20 more seconds
+    # (in reality the sampler died too, but data already on disk past t_last
+    # must survive: beyond the last exact evidence, samples are the truth).
+    samples = sample_range(1001, w0 + PERIOD, t_last + 20 * S,
+                           LOCK_RELATION, 200)
+
+    n_dropped = dropped_by_rule(samples, [(w0, t_last)])
+    n_kept = len(samples) - n_dropped
+    expected_lock_ms = n_kept * (PERIOD / 1e6)
+
+    scenario = {
+        "backends": [{"pid": 1000, "type": "client", "user": "u", "db": "d"},
+                     {"pid": 1001, "type": "client", "user": "u", "db": "d"}],
+        "queries": [{"id": 100, "text": "Q1"}, {"id": 200, "text": "Q2"}],
+        "events": events,
+        "sample_period_ns": PERIOD,
+        "samples": samples,
+        "interleave": 1,
+    }
+    trace_dir = generate_traces(scenario)
+    try:
+        with ServerHarness(trace_dir) as srv:
+            tm = srv.query("time_model")
+            t.check_approx(lock_ms(tm), expected_lock_ms, 0.001,
+                           f"unclosed window clamps at last exact ts: "
+                           f"Lock = {expected_lock_ms:.0f}ms ({n_kept} kept)")
+            rows = {r["name"]: r for r in tm["rows"]}
+            t.check_approx(rows.get("IO", {}).get("ms", -1), 10_000.0, 0.001,
+                           "exact IO chain = 10000ms")
+    finally:
+        cleanup_traces(trace_dir)
+
+
+# ── 4. Multiple windows per file ──────────────────────────────────────
+
+def test_multiple_windows(t):
+    print("\n### 4. Two windows in one file; between-window samples survive ###")
+    a0, a1 = BASE + 10 * S, BASE + 20 * S
+    b0, b1 = BASE + 40 * S, BASE + 50 * S
+
+    events = [
+        esc_marker(a0, MARKER_ESC_START, 10, 0),
+        {"pid": 1000, "ts": a1, "dur": 10 * S,
+         "old": LOCK_RELATION, "new": CPU, "qid": 100},
+        esc_marker(a1, MARKER_ESC_END, 10, 2),
+        esc_marker(b0, MARKER_ESC_START, 10, 0),
+        {"pid": 1000, "ts": b1, "dur": 10 * S,
+         "old": LOCK_RELATION, "new": CPU, "qid": 100},
+        esc_marker(b1, MARKER_ESC_END, 10, 2),
+    ]
+    # Continuous sampling of pid 1000's lock over the whole range.
+    samples = sample_range(1000, a0 + PERIOD, b1 + 10 * S, LOCK_RELATION, 100)
+
+    n_dropped = dropped_by_rule(samples, [(a0, a1), (b0, b1)])
+    n_kept = len(samples) - n_dropped
+    expected_lock_ms = 20_000.0 + n_kept * (PERIOD / 1e6)
+
+    scenario = {
+        "backends": [{"pid": 1000, "type": "client", "user": "u", "db": "d"}],
+        "queries": [{"id": 100, "text": "Q1"}],
+        "events": events,
+        "sample_period_ns": PERIOD,
+        "samples": samples,
+        "interleave": 1,
+    }
+    trace_dir = generate_traces(scenario)
+    try:
+        with ServerHarness(trace_dir) as srv:
+            tm = srv.query("time_model")
+            t.check_approx(lock_ms(tm), expected_lock_ms, 0.001,
+                           f"two windows: Lock = {expected_lock_ms:.0f}ms "
+                           f"(2x10s exact + {n_kept} between/after samples)")
+    finally:
+        cleanup_traces(trace_dir)
+
+
+# ── 5. FID-7: window spans rotation, per-file offsets disagree ────────
+
+def test_cross_file_offsets(t):
+    print("\n### 5. FID-7: rotation mid-window + NTP step between files ###")
+    m0 = BASE + 10 * S        # START (file A)
+    m_rot = m0 + 10 * S       # rotation boundary
+    m1 = m0 + 20 * S          # END (file B)
+
+    # File A (rotated hour): START marker, exact IO 5s, samples up to m_rot.
+    # Its header gets a mono→wall offset of +5s (NTP stepped back 5s after
+    # this file was opened).
+    ev_a = [esc_marker(m0, MARKER_ESC_START, 20, 0)]
+    ts = m0 + PERIOD
+    while ts <= m0 + 5 * S:
+        ev_a.append({"pid": 1000, "ts": ts, "dur": PERIOD,
+                     "old": IO_DATA_FILE_READ, "new": CPU, "qid": 100})
+        ts += PERIOD
+    smp_a = sample_range(1001, m0 + PERIOD, m_rot - PERIOD, LOCK_RELATION, 200)
+
+    # File B (current): window continues — exact IO again, END marker at m1,
+    # then a sampled-only tail. Offset 0.
+    ev_b = []
+    ts = m_rot + PERIOD
+    while ts <= m_rot + 5 * S:
+        ev_b.append({"pid": 1000, "ts": ts, "dur": PERIOD,
+                     "old": IO_DATA_FILE_READ, "new": CPU, "qid": 100})
+        ts += PERIOD
+    ev_b.append(esc_marker(m1, MARKER_ESC_END, 20, 2))
+    smp_b = (sample_range(1001, m_rot, m1, LOCK_RELATION, 200) +
+             sample_range(1001, m1 + PERIOD, m1 + 5 * S, LOCK_RELATION, 200))
+    smp_b.sort(key=lambda s: s["ts"])
+
+    # Ground truth in the MONO domain: every lock sample whose midpoint is in
+    # [m0, m1] is covered by the window — regardless of which file it is in
+    # and regardless of the files' disagreeing wall offsets. File A's
+    # unclosed portion is closed by file B's END marker (same clock domain).
+    all_samples = smp_a + smp_b
+    n_dropped = dropped_by_rule(all_samples, [(m0, m1)])
+    n_kept = len(all_samples) - n_dropped
+    expected_lock_ms = n_kept * (PERIOD / 1e6)
+    expected_io_ms = (len(ev_a) - 1 + len(ev_b) - 1) * (PERIOD / 1e6)
+
+    backends = [{"pid": 1000, "type": "client", "user": "u", "db": "d"},
+                {"pid": 1001, "type": "client", "user": "u", "db": "d"}]
+    queries = [{"id": 100, "text": "Q1"}, {"id": 200, "text": "Q2"}]
+
+    trace_dir = generate_traces(
+        {"backends": backends, "queries": queries, "events": ev_a,
+         "sample_period_ns": PERIOD, "samples": smp_a, "interleave": 1},
+        wall_offset_ns=5 * S, rotate="2025-01-01_10")
+    generate_traces(
+        {"backends": backends, "queries": queries, "events": ev_b,
+         "sample_period_ns": PERIOD, "samples": smp_b, "interleave": 1},
+        output_dir=trace_dir, wall_offset_ns=0)
+
+    try:
+        with ServerHarness(trace_dir) as srv:
+            tm = srv.query("time_model")
+            t.check_approx(lock_ms(tm), expected_lock_ms, 0.001,
+                           f"cross-file merge in mono domain: Lock = "
+                           f"{expected_lock_ms:.0f}ms ({n_kept} samples kept)")
+            rows = {r["name"]: r for r in tm["rows"]}
+            t.check_approx(rows.get("IO", {}).get("ms", -1),
+                           expected_io_ms, 0.001,
+                           f"exact IO across both files = {expected_io_ms:.0f}ms")
+
+            # Re-anchored wall mapping: with the canonical (newest-file)
+            # offset, wall == mono for the whole generation, so a query
+            # sliced at the window end must see exactly the sampled tail.
+            ev = srv.query("top_events",
+                           from_=m1 + PERIOD // 2, to_=m1 + 6 * S)
+            evrows = {r["name"]: r for r in ev["rows"]}
+            tail = [s for s in smp_b if s["ts"] > m1]
+            t.check_approx(evrows.get("Lock:relation", {}).get("total_ms", -1),
+                           len(tail) * (PERIOD / 1e6), 0.05,
+                           "post-window slice sees only the sampled tail "
+                           "(consistent re-anchored wall mapping)")
+    finally:
+        cleanup_traces(trace_dir)
+
+
+def main():
+    t = TestRunner("test_data_esc_coverage")
+    print(f"=== {t.name} ===")
+    test_long_wait_window(t)
+    test_boundary_rule(t)
+    test_crash_mid_window(t)
+    test_multiple_windows(t)
+    test_cross_file_offsets(t)
+    sys.exit(0 if t.summary() else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_data_fidelity.py
+++ b/tests/test_data_fidelity.py
@@ -119,6 +119,12 @@ def test_sampled_only(t):
             io = evrows.get("IO:DataFileRead", {})
             t.check_eq(io.get("count"), 10, "IO:DataFileRead sample count = 10")
 
+            # FID-3: latency columns are fabrications over sampled data —
+            # gated (null) on sampled-only rows; count/total stay valid.
+            for col in ("avg_us", "p50_us", "p95_us", "p99_us", "max_us"):
+                t.check(io.get(col, "missing") is None,
+                        f"sampled-only row gates latency column {col}")
+
             # --- AAS: active-sample-time / window ---
             # 28 total samples span (28-1) periods = 2700ms of wall-clock.
             # The harness queries the full file range. Verify AAS integrates
@@ -167,10 +173,11 @@ def test_exact_unavailable(t):
 def build_mixed():
     """Transition coverage overlapping a continuous sample stream.
 
-    The exact-wins merge (D3) drops any sample whose timestamp falls inside
-    a TRANSITIONS block's [first_ts, last_ts] span — i.e. the span of the
-    transition events' timestamps. So the transition block must actually
-    SPAN the overlap window.
+    This trace has samples + transitions but NO escalation markers, so the
+    exact-wins merge uses the LEGACY per-TRANSITIONS-block coverage
+    (marker windows are the authority when markers exist — see
+    test_data_esc_coverage.py). The transition block must therefore
+    actually SPAN the overlap window.
 
     TRANSITIONS (exact) for PID 1000: a chain of IO:DataFileRead intervals
     with event timestamps from BASE+1.0s to BASE+2.0s (the block's
@@ -178,10 +185,10 @@ def build_mixed():
     exact IO total over the window is 11 * 100ms = 1100ms.
 
     SAMPLES (10 Hz) of Lock:relation run continuously over
-    [BASE+1.0s .. BASE+4.0s] (31 samples). Samples whose ts is in
-    [1.0s, 2.0s] (11 of them) are DROPPED — transition data is
-    authoritative there. The remaining 20 out-of-range samples each add
-    100ms → 2000ms of Lock. No double counting in the overlap.
+    [BASE+1.0s .. BASE+4.0s] (31 samples). Boundary rule (FID-6): a sample
+    represents (ts − period, ts] and is dropped iff its MIDPOINT
+    (ts − period/2) lies inside the covered span. Surviving samples each
+    add 100ms of Lock. No double counting in the overlap.
     """
     one_s = 1_000_000_000
     trans_start = BASE_TS + one_s
@@ -206,9 +213,9 @@ def build_mixed():
         ts += PERIOD
     samples.sort(key=lambda s: s["ts"])
 
-    # Samples inside the transition block span [first_ts, last_ts] are dropped.
+    # Midpoint rule: dropped iff (ts - PERIOD/2) in [first_ts, last_ts].
     in_range = sum(1 for s in samples
-                   if trans_start <= s["ts"] <= trans_end)
+                   if trans_start <= s["ts"] - PERIOD // 2 <= trans_end)
     out_range = len(samples) - in_range
 
     return ({
@@ -252,6 +259,17 @@ def test_mixed_merge(t):
                     "transitions available in a mixed window (has exact data)")
             t.check_eq(tr.get("fidelity"), "mixed",
                        "transitions fidelity = mixed")
+
+            # FID-3 in a mixed window: exact-fed rows keep real latency
+            # stats, sampled-only rows gate them.
+            ev = srv.query("top_events")
+            evrows = {r["name"]: r for r in ev["rows"]}
+            io = evrows.get("IO:DataFileRead", {})
+            lk = evrows.get("Lock:relation", {})
+            t.check(isinstance(io.get("p95_us"), (int, float)),
+                    "mixed window: exact-fed row keeps numeric p95")
+            t.check(lk.get("p95_us", "missing") is None,
+                    "mixed window: sampled-only row gates p95 (null)")
     finally:
         cleanup_traces(trace_dir)
 

--- a/tests/test_data_markers.py
+++ b/tests/test_data_markers.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""test_data_markers.py — T1/FID-4: lifecycle + escalation markers must
+never leak into wait accounting.
+
+Markers (EXEC/PLAN_START/END, ESCALATE_START/END) are structural records:
+duration 0, old_event = new_event = a 0xFFFFFFFx sentinel, and — for
+escalation markers — a PGWT_ESC_PACK(secs, reason) payload in query_id.
+
+Before the fix:
+  * the summary writer accumulated markers (event_stream pushed them before
+    its own PGWT_IS_MARKER check): exec/plan markers inflated per-query
+    counts (skewing avg_us low) and escalation markers inserted bogus
+    query_ids into summaries;
+  * in raw compute only transitions/variants filtered markers — top_events,
+    top_queries, heatmap, sessions, timeline did not. T0's live run showed
+    the symptom directly: "Unknown:id=1677720x" rows in top_events.
+
+The fix filters markers at two chokepoints (pgwt_filter_matches for all raw
+compute; summary accum_event for summaries) while variants and the exec/plan
+lifecycle stats — which legitimately CONSUME markers — keep working.
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(__file__))
+from server_harness import (
+    ServerHarness, generate_traces, cleanup_traces, TestRunner,
+    CPU, IO_DATA_FILE_READ,
+)
+
+BASE = 10_000_000_000_000
+S = 1_000_000_000
+MS = 1_000_000
+
+MARKER_EXEC_START = 0xFFFFFFF0
+MARKER_EXEC_END   = 0xFFFFFFF1
+MARKER_PLAN_START = 0xFFFFFFF2
+MARKER_PLAN_END   = 0xFFFFFFF3
+MARKER_ESC_START  = 0xFFFFFFF4
+MARKER_ESC_END    = 0xFFFFFFF5
+
+ESC_QID_START = (60 << 8) | 1   # PGWT_ESC_PACK(60, ANOMALY)
+ESC_QID_END   = (60 << 8) | 2   # PGWT_ESC_PACK(60, EXPIRED)
+
+# Marker event ids as they'd appear mislabeled in top_events:
+# WE_EVENT(0xFFFFFFF0) = 16777200 .. 16777205 → "Unknown:id=1677720x"
+PHANTOM_ID_LOW = 0xFFFFFFF0 & 0x00FFFFFF
+
+
+def marker(pid, ts, mk, qid):
+    return {"pid": pid, "ts": ts, "dur": 0, "old": mk, "new": mk, "qid": qid}
+
+
+def build_scenario():
+    """3 real IO waits of 10ms inside an exec span, plus every marker type."""
+    events = [
+        marker(0, BASE - 5 * MS, MARKER_ESC_START, ESC_QID_START),
+        marker(1000, BASE - 2 * MS, MARKER_PLAN_START, 100),
+        marker(1000, BASE - 1 * MS, MARKER_PLAN_END, 100),
+        marker(1000, BASE, MARKER_EXEC_START, 100),
+        {"pid": 1000, "ts": BASE + 10 * MS, "dur": 10 * MS,
+         "old": IO_DATA_FILE_READ, "new": CPU, "qid": 100},
+        {"pid": 1000, "ts": BASE + 30 * MS, "dur": 10 * MS,
+         "old": IO_DATA_FILE_READ, "new": CPU, "qid": 100},
+        {"pid": 1000, "ts": BASE + 50 * MS, "dur": 10 * MS,
+         "old": IO_DATA_FILE_READ, "new": CPU, "qid": 100},
+        marker(1000, BASE + 60 * MS, MARKER_EXEC_END, 100),
+        marker(0, BASE + 70 * MS, MARKER_ESC_END, ESC_QID_END),
+    ]
+    return {
+        "backends": [{"pid": 1000, "type": "client", "user": "u", "db": "d"}],
+        "queries": [{"id": 100, "text": "SELECT io()"}],
+        "events": events,
+    }
+
+
+def check_views(t, srv, label, frm=None, to=None):
+    kw = {}
+    if frm is not None:
+        kw = {"from_": frm, "to_": to}
+
+    ev = srv.query("top_events", **kw)
+    phantom = [r for r in ev["rows"]
+               if r["event_id"] >= 0xFFFFFFF0
+               or "Unknown:id=1677720" in r["name"]]
+    t.check(not phantom,
+            f"[{label}] no phantom marker rows in top_events "
+            f"(got: {[r['name'] for r in phantom]})")
+    evrows = {r["name"]: r for r in ev["rows"]}
+    io = evrows.get("IO:DataFileRead", {})
+    t.check_eq(io.get("count"), 3, f"[{label}] IO count = 3 (not inflated)")
+    t.check_approx(io.get("total_ms", -1), 30.0, 0.001,
+                   f"[{label}] IO total = 30ms")
+    t.check_approx(ev.get("db_time_ms", -1), 30.0, 0.001,
+                   f"[{label}] db_time = 30ms (markers contribute nothing)")
+
+    qr = srv.query("top_queries", **kw)
+    qids = {r["query_id"] for r in qr["rows"]}
+    t.check(str(ESC_QID_START) not in qids and str(ESC_QID_END) not in qids,
+            f"[{label}] no phantom PGWT_ESC_PACK query_ids in top_queries")
+    qrow = next((r for r in qr["rows"] if r["query_id"] == "100"), {})
+    t.check_eq(qrow.get("count"), 3,
+               f"[{label}] qid 100 wait count = 3 (markers don't inflate)")
+    t.check_approx(qrow.get("avg_us", -1), 10_000.0, 0.001,
+                   f"[{label}] qid 100 avg = 10ms (not skewed low)")
+
+
+def test_raw_path(t):
+    print("\n### 1. Raw compute path: markers filtered everywhere ###")
+    trace_dir = generate_traces(build_scenario())
+    try:
+        with ServerHarness(trace_dir) as srv:
+            check_views(t, srv, "raw")
+
+            hm = srv.query("heatmap")
+            t.check_eq(hm.get("total_events"), 3,
+                       "heatmap counts only the 3 real waits")
+
+            tl = srv.query("session_timeline")
+            bad = [e for e in tl["events"] if e["e"] >= 0xFFFFFFF0]
+            t.check(not bad, "session_timeline has no marker bars")
+
+            fp = srv.query("fingerprints")
+            frow = next((r for r in fp["rows"]
+                         if str(r["query_id"]) == "100"), {})
+            t.check_eq(frow.get("transitions"), 3,
+                       "fingerprints transitions = 3 (marker hops excluded)")
+
+            sess = srv.query("top_sessions")
+            t.check(all(r["pid"] != 0 for r in sess["rows"]),
+                    "no pid-0 (escalation marker) session row")
+
+            # Consumers that legitimately need markers still work:
+            va = srv.query("variants")
+            t.check_eq(va.get("exec", {}).get("total"), 1,
+                       "variants still sees the exec span (1 execution)")
+            qr = srv.query("top_queries")
+            qrow = next((r for r in qr["rows"]
+                         if r["query_id"] == "100"), {})
+            t.check_eq(qrow.get("exec_count"), 1,
+                       "top_queries lifecycle exec_count still = 1")
+            t.check_eq(qrow.get("plan_count"), 1,
+                       "top_queries lifecycle plan_count still = 1")
+    finally:
+        cleanup_traces(trace_dir)
+
+
+def test_summary_path(t):
+    print("\n### 2. Summary path: markers never accumulated ###")
+    trace_dir = generate_traces(build_scenario())
+    try:
+        with ServerHarness(trace_dir) as srv:
+            # Force the summary fast path with a >= 120 s window around the
+            # data (the trace is exact-only, so summaries stay authoritative).
+            frm, to = BASE - 100 * S, BASE + 100 * S
+            check_views(t, srv, "summary", frm=frm, to=to)
+    finally:
+        cleanup_traces(trace_dir)
+
+
+def main():
+    t = TestRunner("test_data_markers")
+    print(f"=== {t.name} ===")
+    test_raw_path(t)
+    test_summary_path(t)
+    sys.exit(0 if t.summary() else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_data_summary_honesty.py
+++ b/tests/test_data_summary_honesty.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""test_data_summary_honesty.py — T1/FID-2: the summary fast-path must be
+coverage-aware and the fidelity label must reflect the actual data source.
+
+Before the fix, should_use_summaries() selected the summary path on range
+length alone (>= 120 s) and stamped "fidelity":"exact" — but summaries are
+fed only by the exact (watchpoint) path. In the DEFAULT tiered mode a
+"last 15 minutes" query therefore returned escalation slivers or nothing,
+labeled exact: the worst possible violation of "never a silent empty
+result" and of the standing rule that "last 15 min must mean NOW".
+
+After the fix:
+  * a >= 120 s window whose sampled data is not fully covered by exact data
+    falls back to the raw (merge) path → correct ASH-estimated values,
+    honest "sampled"/"mixed" label;
+  * a >= 120 s window fully covered by exact data still uses the summary
+    fast path and is honestly labeled "exact";
+  * a window with no data at all is labeled "none" — never "exact".
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(__file__))
+from server_harness import (
+    ServerHarness, generate_traces, cleanup_traces, TestRunner,
+    CPU, IO_DATA_FILE_READ,
+)
+
+BASE = 10_000_000_000_000
+S = 1_000_000_000
+PERIOD = 1 * S      # 1 Hz sampling keeps the sample count small
+
+
+def build_tiered_15min():
+    """Default-tiered 'last 15 minutes': sampled data only (no escalation
+    ever fired). 900 IO samples at 1 Hz = 900 s of estimated IO time."""
+    samples = []
+    ts = BASE
+    for _ in range(900):
+        ts += PERIOD
+        samples.append({"pid": 1000, "ts": ts, "event": IO_DATA_FILE_READ,
+                        "qid": 100})
+    return {
+        "backends": [{"pid": 1000, "type": "client", "user": "u", "db": "d"}],
+        "queries": [{"id": 100, "text": "SELECT 1"}],
+        "sample_period_ns": PERIOD,
+        "samples": samples,
+    }, BASE, ts
+
+
+def test_tiered_15min(t):
+    print("\n### 1. FID-2: 15-min tiered window returns the sampled data ###")
+    scenario, lo, hi = build_tiered_15min()
+    trace_dir = generate_traces(scenario)
+    try:
+        with ServerHarness(trace_dir) as srv:
+            frm, to = lo - 10 * S, hi + 10 * S   # ~920 s >= 120 s threshold
+            expected_ms = 900 * (PERIOD / 1e6)   # 900 samples * 1 s
+
+            tm = srv.query("time_model", from_=frm, to_=to)
+            rows = {r["name"]: r for r in tm["rows"]}
+            t.check_eq(tm.get("fidelity"), "sampled",
+                       "time_model over sampled-only 15 min: fidelity=sampled")
+            t.check_approx(rows.get("DB Time", {}).get("ms", -1),
+                           expected_ms, 0.001,
+                           f"DB Time = {expected_ms:.0f}ms (never silent-empty)")
+
+            ev = srv.query("top_events", from_=frm, to_=to)
+            t.check_eq(ev.get("fidelity"), "sampled",
+                       "top_events fidelity=sampled")
+            evrows = {r["name"]: r for r in ev["rows"]}
+            t.check_approx(evrows.get("IO:DataFileRead", {}).get("total_ms", -1),
+                           expected_ms, 0.001,
+                           "top_events IO total from samples")
+            # FID-3: latency columns are fabrications over sampled data —
+            # they must be gated (null), not presented like measurements.
+            io = evrows.get("IO:DataFileRead", {})
+            for col in ("avg_us", "p50_us", "p95_us", "p99_us", "max_us"):
+                t.check(io.get(col, "missing") is None,
+                        f"sampled row gates latency column {col} (null)")
+
+            qr = srv.query("top_queries", from_=frm, to_=to)
+            t.check_eq(qr.get("fidelity"), "sampled",
+                       "top_queries fidelity=sampled")
+            qrows = {r["query_id"]: r for r in qr["rows"]}
+            t.check_approx(qrows.get("100", {}).get("total_ms", -1),
+                           expected_ms, 0.001, "top_queries qid 100 total")
+
+            aas = srv.query("aas", from_=frm, to_=to, buckets=10)
+            t.check_eq(aas.get("fidelity"), "sampled", "aas fidelity=sampled")
+            active_ms = sum(
+                v * aas["bucket_ns"] / 1e6
+                for b in aas["buckets"]
+                for k, v in b.items()
+                if k != "t" and isinstance(v, (int, float)))
+            t.check_approx(active_ms, expected_ms, 0.02,
+                           "aas integrates to the sampled DB time")
+
+            sess = srv.query("top_sessions", from_=frm, to_=to)
+            t.check_eq(sess.get("fidelity"), "sampled",
+                       "top_sessions fidelity=sampled")
+            t.check(any(r["pid"] == 1000 for r in sess["rows"]),
+                    "top_sessions shows the sampled session")
+    finally:
+        cleanup_traces(trace_dir)
+
+
+def build_full_300s():
+    """--mode full style trace: exact transitions only, spanning 300 s."""
+    events = []
+    ts = BASE
+    for i in range(300):
+        ts += S
+        events.append({"pid": 1000, "ts": ts, "dur": S,
+                       "old": IO_DATA_FILE_READ if i % 2 else CPU,
+                       "new": CPU, "qid": 100})
+    return {
+        "backends": [{"pid": 1000, "type": "client", "user": "u", "db": "d"}],
+        "queries": [{"id": 100, "text": "SELECT 1"}],
+        "events": events,
+    }, BASE, ts
+
+
+def test_full_mode_still_fast(t):
+    print("\n### 2. Exact-covered long window keeps the summary path ###")
+    scenario, lo, hi = build_full_300s()
+    trace_dir = generate_traces(scenario)
+    try:
+        with ServerHarness(trace_dir) as srv:
+            frm, to = lo - 10 * S, hi + 10 * S
+            tm = srv.query("time_model", from_=frm, to_=to)
+            rows = {r["name"]: r for r in tm["rows"]}
+            t.check_eq(tm.get("fidelity"), "exact",
+                       "fully exact-covered window labeled exact")
+            t.check_approx(rows.get("DB Time", {}).get("ms", -1),
+                           300_000.0, 0.001, "DB Time = 300s from summaries")
+
+            # A window with NO data must be labeled none — never exact.
+            empty = srv.query("time_model",
+                              from_=hi + 1000 * S, to_=hi + 1200 * S)
+            t.check_eq(empty.get("fidelity"), "none",
+                       "empty >=120s window labeled 'none', not 'exact'")
+            erows = {r["name"]: r for r in empty["rows"]}
+            t.check_approx(erows.get("DB Time", {}).get("ms", -1), 0.0, 0.001,
+                           "empty window DB Time = 0")
+    finally:
+        cleanup_traces(trace_dir)
+
+
+def main():
+    t = TestRunner("test_data_summary_honesty")
+    print(f"=== {t.name} ===")
+    test_tiered_15min(t)
+    test_full_mode_still_fast(t)
+    sys.exit(0 if t.summary() else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_event_reader.c
+++ b/tests/test_event_reader.c
@@ -279,7 +279,9 @@ static void test_time_range_replay(void)
     CHECK(pgwt_reader_open(&reader, path) == 0, "reader_open");
 
     struct pgwt_trace_event *decoded = calloc(PGWT_BLOCK_EVENTS, sizeof(*decoded));
-    int count = pgwt_reader_decode_block(&reader, 0, decoded, PGWT_BLOCK_EVENTS);
+    struct pgwt_block_info binfo;
+    int count = pgwt_reader_decode_block_info(&reader, 0, decoded,
+                                              PGWT_BLOCK_EVENTS, &binfo);
     CHECK(count == N, "decoded count=%d", count);
 
     /* Replay with time bounds: skip first 50, take next 100 */
@@ -288,7 +290,7 @@ static void test_time_range_replay(void)
 
     struct pgwt_accumulator *acc = calloc(1, sizeof(*acc));
     pgwt_accum_init(acc);
-    pgwt_replay_events(acc, decoded, count, from_mono, to_mono);
+    pgwt_replay_events(acc, decoded, count, from_mono, to_mono, &binfo, NULL);
 
     /* Should have accumulated ~101 events (50..150 inclusive) */
     CHECK(acc->num_system_events > 0, "system events accumulated");
@@ -304,7 +306,7 @@ static void test_time_range_replay(void)
 
     /* Replay all events (no bounds) */
     pgwt_accum_init(acc);
-    pgwt_replay_events(acc, decoded, count, 0, 0);
+    pgwt_replay_events(acc, decoded, count, 0, 0, &binfo, NULL);
     se = pgwt_find_system_event(acc, 0x0A000001);
     CHECK(se != NULL, "system event found (full)");
     if (se) {
@@ -535,12 +537,14 @@ static void test_replay_time_model(void)
     CHECK(pgwt_reader_open(&reader, path) == 0, "reader_open");
 
     struct pgwt_trace_event *decoded = calloc(PGWT_BLOCK_EVENTS, sizeof(*decoded));
-    int count = pgwt_reader_decode_block(&reader, 0, decoded, PGWT_BLOCK_EVENTS);
+    struct pgwt_block_info binfo;
+    int count = pgwt_reader_decode_block_info(&reader, 0, decoded,
+                                              PGWT_BLOCK_EVENTS, &binfo);
     CHECK(count == N, "decoded count=%d", count);
 
     struct pgwt_accumulator *acc = calloc(1, sizeof(*acc));
     pgwt_accum_init(acc);
-    pgwt_replay_events(acc, decoded, count, 0, 0);
+    pgwt_replay_events(acc, decoded, count, 0, 0, &binfo, NULL);
 
     /* Verify time model */
     CHECK(acc->tm.cpu_time_ns == 20 * 1000ULL,

--- a/tests/test_replay_fidelity.c
+++ b/tests/test_replay_fidelity.c
@@ -1,0 +1,227 @@
+/* test_replay_fidelity.c — T1/FID-5: --replay is fidelity-aware.
+ *
+ * Before the fix, pgwt_replay_events consumed old_event/duration_ns
+ * blindly: decoded SAMPLES records (old_event = 0, duration = 0) inflated
+ * the CPU bucket's count while contributing zero time — a tiered trace
+ * replayed as a near-idle database — and markers created junk "Unknown"
+ * entries in every accumulator table.
+ *
+ * This test writes a synthetic trace (transitions with exec + escalation
+ * markers, then a SAMPLES block) through the real writer, decodes it with
+ * the real reader, replays it through the real accumulation, and asserts:
+ *   - exact waits accumulate exactly (count, total, histogram);
+ *   - each sample is worth one sample_period_ns of estimated time for
+ *     counts / time model / per-query totals;
+ *   - samples contribute NOTHING to histograms/min/max (no fabricated
+ *     latencies) and do not inflate the CPU bucket;
+ *   - markers are skipped everywhere (no marker-id event entries, no
+ *     PGWT_ESC_PACK query ids);
+ *   - the replay stats report what was accumulated (for the loud notice).
+ *
+ * Links the BPF-free accumulator core (map_reader.c with -DPGWT_SERVER)
+ * plus the daemon-flavor event_reader.c — no bpftool needed.
+ */
+#include "event_reader.h"
+#include "event_writer.h"
+#include "map_reader.h"
+#include "wait_event.h"
+#include "pg_wait_tracer.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/stat.h>
+
+#define IO_READ  0x0A000015u   /* IO:DataFileRead */
+#define LOCK_REL 0x03000000u   /* Lock:relation */
+
+static int failures = 0;
+
+#define CHECK(cond, msg) do { \
+    if (cond) { printf("  PASS: %s\n", msg); } \
+    else      { printf("  FAIL: %s\n", msg); failures++; } \
+} while (0)
+
+#define CHECK_EQ_U64(got, want, msg) do { \
+    uint64_t g_ = (got), w_ = (want); \
+    if (g_ == w_) { printf("  PASS: %s\n", msg); } \
+    else { printf("  FAIL: %s (got %llu, want %llu)\n", msg, \
+                  (unsigned long long)g_, (unsigned long long)w_); \
+           failures++; } \
+} while (0)
+
+static struct pgwt_trace_event ev(uint32_t pid, uint64_t ts, uint64_t dur,
+                                  uint32_t old_e, uint32_t new_e,
+                                  uint64_t qid)
+{
+    struct pgwt_trace_event e = {0};
+    e.pid = pid;
+    e.timestamp_ns = ts;
+    e.duration_ns = dur;
+    e.old_event = old_e;
+    e.new_event = new_e;
+    e.query_id = qid;
+    return e;
+}
+
+static const struct pgwt_event_stats *
+find_sys(const struct pgwt_accumulator *acc, uint32_t we)
+{
+    for (int i = 0; i < acc->num_system_events; i++)
+        if (acc->system_events[i].wait_event == we &&
+            acc->system_events[i].count > 0)
+            return &acc->system_events[i];
+    return NULL;
+}
+
+int main(void)
+{
+    char dir[] = "/tmp/pgwt_replay_fid_XXXXXX";
+    if (!mkdtemp(dir)) { perror("mkdtemp"); return 1; }
+
+    const uint64_t BASE = 10000000000000ULL;   /* 10000 s */
+    const uint64_t MS = 1000000ULL;
+    const uint64_t PERIOD = 100 * MS;          /* 100 ms */
+
+    /* ── Write the trace ─────────────────────────────────── */
+    struct pgwt_event_writer w;
+    if (pgwt_writer_init(&w, dir, 18, 24, NULL) != 0) {
+        fprintf(stderr, "writer init failed\n");
+        return 1;
+    }
+
+    struct pgwt_trace_event trans[] = {
+        /* escalation START marker (pid 0, ESC_PACK payload) */
+        ev(0, BASE, 0, PGWT_MARKER_ESCALATE_START, PGWT_MARKER_ESCALATE_START,
+           PGWT_ESC_PACK(60, 1)),
+        /* exec markers around two real IO waits of 10 ms */
+        ev(1000, BASE + 1 * MS, 0, PGWT_MARKER_EXEC_START,
+           PGWT_MARKER_EXEC_START, 100),
+        ev(1000, BASE + 20 * MS, 10 * MS, IO_READ, 0, 100),
+        ev(1000, BASE + 40 * MS, 10 * MS, IO_READ, 0, 100),
+        ev(1000, BASE + 41 * MS, 0, PGWT_MARKER_EXEC_END,
+           PGWT_MARKER_EXEC_END, 100),
+        /* escalation END marker */
+        ev(0, BASE + 50 * MS, 0, PGWT_MARKER_ESCALATE_END,
+           PGWT_MARKER_ESCALATE_END, PGWT_ESC_PACK(60, 2)),
+    };
+    for (size_t i = 0; i < sizeof(trans) / sizeof(trans[0]); i++)
+        pgwt_writer_push_event(&w, &trans[i]);
+
+    /* 5 Lock samples for pid 1001 / query 200 at 100 ms period */
+    struct pgwt_trace_event smp[5];
+    for (int i = 0; i < 5; i++) {
+        smp[i] = ev(1001, BASE + 100 * MS + (uint64_t)i * PERIOD, 0,
+                    0, LOCK_REL, 200);
+    }
+    pgwt_writer_push_samples(&w, smp, 5, PERIOD);
+    pgwt_writer_close(&w);
+    pgwt_writer_destroy(&w);
+
+    /* ── Read + replay ───────────────────────────────────── */
+    char trace_path[600];
+    snprintf(trace_path, sizeof(trace_path), "%s/current.trace", dir);
+
+    struct pgwt_event_reader r;
+    if (pgwt_reader_open(&r, trace_path) != 0) {
+        fprintf(stderr, "reader open failed\n");
+        return 1;
+    }
+    CHECK(r.num_blocks >= 2, "trace has transitions + samples blocks");
+
+    struct pgwt_accumulator *acc = malloc(sizeof(*acc));
+    pgwt_accum_init(acc);
+    struct pgwt_replay_stats st = {0};
+    struct pgwt_trace_event *buf = malloc(PGWT_BLOCK_EVENTS * sizeof(*buf));
+
+    for (int b = 0; b < r.num_blocks; b++) {
+        struct pgwt_block_info bi;
+        int n = pgwt_reader_decode_block_info(&r, b, buf,
+                                              PGWT_BLOCK_EVENTS, &bi);
+        if (n <= 0) continue;
+        pgwt_replay_events(acc, buf, n, 0, 0, &bi, &st);
+    }
+    pgwt_reader_close(&r);
+
+    /* ── Assertions ──────────────────────────────────────── */
+
+    /* Replay stats (drive the loud fidelity notice) */
+    CHECK_EQ_U64(st.transitions, 2, "2 exact transitions accumulated");
+    CHECK_EQ_U64(st.samples, 5, "5 samples accumulated");
+    CHECK_EQ_U64(st.markers_skipped, 4, "4 markers skipped");
+    CHECK_EQ_U64(st.sample_period_ns, PERIOD, "sample period reported");
+
+    /* Exact IO wait: full stats including histogram */
+    const struct pgwt_event_stats *io = find_sys(acc, IO_READ);
+    CHECK(io != NULL, "IO:DataFileRead entry exists");
+    if (io) {
+        CHECK_EQ_U64(io->count, 2, "IO count = 2");
+        CHECK_EQ_U64(io->total_ns, 20 * MS, "IO total = 20 ms (exact)");
+        uint64_t hist_total = 0;
+        for (int i = 0; i < HISTOGRAM_BUCKETS; i++)
+            hist_total += io->histogram[i];
+        CHECK_EQ_U64(hist_total, 2, "IO histogram fed by exact records");
+        CHECK_EQ_U64(io->max_ns, 10 * MS, "IO max = 10 ms");
+    }
+
+    /* Sampled Lock wait: ASH-estimated time, NO histogram/min/max */
+    const struct pgwt_event_stats *lk = find_sys(acc, LOCK_REL);
+    CHECK(lk != NULL, "Lock:relation entry exists (samples visible)");
+    if (lk) {
+        CHECK_EQ_U64(lk->count, 5, "Lock count = 5 samples");
+        CHECK_EQ_U64(lk->total_ns, 5 * PERIOD,
+                     "Lock total = 5 x period (ASH estimate, not 0)");
+        uint64_t hist_total = 0;
+        for (int i = 0; i < HISTOGRAM_BUCKETS; i++)
+            hist_total += lk->histogram[i];
+        CHECK_EQ_U64(hist_total, 0,
+                     "Lock histogram EMPTY (no fabricated latencies)");
+        CHECK_EQ_U64(lk->max_ns, 0, "Lock max not fabricated");
+    }
+
+    /* Samples must NOT be misread as CPU (old_event = 0 on the wire) */
+    const struct pgwt_event_stats *cpu = find_sys(acc, 0);
+    CHECK(cpu == NULL, "no phantom CPU entries from sample records");
+
+    /* Markers create no event entries and no phantom query ids */
+    int marker_entries = 0;
+    for (int i = 0; i < acc->num_system_events; i++)
+        if (PGWT_IS_MARKER(acc->system_events[i].wait_event) &&
+            acc->system_events[i].count > 0)
+            marker_entries++;
+    CHECK_EQ_U64(marker_entries, 0, "no marker entries in system events");
+
+    int esc_qids = 0;
+    uint64_t q100_ns = 0, q200_ns = 0;
+    for (int i = 0; i < acc->num_query_events; i++) {
+        const struct pgwt_query_event_stats *qe = &acc->query_events[i];
+        if (qe->count == 0) continue;
+        if (qe->query_id == PGWT_ESC_PACK(60, 1) ||
+            qe->query_id == PGWT_ESC_PACK(60, 2))
+            esc_qids++;
+        if (qe->query_id == 100) q100_ns += qe->total_ns;
+        if (qe->query_id == 200) q200_ns += qe->total_ns;
+    }
+    CHECK_EQ_U64(esc_qids, 0, "no PGWT_ESC_PACK phantom query ids");
+    CHECK_EQ_U64(q100_ns, 20 * MS, "query 100 total = exact 20 ms");
+    CHECK_EQ_U64(q200_ns, 5 * PERIOD, "query 200 total = 5 x period");
+
+    /* Time model: lock class = sampled estimate, io class = exact */
+    CHECK_EQ_U64(acc->tm.lock_time_ns, 5 * PERIOD,
+                 "time model Lock = 500 ms (sampled, was 0 before fix)");
+    CHECK_EQ_U64(acc->tm.io_time_ns, 20 * MS, "time model IO = 20 ms");
+    CHECK_EQ_U64(acc->tm.db_time_ns, 20 * MS + 5 * PERIOD,
+                 "time model DB time = exact + sampled");
+
+    free(buf);
+    free(acc);
+
+    /* cleanup */
+    char cmd[700];
+    snprintf(cmd, sizeof(cmd), "rm -rf %s", dir);
+    if (system(cmd) != 0) { /* best effort */ }
+
+    printf("%s\n", failures == 0 ? "ALL PASSED" : "FAILURES");
+    return failures == 0 ? 0 : 1;
+}

--- a/tests/unit_tests.list
+++ b/tests/unit_tests.list
@@ -20,3 +20,4 @@ test_concurrent_rw
 test_pg13_resolve
 test_discovery_pie
 test_discovery_nopie
+test_replay_fidelity

--- a/web/static/lib/format.js
+++ b/web/static/lib/format.js
@@ -93,6 +93,9 @@ export function fmtCount(n) {
 export function fmtPct(p) { return p.toFixed(1) + '%'; }
 export function fmtAas(a) { return a.toFixed(2); }
 export function fmtUs(us) {
+    // null = gated latency column (sampled-only row, no real durations —
+    // T1/FID-3); render as em-dash like fmtMs does.
+    if (us == null || isNaN(us)) return '—';
     if (us >= 1e6) return (us / 1e6).toFixed(1) + 's';
     if (us >= 1000) return (us / 1000).toFixed(1) + 'ms';
     return us.toFixed(0) + 'µs';


### PR DESCRIPTION
Phase T1 of the Trust Milestone (docs/TRUST_MILESTONE_PLAN.md). Owns FID-1..5 + FID-7 (and FID-6, folded into FID-1 per the plan). Every fix ships with a regression test that fails against master's pgwt-server and passes after.

## FID-1 (critical) — escalation markers are now the exact-wins coverage authority

Coverage was derived from TRANSITIONS-block `[first_ts, last_ts]` ranges, but transition timestamps are wait-**end** times: a 60 s lock wait emits nothing until it ends, so its interior samples survived the merge AND the exact interval landed → up to 2× on long waits inside escalation windows. Coverage is now built from the `PGWT_MARKER_ESCALATE_START/END` markers the daemon already writes.

Edge-case decisions (documented in the coverage block comment in `src/server.c` and pinned by tests):

- **Crash / still-open window (START, no END):** the window clamps to the last committed TRANSITIONS-block timestamp — exact coverage never extends past the last exact evidence. A still-running wait stays visible through its samples until its transition lands; then the samples are dropped. Exactly-once either way.
- **END with no START** (window opened before this file; older file rotated/deleted): covers from the file's first block.
- **`--mode full` files** (transitions, no SAMPLES blocks): whole-file coverage.
- **Legacy tiered files** (samples + transitions, no markers anywhere): fall back to the old per-block coverage.
- Multiple windows per file and windows spanning rotation are handled by a generation-wide marker state machine.

## FID-6 — boundary rule

A sample represents `(ts − period, ts]`; it is dropped iff its **midpoint** (`ts − period/2`) falls inside a covered span (inclusive). Worst-case error per window edge is period/2, zero-mean. Pinned at both edges by `test_data_esc_coverage.py`.

## FID-7 — merge in one clock domain

The merge now runs in the **monotonic** domain. Files are grouped into clock generations (mono strictly increases within a daemon run; a backwards jump or a >300 s offset delta means reboot/restart); coverage vs. samples compare in mono within a generation, so an NTP step between file opens can no longer misplace coverage against samples from another file. Wall mapping is re-anchored with one canonical offset per generation (the newest file's) so "last 15 minutes from now" lines up with the newest data. Tested with two files whose header offsets disagree by 5 s and a window spanning the rotation.

## FID-2 (critical) — coverage-aware summary path, honest labels

`should_use_summaries()` picked the fast path on range length alone (≥120 s) and stamped `"fidelity":"exact"`, while summaries are fed only by the exact path — the default-tiered "last 15 min" returned slivers or nothing, labeled exact. The summary path is now taken only when the window is fully exact-covered (EXACT) or empty (NONE); anything with uncovered sampled data falls back to the raw merge path with honest `sampled`/`mixed` labels. The label is derived from coverage, never hardcoded; an empty ≥120 s window now reports `none`. (This also made the summary path testable with synthetic traces for the first time — the generator now anchors the summary writer's clocks to the synthetic timestamp domain.)

## FID-3 — no fabricated percentiles

`top_events` latency columns (avg/p50/p95/p99/max) are computed from exact records only; sampled-only rows carry `null` and render as "—" (counts/time totals stay valid via ASH math). The heatmap likewise skips sample records. Mirrored in `tests/mock_server.py`; the only UI edit is a 2-line null-guard in `fmtUs`.

## FID-4 — markers filtered at two chokepoints

- `pgwt_filter_matches` rejects marker records — one chokepoint for every raw compute path (the T0 live run showed the symptom directly: `Unknown:id=1677720x` rows in top_events).
- `summary_writer` `accum_event` skips markers on the write side (event_stream pushes every record before its own check), so exec/plan markers no longer inflate per-query counts and escalation markers no longer insert `PGWT_ESC_PACK` query_ids. The read side also rejects marker event ids so summaries written by older daemons render clean.
- Variants and the exec/plan lifecycle stats consume markers before the filter and are pinned by tests to keep working.

## FID-5 — fidelity-aware `--replay`

Chose the root-cause option (full fidelity awareness), not just a notice: samples accumulate as ASH estimates (count × period) for counts/time-model/query totals and contribute nothing to min/max/histograms; markers are skipped; a loud NOTE reports the composition, and the histogram view over sampled-only data declares itself unavailable instead of rendering fabricated cells. `map_reader.c`'s BPF half is now guarded by `!PGWT_SERVER` (same pattern as sampler.c/anomaly.c) so the replay accumulation is unit-testable without bpftool (`test_replay_fidelity`, wired into `unit_tests.list`).

## Tests

All new suites were verified to fail against master's binary before the fixes (e.g. FID-1 repro: Lock = 125.1 s vs ground truth 65.1 s; FID-2: DB Time = 0 labeled "exact"; FID-4 summary path: count 7/avg 4.3 ms vs true 3/10 ms):

- `tests/test_data_esc_coverage.py` — FID-1/6/7 (14 checks)
- `tests/test_data_summary_honesty.py` — FID-2 + FID-3 (19 checks)
- `tests/test_data_markers.py` — FID-4 raw + summary paths (21 checks)
- `tests/test_replay_fidelity.c` — FID-5 (23 checks)
- `tests/test_data_fidelity.py` — legacy no-marker merge re-pinned under the midpoint rule + FID-3 gating (49 checks)

Local: all `test_data_*` suites, `test_current_trace`, `test_protocol_drift` (48/48), Node web-unit (129), Playwright web UI (198/198), chaos, snapshots (13/13) green; ASan run over the new coverage/merge paths is clean including shutdown.

One behavior note: a ≥120 s window that contains uncovered sampled data now takes the raw path instead of summaries — correctness over speed; the summary fast path is unchanged for exact-covered windows, which is the case it was built for (`--mode full` and post-incident exact ranges).

🤖 Generated with [Claude Code](https://claude.com/claude-code)