### PR TITLE
T5: Durability & retention (DUR-1..10)

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,6 +416,7 @@ per interval, no screen clearing).
 |------|-------|---------|-------------|
 | `--trace-dir <DIR>` | `-T` | disabled | Directory for trace files (enables recording) |
 | `--trace-retention <H>` | `-R` | 24 | Keep trace files for H hours |
+| `--retention-gb <G>` | — | off | Also cap total trace-dir size at G GiB (fractional allowed); oldest archives deleted first, the live current files never |
 | `--trace-group <GROUP>` | — | `dba` | Unix group for trace file access |
 
 ### Replay
@@ -928,47 +929,48 @@ same resources. Available via `interference` server endpoint.
 
 ## Trace File Format
 
-When `--trace-dir` is specified, the daemon (or interactive mode) writes raw
-events to disk in a columnar, LZ4-compressed format.
-
-### File layout
-
-```
-[File Header - 28 bytes]
-  magic: "PGWT"
-  version: 1
-  flags: 0x0001 (LZ4)
-  pg_version: major version (17, 18, ...)
-  start_time_ns: wall-clock (CLOCK_REALTIME)
-  clock_offset_ns: monotonic (CLOCK_MONOTONIC)
-
-[Block 0]
-  [Block Header - 28 bytes]
-    first/last timestamp, num_events, compressed/uncompressed size
-  [LZ4 Compressed Columnar Data]
-    Columns: timestamp (delta + varint), pid, old_event, new_event,
-             duration (varint), query_id
-
-[Block 1]
-  ...
-
-[Footer]
-  [Block Index - N x 16 bytes]
-    (first_timestamp, file_offset) per block
-  [Block Count - 4 bytes]
-```
+When `--trace-dir` is specified, the daemon writes raw events to disk in a
+columnar, LZ4-compressed format (trace format **v2**: typed blocks — exact
+TRANSITIONS from the watchpoint tier, SAMPLES from the always-on sampler).
+The full byte-level spec — endianness/packing, block types and columnar
+layouts, the footer, the `current.trace.meta` committed-block protocol, and
+the durability guarantees — lives in
+[docs/TRACE_FORMAT.md](docs/TRACE_FORMAT.md).
 
 ### File lifecycle
 
-- **Active file**: `current.trace` — being written, no footer. Not readable
-  by the C replay mode. Only rotated `.trace.lz4` files are readable.
-- **Rotation**: Every calendar hour, the current file is finalized (footer
-  written) and renamed to `YYYY-MM-DD_HH.trace.lz4`.
-- **Retention**: Files older than `--trace-retention` hours are deleted.
-  Cleanup runs every 60 ticks (60 x interval seconds).
-- **Block size**: 4096 events per block. Blocks are flushed when full or
-  on rotation.
-- **Compression ratio**: Typical ~36x (36 bytes/event raw, ~1 byte compressed).
+- **Active file**: `current.trace` — being written. Readable while live via
+  the `current.trace.meta` high watermark (this is how `pgwt-server` serves
+  the current hour).
+- **Rotation**: every calendar hour the current file is finalized (footer
+  written, fsynced) and renamed to `YYYY-MM-DD_HH.trace.lz4`. If that name
+  already exists (restart within the hour, DST fold), a collision-safe
+  `YYYY-MM-DD_HH.N.trace.lz4` is used — an existing archive is never
+  clobbered.
+- **Crash recovery**: on startup, a leftover `current.trace` /
+  `current.summary` (crash, `kill -9`, or previous clean shutdown) is
+  finalized — torn tail dropped, footer appended — and archived under a
+  collision-safe name. Existing data is **never truncated**: a daemon crash
+  loses at most the unflushed tail (< 1 block of transitions, < ~1 s of
+  samples), never a committed hour.
+- **Durability**: archives are fsynced at rotation/recovery. The in-progress
+  hour is committed to the OS page cache per block (survives daemon death;
+  an OS crash / power loss can lose it). See docs/TRACE_FORMAT.md for the
+  measured trade-off.
+- **Retention**: archives older than `--trace-retention` hours are deleted,
+  and `--retention-gb` additionally caps total directory size (oldest
+  archives deleted first). Cleanup runs every 60 ticks.
+- **Block size**: 4096 events per block; SAMPLES ticks are batched into
+  ~1 s blocks. Blocks are flushed when full, on batch timeout, and on
+  rotation.
+- **Compression ratio**: typical ~36x (36 bytes/event raw, ~1 byte compressed).
+
+> **PII note:** with recording enabled, `query_texts.jsonl` stores the raw
+> running SQL (inline literals included, unlike the normalized
+> `pg_stat_statements` text), and `backends.jsonl` stores usernames,
+> database names and client addresses. The files get the trace files'
+> `0640` / `--trace-group` permissions; there is no redaction option.
+> Treat the trace directory as sensitive.
 
 ## Wait Event Classes
 

--- a/docs/TRACE_FORMAT.md
+++ b/docs/TRACE_FORMAT.md
@@ -1,0 +1,298 @@
+# pg_wait_tracer on-disk trace format (v2)
+
+Status: authoritative spec for trace format version 2 (the only version a
+current build reads or writes) and the sidecar files in a trace directory.
+Written for Phase T5 of the Trust Milestone (DUR-5/6: the format and its
+durability guarantees were previously implicit in the code).
+
+## Scope and general rules
+
+A trace directory (`--trace-dir`) contains:
+
+| File | Written by | Purpose |
+|---|---|---|
+| `current.trace` | event writer | live raw-event file (this hour) |
+| `current.trace.meta` | event writer | committed-block high watermark |
+| `YYYY-MM-DD_HH[.N].trace.lz4` | rotation/recovery | finished hourly archives |
+| `current.summary` / `.meta` | summary writer | live per-second summary file |
+| `YYYY-MM-DD_HH[.N].summary.lz4` | rotation/recovery | finished summary archives |
+| `query_texts.jsonl` | query-text capture | query_id → SQL text sidecar |
+| `backends.jsonl` | backend-meta writer | pid → type/user/db sidecar |
+| `wait_event_names.json` | daemon | event-id → name tables (PG17+) |
+| `*.corrupt.<unixtime>` | recovery | preserved unreadable leftovers |
+| `pgwt.sock` | daemon | control socket |
+
+**Endianness and packing.** All integers are little-endian, two's
+complement. All on-disk structs are `__attribute__((packed))` — there is no
+implicit padding, and the byte layouts below are exact. The format is not
+portable to big-endian writers/readers (none are supported).
+
+**Timestamps.** Raw event timestamps are `CLOCK_MONOTONIC` nanoseconds.
+Each file header records one (`CLOCK_REALTIME`, `CLOCK_MONOTONIC`) pair
+captured at file creation; readers derive the mono→wall mapping per file
+(and re-anchor across files per clock generation — see FID-7 in
+`TRUST_MILESTONE_PLAN.md`). Summary block timestamps are wall-clock.
+
+## Trace file layout
+
+```
+[file header — 28 bytes]
+[block 0][block 1]...[block N-1]
+[footer: block index — N × 16 bytes][block count — u32]
+```
+
+`current.trace` has no footer while being written; archives always do
+(rotation and startup recovery both append one).
+
+### File header (28 bytes, struct pgwt_trace_file_header)
+
+| off | size | field | value |
+|---|---|---|---|
+| 0 | 4 | magic | `0x54574750` ("PGWT" as LE bytes) |
+| 4 | 2 | version | 2 |
+| 6 | 2 | flags | bit 0: LZ4-compressed blocks |
+| 8 | 4 | pg_version | PostgreSQL major version |
+| 12 | 8 | start_time_ns | CLOCK_REALTIME at file creation |
+| 20 | 8 | clock_offset_ns | CLOCK_MONOTONIC at file creation |
+
+Summary files reuse the same header struct with magic `0x53574750`
+("PGWS") and their own version (currently 2; v1 files remain readable).
+
+### Block header (40 bytes, struct pgwt_trace_block_header)
+
+| off | size | field |
+|---|---|---|
+| 0 | 8 | first_timestamp_ns (mono) |
+| 8 | 8 | last_timestamp_ns (mono) |
+| 16 | 4 | num_events (1 … 4096) |
+| 20 | 4 | compressed_size (bytes following this header) |
+| 24 | 4 | uncompressed_size |
+| 28 | 2 | block_type (enum pgwt_block_type) |
+| 30 | 2 | reserved (0) |
+| 32 | 8 | sample_period_ns (SAMPLES: nominal per-sample weight; else 0) |
+
+The compressed payload (LZ4, `LZ4_compress_default`) follows immediately.
+
+### Block types and columnar payloads
+
+A block holds records of exactly one type (never mixed). After LZ4
+decompression the payload is column-major:
+
+**TRANSITIONS (type 0)** — exact wait-event transition intervals from the
+watchpoint (full/escalated) tier:
+
+1. timestamps: delta-encoded unsigned LEB128 varints (first delta is the
+   absolute value; deltas may be 0)
+2. pids: raw u32 × num_events
+3. old_event: raw u32 × num_events (the event whose interval just ended)
+4. new_event: raw u32 × num_events (`0xFFFFFFFF` = process exit)
+5. duration_ns: unsigned LEB128 varint × num_events
+6. query_id: raw u64 × num_events
+
+**SAMPLES (type 1)** — point observations from the userspace sampler:
+
+1. timestamps: delta varints (as above; one tick's samples share a value)
+2. pids: raw u32 × num_events
+3. event: raw u32 × num_events (the sampled wait event)
+4. query_id: raw u64 × num_events
+
+A sample means "at time T, pid P was in event E" and is worth ONE
+`sample_period_ns` of estimated time — never an interval measurement. The
+reader surfaces samples with `PGWT_EVENT_FLAG_SAMPLE` set; on-disk records
+carry no flags.
+
+**Batching (DUR-8).** The writer buffers sample-type pushes and cuts a
+block roughly once per second (or at 4096 records), instead of one tiny
+block per sampler tick — ~10× fewer blocks at 10 Hz. The block's
+`sample_period_ns` is the count-weighted mean of the batched ticks'
+periods, so the block's total estimated time equals the exact per-tick sum;
+a push whose period deviates more than ~1.6 % (period/64) from the pending
+batch — an SMP-3 stall tick with its measured, compensating weight — is cut
+into its own block so its weight stays exact. The buffering layer is
+type-agnostic: a future sample-like block type flows through the same
+batching with its own type/period gate. Readers make no assumption about
+records-per-block, so files written by older per-tick writers stay
+readable.
+
+### Markers
+
+Query lifecycle and escalation markers are TRANSITIONS records with
+sentinel event ids (`0xFFFFFFF0`–`0xFFFFFFF5`, see `pg_wait_tracer.h`),
+duration 0. Escalation markers use pid 0 and pack reason/duration into
+query_id (`PGWT_ESC_PACK`). They are structural — every consumer must
+exclude them from wait aggregation (`pgwt_filter_matches` is the
+chokepoint); only variants/lifecycle stats and coverage read them.
+
+### Footer
+
+`N × struct pgwt_block_index_entry { u64 first_timestamp_ns; u64
+file_offset; }` followed by `u32 N`. Offsets point at block headers,
+strictly increasing; the first entry is always at offset 28 (right after
+the file header). Readers verify this shape before trusting a footer, so a
+footer-less crash leftover can never be misread through the footer path.
+
+### Block index sortedness
+
+The index (and the physical block sequence) is sorted by
+`first_timestamp_ns`: when both a transitions buffer and a pending sample
+batch exist, the writer flushes the buffer holding the older first
+timestamp first. Readers binary-search the index for range queries.
+
+## Reader strategies and sanity caps (DUR-7)
+
+`pgwt_reader_open` determines the block index by, in order:
+
+1. **Meta high watermark** — `<file>.meta` holds the committed block count
+   (see below); scan exactly that many block headers sequentially.
+2. **Footer** — archives; validated as described above.
+3. **Sequential scan** — fallback; stops at the first implausible header.
+
+All three paths enforce the same caps — a corrupt meta/footer/header must
+never drive a huge allocation or a seek into garbage:
+
+| quantity | cap |
+|---|---|
+| blocks per file (reader) | `PGWT_MAX_READ_BLOCKS` = 4 Mi |
+| blocks per file (writer; forces early rotation) | `PGWT_MAX_FILE_BLOCKS` = 1 Mi |
+| num_events per block | `PGWT_BLOCK_EVENTS` = 4096 |
+| compressed/uncompressed block size | 10 MB |
+
+## The meta high-watermark protocol
+
+Readers may open `current.trace` while the daemon is writing it. After
+every block flush the writer:
+
+1. `fflush(fp)` — the block reaches the OS page cache, visible to readers;
+2. writes the new committed block count into `current.trace.meta.tmp`;
+3. `rename(meta.tmp, meta)` — atomic on POSIX.
+
+A reader that sees `meta == N` can safely scan/decode exactly N blocks;
+anything after that is an uncommitted tail that must be (and is) ignored.
+The meta file is removed on rotation (the archive has a footer) and by
+startup recovery.
+
+## File lifecycle: open, rotation, recovery
+
+**Open.** `current.trace` is created with `O_EXCL` semantics (`"wbx"`) —
+the writer NEVER truncates an existing file (DUR-1; the pre-T5 code's
+`fopen("wb")` destroyed up to an hour of data on every restart).
+
+**Rotation.** On the first write after the local-time hour changes (or when
+the writer block cap forces it): flush both pending buffers, append the
+footer, `fsync` the file, close, rename to `YYYY-MM-DD_HH.trace.lz4` (the
+hour the file STARTED), remove the meta file, `fsync` the directory.
+
+**Archive naming** is local time (operators correlate archives with server
+logs). Collision safety, not name uniqueness, is what protects data
+(DUR-2): if the target name exists — a restart within the same hour, or a
+DST fold replaying an hour — the writer picks `YYYY-MM-DD_HH.N.trace.lz4`
+for the first free `N` instead of clobbering. Discovery and retention parse
+the leading `YYYY-MM-DD_HH` and the suffix, so suffixed archives are
+first-class.
+
+**Startup recovery (DUR-1).** If a `current.trace`/`current.summary`
+exists at writer init (crash, kill -9, OOM, or plain shutdown — a clean
+close also leaves the current file in place):
+
+1. read the header; if unreadable, preserve the file as
+   `current.trace.corrupt.<unixtime>` (never delete data that might be
+   someone's evidence; a header-only file is simply removed);
+2. scan committed blocks with the reader's sanity caps, requiring each
+   block's payload to lie fully inside the file — a torn tail (killed
+   mid-`fwrite`) ends the scan;
+3. cross-check against the meta watermark; fewer recovered blocks than
+   committed is loudly reported (it means FS-level loss, not a writer bug);
+4. truncate the torn tail, append a footer, `fsync`;
+5. rename to a collision-safe archive name and `fsync` the directory.
+
+The recovered archive is indistinguishable from a normally rotated one.
+
+## Durability policy (DUR-5/6)
+
+What survives what:
+
+| failure | guaranteed loss bound |
+|---|---|
+| daemon crash / kill -9 | the unflushed tail only: < 1 buffered TRANSITIONS block (≤ 4096 events) + < ~1 s of batched samples + the current partial summary second. Every flushed block is in the OS page cache and is recovered on restart. |
+| OS crash / power loss | rotated/recovered archives are `fsync`ed and safe. The CURRENT hour's file has no per-block fsync — up to the entire current file can be lost (page cache never reached disk). The meta file may also be stale/absent, which readers tolerate. |
+
+Chosen policy: **fsync on rotation, close, and recovery + directory fsync
+after every rename; no per-block fsync.** Measured on the test host
+(Hetzner, ext4 on SSD, 64 KB blocks ≈ one compressed block):
+0.067 ms/block with the chosen policy vs 0.963 ms/block (~14×) with
+per-block fsync. At the batched block rate the absolute cost would be
+small on this SSD, but per-block fsync stalls the capture loop on slower
+storage (10–20 ms per fsync on spinning disks, unbounded on saturated
+volumes) exactly when the database is busiest — and the tool's promise is
+"a daemon crash loses at most the unflushed tail, never a committed hour",
+which page-cache commits already deliver. Power-loss durability of the
+in-progress hour is explicitly out of scope; operators who need it can run
+with a shorter rotation via external sync.
+
+## Retention (DUR-3)
+
+Runs every 60 daemon ticks:
+
+- **Hours** (`--trace-retention`, default 24 h): archives (trace, summary,
+  suffixed, and preserved `.corrupt.*` files) older than the cutoff are
+  deleted. Age comes from the `YYYY-MM-DD_HH` name when parseable, else
+  file mtime. `--trace-retention 0` disables the hours rule only.
+- **Size cap** (`--retention-gb`, fractional GiB, default off): if the
+  trace directory's total size exceeds the cap, the OLDEST archives are
+  deleted first until it fits. The live `current.*` files and the sidecar
+  `.jsonl` files are never deleted; if they alone exceed the cap, a WARN
+  says so.
+- **Orphans**: stale `*.meta.tmp` (torn meta writes) and `current.*.meta`
+  files whose current file is gone are removed once provably stale (> 1 h
+  old, so a live daemon's meta cycle is never raced).
+
+## Summary files
+
+Same header struct (magic "PGWS", version 2), then per-second blocks:
+
+```
+struct pgwt_summary_block_header {   /* 24 bytes, packed */
+    u64 wall_ns;            /* the second this block covers */
+    u32 num_events;         /* distinct event ids */
+    u16 num_sessions;       /* distinct pids */
+    u16 num_queries;        /* distinct query ids */
+    u32 compressed_size;
+    u32 uncompressed_size;
+};
+```
+
+The LZ4 payload is the serialized per-second accumulator (time-model class
+totals, per-event stats + histograms, per-session, per-query — see
+`pgwt_summary_serialize`). Lifecycle, meta protocol, rotation, recovery,
+naming, and retention are identical to trace files with the
+`.summary`/`.summary.lz4` names.
+
+## query_texts.jsonl (and PII — DUR-10)
+
+One JSON object per line: `{"q":"<query_id as signed decimal string>",
+"t":"<SQL text>","ts":<wall ns>}`. The file is append-only across daemon
+restarts; at startup the daemon loads existing ids into its dedup table
+(bounded: 4096 ids — when the table fills, a WARN is logged once and text
+for further NEW ids is not captured until restart) and compacts the file
+in place (atomic tmp+rename, first line per id wins) only when it exceeds
+32 MB (`PGWT_QT_COMPACT_BYTES` overrides for tests). Retained trace files
+reference these query_ids, so the file must never be truncated while
+traces that mention its ids exist.
+
+**PII warning:** the text is the RAW running SQL captured from backend
+memory — with literal values, not normalized like `pg_stat_statements`.
+Bind parameters of prepared statements are not included, but inline
+literals (names, emails, amounts…) are. The file is created with the same
+group/permissions as the trace files (0640, `--trace-group`). There is no
+redaction option yet; if raw SQL must not persist on disk, disable
+recording or restrict the trace directory. The same applies to trace files
+themselves to a lesser degree (query_ids only) and to `backends.jsonl`
+(usernames, database names, client addresses).
+
+## Versioning
+
+Readers reject unknown trace versions loudly and per-file (skip, never
+crash). v2 is not backward compatible with v1 (no deployed v1 installs
+existed). Additive evolution should use: new block types (the reader skips
+blocks with a type it does not know rather than mis-decoding them), the
+block header's `reserved` field, and header `flags` bits.

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -603,9 +603,14 @@ int pgwt_daemon_init(struct pgwt_daemon *d)
             goto fail;
         }
         d->event_writer->verbose = d->verbose;
+        /* DUR-3: optional size cap on top of the hours-based retention. */
+        if (d->trace_retention_gb > 0)
+            d->event_writer->retention_bytes =
+                (uint64_t)(d->trace_retention_gb * 1024.0 * 1024.0 * 1024.0);
         if (d->verbose)
-            fprintf(stderr, "INFO: trace writer: %s (retention %dh)\n",
-                    d->trace_dir, ret);
+            fprintf(stderr, "INFO: trace writer: %s (retention %dh%s)\n",
+                    d->trace_dir, ret,
+                    d->event_writer->retention_bytes ? ", size-capped" : "");
 
         /* Init summary writer (alongside event writer) */
         d->summary_writer = calloc(1, sizeof(*d->summary_writer));
@@ -628,7 +633,8 @@ int pgwt_daemon_init(struct pgwt_daemon *d)
             if (d->query_text_capture) {
                 if (pgwt_qt_init(d->query_text_capture, d->trace_dir,
                                   d->my_be_entry_addr,
-                                  d->st_activity_offset) != 0) {
+                                  d->st_activity_offset,
+                                  d->event_writer->trace_gid) != 0) {
                     free(d->query_text_capture);
                     d->query_text_capture = NULL;
                 } else {

--- a/src/daemon.h
+++ b/src/daemon.h
@@ -173,6 +173,7 @@ struct pgwt_daemon {
     /* Trace file recording */
     const char *trace_dir;                  /* NULL = disabled */
     int         trace_retention;            /* hours, default 24 */
+    double      trace_retention_gb;          /* size cap in GiB, 0 = off (DUR-3) */
     const char *trace_group;                /* group for trace files, default "dba" */
     struct pgwt_event_writer *event_writer;     /* NULL if disabled */
     struct pgwt_summary_writer *summary_writer; /* NULL if disabled */

--- a/src/event_reader.c
+++ b/src/event_reader.c
@@ -75,7 +75,12 @@ int pgwt_reader_open(struct pgwt_event_reader *r, const char *path)
         FILE *mf = fopen(meta_path, "r");
         if (mf) {
             int committed = 0;
-            if (fscanf(mf, "%d", &committed) == 1 && committed > 0) {
+            /* DUR-7: the committed count sizes an allocation and drives the
+             * scan — cap it like the footer count, and give the block scan
+             * the same per-block sanity caps as the fallback scan (a corrupt
+             * meta or torn block header must never seek us into garbage). */
+            if (fscanf(mf, "%d", &committed) == 1 && committed > 0 &&
+                committed < PGWT_MAX_READ_BLOCKS) {
                 /* Scan exactly 'committed' blocks sequentially */
                 fseek(r->fp, (long)sizeof(struct pgwt_trace_file_header),
                       SEEK_SET);
@@ -86,7 +91,9 @@ int pgwt_reader_open(struct pgwt_event_reader *r, const char *path)
                     struct pgwt_trace_block_header bh;
                     while (r->num_blocks < committed &&
                            fread(&bh, sizeof(bh), 1, r->fp) == 1 &&
-                           bh.compressed_size > 0 && bh.num_events > 0) {
+                           bh.compressed_size > 0 && bh.num_events > 0 &&
+                           bh.num_events <= PGWT_BLOCK_EVENTS &&
+                           bh.compressed_size <= PGWT_MAX_BLOCK_COMPRESSED) {
                         long off = ftell(r->fp) - (long)sizeof(bh);
                         r->block_index[r->num_blocks++] =
                             (struct pgwt_block_index_entry){
@@ -114,7 +121,7 @@ int pgwt_reader_open(struct pgwt_event_reader *r, const char *path)
         uint32_t nb = 0;
         if (fseek(r->fp, -4, SEEK_END) == 0 &&
             fread(&nb, sizeof(nb), 1, r->fp) == 1 &&
-            nb > 0 && nb < 100000) {  /* sanity: < 100K blocks */
+            nb > 0 && nb < PGWT_MAX_READ_BLOCKS) {  /* sanity cap */
             long index_start = ftell(r->fp) - 4
                              - (long)nb * (long)sizeof(struct pgwt_block_index_entry);
             if (index_start >= (long)sizeof(struct pgwt_trace_file_header)) {
@@ -123,8 +130,26 @@ int pgwt_reader_open(struct pgwt_event_reader *r, const char *path)
                 if (r->block_index &&
                     fread(r->block_index, sizeof(struct pgwt_block_index_entry),
                           nb, r->fp) == nb) {
-                    r->num_blocks = (int)nb;
-                    have_index = 1;
+                    /* DUR-7: a footer-less file's trailing bytes can decode
+                     * as a plausible count. A REAL index has its first block
+                     * right after the header and strictly increasing,
+                     * in-bounds offsets — verify before trusting it. */
+                    int valid =
+                        r->block_index[0].file_offset ==
+                        sizeof(struct pgwt_trace_file_header);
+                    for (uint32_t i = 1; valid && i < nb; i++)
+                        if (r->block_index[i].file_offset <=
+                                r->block_index[i - 1].file_offset ||
+                            r->block_index[i].file_offset >=
+                                (uint64_t)index_start)
+                            valid = 0;
+                    if (valid) {
+                        r->num_blocks = (int)nb;
+                        have_index = 1;
+                    } else {
+                        free(r->block_index);
+                        r->block_index = NULL;
+                    }
                 } else {
                     free(r->block_index);
                     r->block_index = NULL;
@@ -147,7 +172,7 @@ int pgwt_reader_open(struct pgwt_event_reader *r, const char *path)
         while (fread(&bh, sizeof(bh), 1, r->fp) == 1 &&
                bh.compressed_size > 0 && bh.num_events > 0 &&
                bh.num_events <= PGWT_BLOCK_EVENTS &&
-               bh.compressed_size <= 10 * 1024 * 1024) {
+               bh.compressed_size <= PGWT_MAX_BLOCK_COMPRESSED) {
             if (r->num_blocks >= cap) {
                 cap *= 2;
                 struct pgwt_block_index_entry *tmp =
@@ -237,6 +262,12 @@ int pgwt_reader_decode_block_info(struct pgwt_event_reader *r, int block_idx,
         info->first_timestamp_ns = bh.first_timestamp_ns;
         info->last_timestamp_ns  = bh.last_timestamp_ns;
     }
+
+    /* Unknown block type (written by a NEWER build): skip the block rather
+     * than decode it with the wrong columnar layout — garbage must never be
+     * surfaced as data. */
+    if (bh.block_type > PGWT_BLOCK_SAMPLES)
+        return -1;
 
     int count = (int)bh.num_events;
     if (count > max_events) count = max_events;

--- a/src/event_writer.c
+++ b/src/event_writer.c
@@ -10,6 +10,7 @@
 #include <time.h>
 #include <sys/stat.h>
 #include <dirent.h>
+#include <fcntl.h>
 #include <unistd.h>
 #include <grp.h>
 #include <lz4.h>
@@ -131,6 +132,207 @@ size_t pgwt_encode_sample_block(const struct pgwt_trace_event *events, int count
     return (size_t)(p - out);
 }
 
+/* ── Shared file-lifecycle helpers (DUR-1/2/5) ────────────── */
+
+void pgwt_fsync_dir(const char *dir)
+{
+    int fd = open(dir, O_RDONLY | O_DIRECTORY | O_CLOEXEC);
+    if (fd >= 0) {
+        fsync(fd);
+        close(fd);
+    }
+}
+
+int pgwt_archive_path_nonclobber(const char *dir, const struct tm *tm,
+                                 const char *ext, char *out, size_t out_size)
+{
+    snprintf(out, out_size, "%s/%04d-%02d-%02d_%02d%s",
+             dir, tm->tm_year + 1900, tm->tm_mon + 1, tm->tm_mday,
+             tm->tm_hour, ext);
+    if (access(out, F_OK) != 0)
+        return 0;
+    /* Target exists (restart mid-hour, or a DST fold repeating the hour):
+     * pick a numeric-suffix name instead of clobbering. Readers accept the
+     * suffixed form — pgwt_scan_trace_files / retention parse the leading
+     * YYYY-MM-DD_HH and match the .trace.lz4/.summary.lz4 suffix, which the
+     * extra ".N." does not disturb. */
+    for (int n = 1; n < 10000; n++) {
+        snprintf(out, out_size, "%s/%04d-%02d-%02d_%02d.%d%s",
+                 dir, tm->tm_year + 1900, tm->tm_mon + 1, tm->tm_mday,
+                 tm->tm_hour, n, ext);
+        if (access(out, F_OK) != 0)
+            return 0;
+    }
+    return -1;
+}
+
+/* ── Startup recovery (DUR-1) ─────────────────────────────── */
+
+/* A previous daemon left a current.trace behind (crash, kill -9, or plain
+ * shutdown). NEVER truncate it — the old code's fopen("wb") erased up to an
+ * hour of committed data on every restart. Instead: scan its committed
+ * blocks (same sanity rules as the reader's fallback scan), drop any torn
+ * tail, append a real footer, fsync, and rename it aside to a collision-safe
+ * archive name so it stays readable like any rotated file. A file with a
+ * valid header but no complete block carries no events; if it has any
+ * payload beyond the header it is preserved as *.corrupt.<ts> for forensics,
+ * otherwise removed. */
+static void recover_current_trace(struct pgwt_event_writer *w)
+{
+    char cur[512], meta[600], meta_tmp[600];
+    snprintf(cur, sizeof(cur), "%s/current.trace", w->trace_dir);
+    snprintf(meta, sizeof(meta), "%s/current.trace.meta", w->trace_dir);
+    snprintf(meta_tmp, sizeof(meta_tmp), "%s/current.trace.meta.tmp",
+             w->trace_dir);
+
+    /* A half-written meta tmp from a crash mid-meta-write is always stale. */
+    unlink(meta_tmp);
+
+    struct stat st;
+    if (stat(cur, &st) != 0) {
+        unlink(meta);   /* meta without a current file is an orphan */
+        return;
+    }
+
+    /* Read the meta high-watermark BEFORE touching the file: it is the
+     * committed-block floor the recovery scan must reach. */
+    int committed = 0;
+    {
+        FILE *mf = fopen(meta, "r");
+        if (mf) {
+            if (fscanf(mf, "%d", &committed) != 1)
+                committed = 0;
+            fclose(mf);
+        }
+    }
+
+    FILE *fp = fopen(cur, "r+b");
+    struct pgwt_trace_file_header hdr;
+    if (!fp) {
+        fprintf(stderr, "WARN: cannot open %s for recovery: %s "
+                "(leaving it in place)\n", cur, strerror(errno));
+        return;
+    }
+    if (fread(&hdr, sizeof(hdr), 1, fp) != 1 ||
+        hdr.magic != PGWT_TRACE_MAGIC ||
+        hdr.version != PGWT_TRACE_VERSION) {
+        fclose(fp);
+        char aside[600];
+        snprintf(aside, sizeof(aside), "%s.corrupt.%lld", cur,
+                 (long long)time(NULL));
+        if (rename(cur, aside) == 0)
+            fprintf(stderr, "WARN: %s has an unreadable header — preserved "
+                    "as %s\n", cur, aside);
+        unlink(meta);
+        pgwt_fsync_dir(w->trace_dir);
+        return;
+    }
+
+    /* Scan committed blocks (strict: same caps as the reader, plus the block
+     * payload must lie fully inside the file — a torn tail ends the scan). */
+    long fsize = (long)st.st_size;
+    struct pgwt_block_index_entry *idx = NULL;
+    int nidx = 0, cap = 0;
+    uint64_t nevents = 0;
+    long pos = (long)sizeof(hdr);
+    struct pgwt_trace_block_header bh;
+    while (nidx < PGWT_MAX_READ_BLOCKS) {
+        if (fseek(fp, pos, SEEK_SET) != 0 ||
+            fread(&bh, sizeof(bh), 1, fp) != 1)
+            break;
+        if (bh.num_events == 0 || bh.num_events > PGWT_BLOCK_EVENTS ||
+            bh.compressed_size == 0 ||
+            bh.compressed_size > PGWT_MAX_BLOCK_COMPRESSED ||
+            bh.block_type > 15)
+            break;
+        long end = pos + (long)sizeof(bh) + (long)bh.compressed_size;
+        if (end > fsize)
+            break;   /* torn tail: block header landed, payload didn't */
+        if (nidx >= cap) {
+            int newcap = cap ? cap * 2 : 256;
+            struct pgwt_block_index_entry *tmp =
+                realloc(idx, newcap * sizeof(*tmp));
+            if (!tmp)
+                break;
+            idx = tmp;
+            cap = newcap;
+        }
+        idx[nidx++] = (struct pgwt_block_index_entry){
+            .timestamp_ns = bh.first_timestamp_ns,
+            .file_offset = (uint64_t)pos,
+        };
+        nevents += bh.num_events;
+        pos = end;
+    }
+
+    if (committed > nidx)
+        fprintf(stderr, "ERROR: recovery of %s found %d complete blocks but "
+                "the meta high-watermark says %d were committed — data below "
+                "the watermark is missing or corrupt\n", cur, nidx, committed);
+
+    if (nidx == 0) {
+        free(idx);
+        fclose(fp);
+        if (fsize > (long)sizeof(hdr)) {
+            char aside[600];
+            snprintf(aside, sizeof(aside), "%s.corrupt.%lld", cur,
+                     (long long)time(NULL));
+            if (rename(cur, aside) == 0)
+                fprintf(stderr, "WARN: %s had no complete block — preserved "
+                        "as %s\n", cur, aside);
+        } else {
+            unlink(cur);   /* header-only file: nothing to preserve */
+        }
+        unlink(meta);
+        pgwt_fsync_dir(w->trace_dir);
+        return;
+    }
+
+    /* Finalize: drop the torn tail (or the previous footer, which re-scans
+     * as an invalid block and is rewritten identically), append the footer,
+     * make it durable. */
+    int finalize_failed = 0;
+    if (ftruncate(fileno(fp), (off_t)pos) != 0)
+        finalize_failed = 1;
+    if (!finalize_failed && fseek(fp, pos, SEEK_SET) == 0) {
+        for (int i = 0; i < nidx && !finalize_failed; i++)
+            if (fwrite(&idx[i], sizeof(idx[i]), 1, fp) != 1)
+                finalize_failed = 1;
+        uint32_t nb = (uint32_t)nidx;
+        if (!finalize_failed && fwrite(&nb, sizeof(nb), 1, fp) != 1)
+            finalize_failed = 1;
+    } else {
+        finalize_failed = 1;
+    }
+    fflush(fp);
+    fsync(fileno(fp));
+    fclose(fp);
+    free(idx);
+    if (finalize_failed)
+        fprintf(stderr, "WARN: could not append a footer to recovered %s "
+                "(%s) — archiving anyway; readers will fall back to a "
+                "sequential scan\n", cur, strerror(errno));
+
+    /* Archive under the hour of the file's own start time, never clobbering
+     * an existing archive. */
+    time_t start_sec = (time_t)(hdr.start_time_ns / 1000000000ULL);
+    struct tm tm;
+    localtime_r(&start_sec, &tm);
+    char dest[512];
+    if (pgwt_archive_path_nonclobber(w->trace_dir, &tm, ".trace.lz4",
+                                     dest, sizeof(dest)) != 0 ||
+        rename(cur, dest) != 0) {
+        fprintf(stderr, "WARN: cannot archive recovered %s: %s "
+                "(leaving it in place; it will NOT be truncated)\n",
+                cur, strerror(errno));
+        return;
+    }
+    unlink(meta);
+    pgwt_fsync_dir(w->trace_dir);
+    fprintf(stderr, "INFO: recovered previous current.trace: %d blocks, "
+            "%llu events -> %s\n", nidx, (unsigned long long)nevents, dest);
+}
+
 /* ── File operations (static) ─────────────────────────────── */
 
 static int write_footer(struct pgwt_event_writer *w)
@@ -152,7 +354,14 @@ static int open_trace_file(struct pgwt_event_writer *w, uint64_t first_mono_ns)
     snprintf(w->current_path, sizeof(w->current_path),
              "%s/current.trace", w->trace_dir);
 
-    w->fp = fopen(w->current_path, "wb");
+    /* DUR-1: NEVER truncate an existing current.trace ("wbx", not "wb").
+     * Init already recovered any leftover file; if one (re)appeared since —
+     * e.g. lazy first-open long after init — recover it now and retry. */
+    w->fp = fopen(w->current_path, "wbx");
+    if (!w->fp && errno == EEXIST) {
+        recover_current_trace(w);
+        w->fp = fopen(w->current_path, "wbx");
+    }
     if (!w->fp) {
         fprintf(stderr, "WARN: cannot create %s: %s\n",
                 w->current_path, strerror(errno));
@@ -223,6 +432,17 @@ static int write_typed_block(struct pgwt_event_writer *w,
         return -1;
     }
 
+    /* DUR-8: a file must never outgrow what the readers' footer/meta sanity
+     * caps accept. Ask for an early rotation at the writer cap; the readers
+     * accept up to 4× it, which covers the few blocks written between the
+     * cap being hit and the next rotation check (only reachable at
+     * pathological block rates — see PGWT_MAX_FILE_BLOCKS). */
+    if (w->num_blocks >= PGWT_MAX_FILE_BLOCKS && !w->force_rotate) {
+        w->force_rotate = true;
+        fprintf(stderr, "WARN: trace file reached %d blocks — forcing an "
+                "early rotation\n", PGWT_MAX_FILE_BLOCKS);
+    }
+
     /* Grow block index if needed */
     if (w->num_blocks >= w->block_index_cap) {
         int new_cap = w->block_index_cap * 2;
@@ -287,7 +507,8 @@ static int write_typed_block(struct pgwt_event_writer *w,
     return 0;
 }
 
-static int flush_block(struct pgwt_event_writer *w)
+/* Write the buffered TRANSITIONS block (no ordering logic — see flush_block). */
+static int flush_block_core(struct pgwt_event_writer *w)
 {
     if (w->num_events == 0 || !w->fp) return 0;
 
@@ -295,6 +516,48 @@ static int flush_block(struct pgwt_event_writer *w)
                                PGWT_BLOCK_TRANSITIONS, 0);
     w->num_events = 0;
     return rc;
+}
+
+/* Write the pending batched sample-type block (DUR-8). The block period is
+ * the count-weighted mean of the batched pushes' periods, so the block's
+ * TOTAL estimated time equals the exact per-tick sum (SMP-3 weights are
+ * preserved in aggregate; the compatibility gate in push bounds the per-tick
+ * skew to ~1.6%). */
+static int flush_sample_buf(struct pgwt_event_writer *w)
+{
+    if (w->num_sample_buf == 0 || !w->fp) return 0;
+
+    uint64_t period = w->sample_buf_weight_ns / (uint64_t)w->num_sample_buf;
+    int rc = write_typed_block(w, w->sample_buf, w->num_sample_buf,
+                               (enum pgwt_block_type)w->sample_buf_type,
+                               period);
+    w->num_sample_buf = 0;
+    w->sample_buf_weight_ns = 0;
+    w->sample_buf_period_ns = 0;
+    return rc;
+}
+
+/* Ordered flushes: whichever pending buffer holds the OLDER first timestamp
+ * is written first, so the file's block index stays sorted (readers
+ * binary-search it). Each buffer is internally time-sorted already. */
+static int flush_block(struct pgwt_event_writer *w)
+{
+    if (w->num_sample_buf > 0 && w->num_events > 0 &&
+        w->sample_buf[0].timestamp_ns < w->events[0].timestamp_ns) {
+        if (flush_sample_buf(w) != 0)
+            return -1;
+    }
+    return flush_block_core(w);
+}
+
+static int flush_samples(struct pgwt_event_writer *w)
+{
+    if (w->num_events > 0 && w->num_sample_buf > 0 &&
+        w->events[0].timestamp_ns <= w->sample_buf[0].timestamp_ns) {
+        if (flush_block_core(w) != 0)
+            return -1;
+    }
+    return flush_sample_buf(w);
 }
 
 /* ── Public API ───────────────────────────────────────────── */
@@ -328,6 +591,10 @@ int pgwt_writer_init(struct pgwt_event_writer *w, const char *trace_dir,
         chown(w->trace_dir, (uid_t)-1, w->trace_gid);
         chmod(w->trace_dir, 0750);
     }
+
+    /* DUR-1: recover (finalize + archive) any current.trace a previous
+     * daemon left behind — never truncate it. */
+    recover_current_trace(w);
 
     /* Allocate scratch buffers */
     w->encode_buf_size = PGWT_BLOCK_EVENTS * 36 + PGWT_BLOCK_EVENTS * 10;
@@ -383,24 +650,49 @@ int pgwt_writer_push_samples(struct pgwt_event_writer *w,
         }
     }
 
-    /* Flush any pending buffered TRANSITIONS block first so block
-     * boundaries stay clean (one block is either all transitions or all
-     * samples — never mixed). */
-    if (w->num_events > 0) {
-        if (flush_block(w) != 0)
-            return -1;
+    /* DUR-8: buffer sample-type records and cut a block roughly once per
+     * second instead of once per sampler tick (~10× fewer blocks at 10 Hz).
+     * The buffering is type-agnostic: a pending batch of a DIFFERENT block
+     * type is flushed before this one starts. A push whose period deviates
+     * from the pending batch by more than ~1.6% (period/64) also flushes
+     * first — timer jitter batches, an SMP-3 stall tick (measured elapsed ≫
+     * nominal) gets its own block so its compensation weight stays exact. */
+    if (w->num_sample_buf > 0) {
+        uint64_t p0 = w->sample_buf_period_ns;
+        uint64_t diff = sample_period_ns > p0 ? sample_period_ns - p0
+                                              : p0 - sample_period_ns;
+        if (w->sample_buf_type != (uint16_t)PGWT_BLOCK_SAMPLES ||
+            diff > p0 / 64) {
+            if (flush_samples(w) != 0)
+                return -1;
+        }
     }
 
-    /* Samples can exceed one block; split into PGWT_BLOCK_EVENTS chunks. */
     int off = 0;
     while (off < count) {
+        if (w->num_sample_buf == 0) {
+            w->sample_buf_type = (uint16_t)PGWT_BLOCK_SAMPLES;
+            w->sample_buf_period_ns = sample_period_ns;
+        }
+        int room = PGWT_BLOCK_EVENTS - w->num_sample_buf;
         int chunk = count - off;
-        if (chunk > PGWT_BLOCK_EVENTS) chunk = PGWT_BLOCK_EVENTS;
-        if (write_typed_block(w, samples + off, chunk,
-                              PGWT_BLOCK_SAMPLES, sample_period_ns) != 0)
-            return -1;
+        if (chunk > room) chunk = room;
+        memcpy(&w->sample_buf[w->num_sample_buf], samples + off,
+               (size_t)chunk * sizeof(*samples));
+        w->num_sample_buf += chunk;
+        w->sample_buf_weight_ns += (uint64_t)chunk * sample_period_ns;
         off += chunk;
+        if (w->num_sample_buf >= PGWT_BLOCK_EVENTS) {
+            if (flush_samples(w) != 0)
+                return -1;
+        }
     }
+
+    /* Time-based cut: the pending batch spans ~1 s of ticks. */
+    if (w->num_sample_buf > 0 &&
+        w->sample_buf[w->num_sample_buf - 1].timestamp_ns -
+        w->sample_buf[0].timestamp_ns >= PGWT_SAMPLE_BATCH_NS)
+        return flush_samples(w);
 
     return 0;
 }
@@ -416,11 +708,12 @@ int pgwt_writer_check_rotation(struct pgwt_event_writer *w)
     localtime_r(&now, &tm);
     int current_hour = tm.tm_yday * 24 + tm.tm_hour;
 
-    if (current_hour == w->current_hour)
+    if (current_hour == w->current_hour && !w->force_rotate)
         return 0;
 
-    /* Hour changed — rotate */
+    /* Hour changed (or the block cap forced it) — rotate */
     flush_block(w);
+    flush_samples(w);
     write_footer(w);
 
     if (w->verbose) {
@@ -433,19 +726,31 @@ int pgwt_writer_check_rotation(struct pgwt_event_writer *w)
                 (unsigned long)w->total_bytes_written, ratio);
     }
 
+    /* DUR-5: an archive is durable once rotated — flush it to stable
+     * storage before it gets its final name. */
+    fflush(w->fp);
+    fsync(fileno(w->fp));
     fclose(w->fp);
     w->fp = NULL;
 
-    /* Rename current.trace → YYYY-MM-DD_HH.trace.lz4 */
+    /* Rename current.trace → YYYY-MM-DD_HH[.N].trace.lz4. DUR-2: the target
+     * is derived from the file's START hour; a restart mid-hour (the
+     * recovered archive already claimed the name) or a DST fold (localtime_r
+     * repeats an hour) must never clobber an existing archive — the helper
+     * picks a numeric-suffix name instead. Naming stays in LOCAL time
+     * (operators read these against server logs); collision safety, not
+     * unique naming, is what prevents data loss. */
     time_t file_start_sec = (time_t)(w->file_start_wall_ns / 1000000000ULL);
     struct tm file_tm;
     localtime_r(&file_start_sec, &file_tm);
     char new_path[512];
-    snprintf(new_path, sizeof(new_path), "%s/%04d-%02d-%02d_%02d.trace.lz4",
-             w->trace_dir,
-             file_tm.tm_year + 1900, file_tm.tm_mon + 1,
-             file_tm.tm_mday, file_tm.tm_hour);
-    rename(w->current_path, new_path);
+    if (pgwt_archive_path_nonclobber(w->trace_dir, &file_tm, ".trace.lz4",
+                                     new_path, sizeof(new_path)) == 0)
+        rename(w->current_path, new_path);
+    else
+        fprintf(stderr, "WARN: no free archive name for %s — leaving it as "
+                "current.trace (it will be recovered on next start)\n",
+                w->current_path);
 
     /* Remove meta file — the rotated .trace.lz4 has a real footer */
     {
@@ -454,10 +759,12 @@ int pgwt_writer_check_rotation(struct pgwt_event_writer *w)
                  w->trace_dir);
         unlink(meta_path);
     }
+    pgwt_fsync_dir(w->trace_dir);
 
     /* Reset stats for next file */
     w->total_events_written = 0;
     w->total_bytes_written = 0;
+    w->force_rotate = false;
 
     return 0;
 }
@@ -467,6 +774,7 @@ int pgwt_writer_close(struct pgwt_event_writer *w)
     if (!w->fp) return 0;
 
     flush_block(w);
+    flush_samples(w);
     write_footer(w);
 
     if (w->verbose) {
@@ -479,45 +787,178 @@ int pgwt_writer_close(struct pgwt_event_writer *w)
                 (unsigned long)w->total_bytes_written, ratio);
     }
 
+    /* DUR-5: a cleanly closed file is durable (it is archived on the next
+     * daemon start by recovery, footer intact). */
+    fflush(w->fp);
+    fsync(fileno(w->fp));
     fclose(w->fp);
     w->fp = NULL;
     return 0;
 }
 
-int pgwt_writer_cleanup_old_files(struct pgwt_event_writer *w)
+/* Classify a trace-dir entry for retention purposes. */
+enum retn_kind {
+    RETN_SKIP = 0,        /* live files, sidecars, unknown names */
+    RETN_TRACE_ARCHIVE,   /* *.trace.lz4 (incl. numeric-suffix names) */
+    RETN_SUMMARY_ARCHIVE, /* *.summary.lz4 */
+    RETN_CORRUPT,         /* preserved *.corrupt.<ts> files */
+    RETN_ORPHAN_META,     /* current.*.meta[.tmp] with no live writer file */
+};
+
+static int has_suffix(const char *name, const char *suffix)
 {
-    if (w->retention_hours <= 0) return 0;
+    size_t nl = strlen(name), sl = strlen(suffix);
+    return nl >= sl && strcmp(name + nl - sl, suffix) == 0;
+}
 
-    DIR *dir = opendir(w->trace_dir);
-    if (!dir) return -1;
+static enum retn_kind retn_classify(const char *dir, const char *name)
+{
+    if (strcmp(name, "current.trace") == 0 ||
+        strcmp(name, "current.summary") == 0)
+        return RETN_SKIP;
+    if (has_suffix(name, ".trace.lz4"))
+        return RETN_TRACE_ARCHIVE;
+    if (has_suffix(name, ".summary.lz4"))
+        return RETN_SUMMARY_ARCHIVE;
+    if (strstr(name, ".corrupt."))
+        return RETN_CORRUPT;
+    if (has_suffix(name, ".meta.tmp") || has_suffix(name, ".jsonl.tmp"))
+        return RETN_ORPHAN_META;   /* torn meta/compaction write — stale */
+    if (strcmp(name, "current.trace.meta") == 0 ||
+        strcmp(name, "current.summary.meta") == 0) {
+        /* Orphan only if the file it describes is gone. */
+        char live[600];
+        snprintf(live, sizeof(live), "%s/%.*s", dir,
+                 (int)(strlen(name) - 5), name);
+        return access(live, F_OK) == 0 ? RETN_SKIP : RETN_ORPHAN_META;
+    }
+    return RETN_SKIP;
+}
 
-    time_t cutoff = time(NULL) - (time_t)w->retention_hours * 3600;
-
-    struct dirent *ent;
-    while ((ent = readdir(dir)) != NULL) {
-        if (!strstr(ent->d_name, ".trace.lz4"))
-            continue;
-
-        struct tm ftm = {0};
-        int hour;
-        if (sscanf(ent->d_name, "%4d-%2d-%2d_%2d.trace.lz4",
-                   &ftm.tm_year, &ftm.tm_mon, &ftm.tm_mday, &hour) != 4)
-            continue;
-
+/* Archive age: from the YYYY-MM-DD_HH name when parseable (recovered
+ * archives are CREATED late but hold old data), else the file mtime. */
+static time_t retn_file_time(const char *name, time_t mtime)
+{
+    struct tm ftm = {0};
+    int hour;
+    if (sscanf(name, "%4d-%2d-%2d_%2d",
+               &ftm.tm_year, &ftm.tm_mon, &ftm.tm_mday, &hour) == 4) {
         ftm.tm_year -= 1900;
         ftm.tm_mon -= 1;
         ftm.tm_hour = hour;
         ftm.tm_isdst = -1;
-        time_t file_time = mktime(&ftm);
+        time_t t = mktime(&ftm);
+        if (t > 0)
+            return t;
+    }
+    return mtime;
+}
 
-        if (file_time > 0 && file_time < cutoff) {
-            char path[512];
-            snprintf(path, sizeof(path), "%s/%s", w->trace_dir, ent->d_name);
-            if (unlink(path) == 0 && w->verbose)
-                fprintf(stderr, "INFO: deleted old trace file %s\n", ent->d_name);
+struct retn_entry {
+    char     name[300];
+    time_t   ftime;
+    uint64_t size;
+};
+
+static int retn_cmp_oldest(const void *a, const void *b)
+{
+    time_t ta = ((const struct retn_entry *)a)->ftime;
+    time_t tb = ((const struct retn_entry *)b)->ftime;
+    return (ta > tb) - (ta < tb);
+}
+
+int pgwt_writer_cleanup_old_files(struct pgwt_event_writer *w)
+{
+    DIR *dir = opendir(w->trace_dir);
+    if (!dir) return -1;
+
+    time_t now = time(NULL);
+    time_t cutoff = w->retention_hours > 0
+                  ? now - (time_t)w->retention_hours * 3600 : 0;
+
+    struct retn_entry *kept = NULL;
+    int n_kept = 0, cap_kept = 0;
+    uint64_t total_bytes = 0;   /* everything in the dir, live files included */
+
+    struct dirent *ent;
+    while ((ent = readdir(dir)) != NULL) {
+        if (strcmp(ent->d_name, ".") == 0 || strcmp(ent->d_name, "..") == 0)
+            continue;
+        char path[600];
+        snprintf(path, sizeof(path), "%s/%s", w->trace_dir, ent->d_name);
+        struct stat st;
+        if (stat(path, &st) != 0 || !S_ISREG(st.st_mode))
+            continue;
+
+        enum retn_kind kind = retn_classify(w->trace_dir, ent->d_name);
+        if (kind == RETN_ORPHAN_META) {
+            /* DUR-3: leftovers of a dead writer — but only when provably
+             * stale (an hour old) so we never race a live daemon's
+             * meta-tmp-rename cycle. */
+            if (now - st.st_mtime > 3600 && unlink(path) == 0 && w->verbose)
+                fprintf(stderr, "INFO: deleted orphaned %s\n", ent->d_name);
+            continue;
+        }
+        if (kind == RETN_SKIP) {
+            total_bytes += (uint64_t)st.st_size;
+            continue;
+        }
+
+        /* Hours-based retention (archives + preserved corrupt files). */
+        time_t ftime = retn_file_time(ent->d_name, st.st_mtime);
+        if (cutoff && ftime < cutoff) {
+            if (unlink(path) == 0) {
+                if (w->verbose)
+                    fprintf(stderr, "INFO: deleted old file %s\n",
+                            ent->d_name);
+                continue;
+            }
+        }
+
+        total_bytes += (uint64_t)st.st_size;
+        if (w->retention_bytes > 0) {
+            if (n_kept >= cap_kept) {
+                int newcap = cap_kept ? cap_kept * 2 : 64;
+                struct retn_entry *tmp =
+                    realloc(kept, (size_t)newcap * sizeof(*tmp));
+                if (!tmp)
+                    continue;
+                kept = tmp;
+                cap_kept = newcap;
+            }
+            snprintf(kept[n_kept].name, sizeof(kept[n_kept].name), "%s",
+                     ent->d_name);
+            kept[n_kept].ftime = ftime;
+            kept[n_kept].size = (uint64_t)st.st_size;
+            n_kept++;
         }
     }
     closedir(dir);
+
+    /* DUR-3: size cap. Total dir usage (live files included) must fit under
+     * retention_bytes; delete the OLDEST archives first, never the live
+     * current files or sidecars. */
+    if (w->retention_bytes > 0 && total_bytes > w->retention_bytes) {
+        if (n_kept > 0)
+            qsort(kept, (size_t)n_kept, sizeof(*kept), retn_cmp_oldest);
+        for (int i = 0; i < n_kept && total_bytes > w->retention_bytes; i++) {
+            char path[600];
+            snprintf(path, sizeof(path), "%s/%s", w->trace_dir, kept[i].name);
+            if (unlink(path) == 0) {
+                total_bytes -= kept[i].size;
+                if (w->verbose)
+                    fprintf(stderr, "INFO: size cap: deleted %s (%llu bytes)\n",
+                            kept[i].name,
+                            (unsigned long long)kept[i].size);
+            }
+        }
+        if (total_bytes > w->retention_bytes)
+            fprintf(stderr, "WARN: trace dir still %llu bytes over the "
+                    "--retention-gb cap after deleting every archive — the "
+                    "live current files alone exceed the cap\n",
+                    (unsigned long long)(total_bytes - w->retention_bytes));
+    }
+    free(kept);
     return 0;
 }
 

--- a/src/event_writer.h
+++ b/src/event_writer.h
@@ -8,6 +8,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <stdio.h>
+#include <time.h>
 #include <sys/types.h>
 
 /* ── On-disk format constants ─────────────────────────────── */
@@ -17,6 +18,25 @@
 #define PGWT_FLAG_LZ4         0x0001
 
 #define PGWT_BLOCK_EVENTS     4096         /* events per block */
+
+/* Hard cap on blocks per trace/summary file (DUR-7/8). The writer forces an
+ * early rotation when a file reaches it; readers use it as the sanity cap for
+ * footer block counts and meta committed counts (a corrupted footer/meta must
+ * never drive a multi-GB allocation). 1M blocks = a 16 MB footer index; with
+ * ~1 s SAMPLES batching even 1000 Hz × 1024 backends (≈250 full blocks/s)
+ * stays under it for a full hour (~900k blocks). Readers accept up to
+ * PGWT_MAX_READ_BLOCKS (4×) to cover blocks written between the writer cap
+ * being hit and the forced rotation taking effect. */
+#define PGWT_MAX_FILE_BLOCKS  (1024 * 1024)
+#define PGWT_MAX_READ_BLOCKS  (4 * PGWT_MAX_FILE_BLOCKS)
+
+/* Reader/recovery sanity cap for one compressed block (matches the historic
+ * fallback-scan cap; a real block is ≤ ~190 KB uncompressed). */
+#define PGWT_MAX_BLOCK_COMPRESSED (10u * 1024 * 1024)
+
+/* DUR-8: batch buffered sample-type records into ~1 s blocks instead of one
+ * tiny block per sampler tick (~10× fewer blocks at 10 Hz). */
+#define PGWT_SAMPLE_BATCH_NS  1000000000ULL
 
 /* Block type (trace format v2). Identifies what a block's columns mean.
  *   TRANSITIONS — wait-event transition intervals (exact fidelity): the
@@ -84,6 +104,7 @@ struct pgwt_event_writer {
     char          trace_dir[256];
     int           pg_version;
     int           retention_hours;
+    uint64_t      retention_bytes;  /* size cap for archived files (0 = off) */
     gid_t         trace_gid;      /* group for trace files, (gid_t)-1 = no chown */
     bool          enabled;
     bool          verbose;
@@ -92,6 +113,7 @@ struct pgwt_event_writer {
     FILE         *fp;
     char          current_path[512];
     int           current_hour;           /* day*24 + hour for rotation */
+    bool          force_rotate;           /* block cap reached — rotate now */
     uint64_t      file_start_wall_ns;
     uint64_t      file_start_mono_ns;
 
@@ -103,6 +125,16 @@ struct pgwt_event_writer {
     /* Event buffer (current block) */
     struct pgwt_trace_event events[PGWT_BLOCK_EVENTS];
     int           num_events;
+
+    /* Pending sample-type record buffer (DUR-8): many small pushes (one per
+     * sampler tick) are batched into ~1 s blocks. Type-agnostic — any
+     * non-TRANSITIONS block type routed through pgwt_writer_push_samples'
+     * buffering path shares it; a type or period change flushes first. */
+    struct pgwt_trace_event sample_buf[PGWT_BLOCK_EVENTS];
+    int           num_sample_buf;
+    uint16_t      sample_buf_type;        /* enum pgwt_block_type of batch */
+    uint64_t      sample_buf_period_ns;   /* period of the first batched push */
+    uint64_t      sample_buf_weight_ns;   /* Σ period_i per record (weighted mean) */
 
     /* Scratch buffers (allocated once) */
     uint8_t      *encode_buf;
@@ -138,8 +170,27 @@ int  pgwt_writer_push_samples(struct pgwt_event_writer *w,
 
 int  pgwt_writer_check_rotation(struct pgwt_event_writer *w);
 int  pgwt_writer_close(struct pgwt_event_writer *w);
+
+/* Retention (DUR-3). Deletes archived files past retention_hours (if > 0),
+ * cleans orphans (stale current.*.meta / *.meta.tmp with no writer), and —
+ * when retention_bytes > 0 — deletes the OLDEST archived .trace.lz4 /
+ * .summary.lz4 / preserved .corrupt files until total trace-dir usage fits
+ * under the cap. Never touches the live current.trace / current.summary or
+ * the sidecar .jsonl files. */
 int  pgwt_writer_cleanup_old_files(struct pgwt_event_writer *w);
 void pgwt_writer_destroy(struct pgwt_event_writer *w);
+
+/* ── Shared file-lifecycle helpers (used by summary_writer too) ── */
+
+/* Build a collision-safe archive path "<dir>/YYYY-MM-DD_HH<ext>"; if that
+ * exists, "<dir>/YYYY-MM-DD_HH.<n><ext>" for the first free n (DUR-2: a
+ * restart mid-hour or a DST fold must never clobber an existing archive).
+ * Returns 0 on success, -1 if no free name could be found. */
+int pgwt_archive_path_nonclobber(const char *dir, const struct tm *tm,
+                                 const char *ext, char *out, size_t out_size);
+
+/* fsync a directory so a just-renamed file survives power loss (DUR-5). */
+void pgwt_fsync_dir(const char *dir);
 
 /* ── Exposed for unit testing ─────────────────────────────── */
 

--- a/src/pg_wait_tracer.c
+++ b/src/pg_wait_tracer.c
@@ -40,6 +40,9 @@ static void usage(const char *prog)
         "Recording:\n"
         "  -T, --trace-dir <DIR>      Write raw trace files to DIR\n"
         "  -R, --trace-retention <H>  Keep trace files for H hours (default: 24)\n"
+        "      --retention-gb <G>     Also cap total trace-dir size at G GiB\n"
+        "                             (oldest archives deleted first; fractional\n"
+        "                             values allowed; default: no size cap)\n"
         "      --trace-group <GROUP>  Group for trace file access (default: dba)\n"
         "\n"
         "Replay (offline analysis — no root, no PostgreSQL needed):\n"
@@ -210,6 +213,7 @@ static enum pgwt_mode parse_mode(const char *s)
 #define OPT_ANOM_LOCK_FRAC  269
 #define OPT_ANOM_COOLDOWN   270
 #define OPT_ANOM_WINDOW     271
+#define OPT_RETENTION_GB    272
 
 static struct option long_opts[] = {
     {"pid",        required_argument, NULL, 'p'},
@@ -226,6 +230,7 @@ static struct option long_opts[] = {
     {"sort",            required_argument, NULL, 'S'},
     {"trace-dir",       required_argument, NULL, 'T'},
     {"trace-retention", required_argument, NULL, 'R'},
+    {"retention-gb",    required_argument, NULL, OPT_RETENTION_GB},
     {"replay",          no_argument,       NULL, OPT_REPLAY},
     {"from",            required_argument, NULL, OPT_FROM},
     {"to",              required_argument, NULL, OPT_TO},
@@ -306,6 +311,7 @@ int main(int argc, char **argv)
         case 'S': d->sort_mode = parse_sort(optarg); break;
         case 'T': d->trace_dir = optarg; break;
         case 'R': d->trace_retention = atoi(optarg); break;
+        case OPT_RETENTION_GB: d->trace_retention_gb = atof(optarg); break;
         case OPT_REPLAY: replay_mode = true; break;
         case OPT_FROM:   from_str = optarg; break;
         case OPT_TO:     to_str = optarg; break;

--- a/src/query_text.c
+++ b/src/query_text.c
@@ -11,6 +11,7 @@
 #include <fcntl.h>
 #include <unistd.h>
 #include <time.h>
+#include <sys/stat.h>
 
 /* ── Hash set for seen query_ids ─────────────────────────── */
 
@@ -22,7 +23,8 @@ static uint64_t hash64(uint64_t x)
     return x;
 }
 
-/* Returns 1 if query_id was already in the set, 0 if newly inserted. */
+/* Returns 0 if newly inserted, 1 if already in the set, 2 if the table is
+ * full (id NOT tracked — DUR-10: callers log this loudly, once). */
 static int seen_check_or_insert(struct pgwt_query_text_capture *qt,
                                  uint64_t query_id)
 {
@@ -38,8 +40,20 @@ static int seen_check_or_insert(struct pgwt_query_text_capture *qt,
         }
         idx = (idx + 1) & (QT_HT_SIZE - 1);
     }
-    /* Table full — treat as "seen" to avoid repeated reads */
-    return 1;
+    return 2;  /* table full */
+}
+
+/* DUR-10: the 4096-id dedup table capping out means query TEXT for further
+ * new query_ids is never captured again — that must be loud, once. */
+static void qt_log_cap_once(struct pgwt_query_text_capture *qt)
+{
+    if (qt->cap_logged)
+        return;
+    qt->cap_logged = true;
+    fprintf(stderr,
+            "WARN: query-text id table is FULL (%d unique query_ids) — "
+            "text for NEW query_ids will no longer be captured until the "
+            "daemon restarts (ids and waits are unaffected)\n", QT_HT_SIZE);
 }
 
 /* ── Read st_activity_raw from backend process ───────────── */
@@ -115,17 +129,113 @@ static void write_json_string(FILE *fp, const char *s, int len)
     fputc('"', fp);
 }
 
+/* ── Load / compact existing file (DUR-4) ────────────────── */
+
+/* Parse the query_id out of a JSONL line ({"q":"<signed id>",...}).
+ * Returns 0 on success. */
+static int qt_parse_line_qid(const char *line, uint64_t *qid)
+{
+    long long v;
+    if (sscanf(line, "{\"q\":\"%lld\"", &v) != 1)
+        return -1;
+    *qid = (uint64_t)(int64_t)v;
+    return 0;
+}
+
+/* Load the ids of an existing query_texts.jsonl into the seen set so a
+ * restarted daemon appends instead of re-capturing (and NEVER truncates —
+ * retained traces reference these ids). Memory is bounded by the fixed
+ * QT_HT_SIZE table; the line buffer is the only allocation (getline, freed).
+ *
+ * If the file exceeds the compaction threshold, it is rewritten atomically
+ * (tmp + rename) keeping the FIRST line per query_id — first-seen matches
+ * the capture semantics. Lines whose ids no longer fit in the table are
+ * kept verbatim (they may be referenced by retained traces; dropping them
+ * would lose data). */
+static void qt_load_existing(struct pgwt_query_text_capture *qt,
+                             const char *path)
+{
+    struct stat st;
+    if (stat(path, &st) != 0)
+        return;
+
+    long threshold = QT_COMPACT_THRESHOLD;
+    const char *env = getenv("PGWT_QT_COMPACT_BYTES");
+    if (env && atol(env) > 0)
+        threshold = atol(env);
+    int compact = st.st_size > threshold;
+
+    FILE *in = fopen(path, "r");
+    if (!in)
+        return;
+
+    FILE *out = NULL;
+    char tmp_path[600];
+    if (compact) {
+        snprintf(tmp_path, sizeof(tmp_path), "%s.tmp", path);
+        out = fopen(tmp_path, "w");
+        if (!out)
+            compact = 0;   /* fall back to plain load */
+    }
+
+    char *line = NULL;
+    size_t line_cap = 0;
+    ssize_t len;
+    int loaded = 0, dropped = 0;
+    while ((len = getline(&line, &line_cap, in)) > 0) {
+        uint64_t qid;
+        if (qt_parse_line_qid(line, &qid) != 0 || qid == 0) {
+            dropped++;   /* torn/garbage line (e.g. crash mid-append) */
+            continue;
+        }
+        int rc = seen_check_or_insert(qt, qid);
+        if (rc == 0)
+            loaded++;
+        else if (rc == 2)
+            qt_log_cap_once(qt);
+        if (compact && (rc == 0 || rc == 2)) {
+            /* keep first occurrence; keep untracked (table-full) lines */
+            if (fwrite(line, 1, (size_t)len, out) != (size_t)len) {
+                /* tmp write failed — abandon compaction, keep original */
+                fclose(out);
+                out = NULL;
+                unlink(tmp_path);
+                compact = 0;
+            }
+        }
+    }
+    free(line);
+    fclose(in);
+
+    if (compact && out) {
+        fflush(out);
+        fsync(fileno(out));
+        fclose(out);
+        if (rename(tmp_path, path) != 0)
+            unlink(tmp_path);
+        else if (qt->verbose)
+            fprintf(stderr, "INFO: compacted query_texts.jsonl\n");
+    }
+
+    if (qt->verbose)
+        fprintf(stderr, "INFO: loaded %d existing query text ids "
+                "(%d unreadable lines skipped)%s\n", loaded, dropped,
+                qt->cap_logged ? " — id table full" : "");
+}
+
 /* ── Public API ──────────────────────────────────────────── */
 
 int pgwt_qt_init(struct pgwt_query_text_capture *qt,
                  const char *trace_dir,
                  uint64_t my_be_entry_addr,
-                 int st_activity_offset)
+                 int st_activity_offset,
+                 gid_t trace_gid)
 {
     memset(qt, 0, sizeof(*qt));
     snprintf(qt->trace_dir, sizeof(qt->trace_dir), "%s", trace_dir);
     qt->my_be_entry_addr = my_be_entry_addr;
     qt->st_activity_offset = st_activity_offset;
+    qt->trace_gid = trace_gid;
     qt->enabled = true;
 
     /* Allocate reusable read buffer (1 MB on heap, not stack) */
@@ -136,14 +246,25 @@ int pgwt_qt_init(struct pgwt_query_text_capture *qt,
         return -1;
     }
 
-    /* Open (truncate) query_texts.jsonl */
     char path[512];
     snprintf(path, sizeof(path), "%s/query_texts.jsonl", trace_dir);
-    qt->fp = fopen(path, "w");
+
+    /* DUR-4: dedup-on-load + bounded compaction, then APPEND — never "w".
+     * Retained trace files reference these ids across restarts. */
+    qt_load_existing(qt, path);
+
+    qt->fp = fopen(path, "a");
     if (!qt->fp) {
-        fprintf(stderr, "WARN: cannot create %s: %s\n", path, strerror(errno));
+        fprintf(stderr, "WARN: cannot open %s: %s\n", path, strerror(errno));
         qt->enabled = false;
         return -1;
+    }
+
+    /* DUR-10: match trace-file group/permissions (raw SQL may contain
+     * literals — it must not be more readable than the traces). */
+    if (qt->trace_gid != (gid_t)-1) {
+        fchown(fileno(qt->fp), (uid_t)-1, qt->trace_gid);
+        fchmod(fileno(qt->fp), 0640);
     }
 
     return 0;
@@ -156,8 +277,12 @@ void pgwt_qt_check(struct pgwt_query_text_capture *qt,
         return;
 
     /* Check if already seen */
-    if (seen_check_or_insert(qt, query_id))
+    int rc = seen_check_or_insert(qt, query_id);
+    if (rc != 0) {
+        if (rc == 2)
+            qt_log_cap_once(qt);
         return;
+    }
 
     /* New query_id — read st_activity_raw from the backend */
     int len = read_activity(qt, pid, qt->read_buf, QT_MAX_TEXT);
@@ -197,8 +322,12 @@ void pgwt_qt_store(struct pgwt_query_text_capture *qt,
         return;
 
     /* Check if already seen */
-    if (seen_check_or_insert(qt, query_id))
+    int rc = seen_check_or_insert(qt, query_id);
+    if (rc != 0) {
+        if (rc == 2)
+            qt_log_cap_once(qt);
         return;
+    }
 
     int len = (int)strnlen(text, PGWT_QUERY_TEXT_LEN - 1);
 

--- a/src/query_text.h
+++ b/src/query_text.h
@@ -21,6 +21,11 @@
 /* Max length of captured query text (matches PG's max track_activity_query_size) */
 #define QT_MAX_TEXT (1024 * 1024)
 
+/* DUR-4: query_texts.jsonl is compacted (deduplicated in place, atomically)
+ * at startup only when it exceeds this size. Overridable for tests via the
+ * PGWT_QT_COMPACT_BYTES environment variable. */
+#define QT_COMPACT_THRESHOLD (32 * 1024 * 1024)
+
 struct pgwt_query_text_capture {
     char          trace_dir[256];
     FILE         *fp;                    /* query_texts.jsonl file handle */
@@ -28,10 +33,13 @@ struct pgwt_query_text_capture {
     /* Seen set: open-addressing hash table of query_ids */
     uint64_t      seen[QT_HT_SIZE];
     int           num_seen;
+    bool          cap_logged;            /* DUR-10: seen-table-full logged once */
 
     /* Addresses for reading st_activity_raw */
     uint64_t      my_be_entry_addr;     /* MyBEEntry symbol VA */
     int           st_activity_offset;   /* offset of st_activity_raw in PgBackendStatus */
+
+    gid_t         trace_gid;             /* group for the file, (gid_t)-1 = none */
 
     char         *read_buf;              /* reusable read buffer (QT_MAX_TEXT bytes) */
 
@@ -39,11 +47,17 @@ struct pgwt_query_text_capture {
     bool          verbose;
 };
 
-/* Initialize query text capture. Returns 0 on success. */
+/* Initialize query text capture. Returns 0 on success.
+ * DUR-4: query_texts.jsonl is opened in APPEND mode and existing entries are
+ * loaded into the seen set (dedup-on-load) — retained trace files reference
+ * these query_ids across daemon restarts, so the file must never be
+ * truncated. trace_gid mirrors the trace files' group/permissions (DUR-10);
+ * pass (gid_t)-1 for none. */
 int pgwt_qt_init(struct pgwt_query_text_capture *qt,
                  const char *trace_dir,
                  uint64_t my_be_entry_addr,
-                 int st_activity_offset);
+                 int st_activity_offset,
+                 gid_t trace_gid);
 
 /* Check if query_id is new; if so, capture st_activity_raw from the backend.
  * Called from the event stream handler for each trace event with query_id != 0.

--- a/src/server.c
+++ b/src/server.c
@@ -200,6 +200,8 @@ struct pgwt_load_info {
     int      has_transitions;   /* a TRANSITIONS block contributed records */
     int      has_samples;       /* a SAMPLES record survived the merge */
     uint64_t sample_period_ns;  /* nominal sample interval (0 if no samples) */
+    int      overloaded;        /* DUR-9: hard load bound hit — result is
+                                   partial; handlers MUST error, not render */
 };
 
 struct pgwt_server {
@@ -699,17 +701,38 @@ get_cached_immutable(struct pgwt_server *srv, const char *path)
     return ce;
 }
 
+/* DUR-9: hard bound on the raw-load working array. Defaults to the same
+ * budget as the immutable-file cache (25% of RAM, capped at 2 GB); the
+ * PGWT_LOAD_MAX_EVENTS environment variable overrides it (tests use a tiny
+ * value to prove the bound fires as a structured error, never an OOM). */
+static int load_max_events(void)
+{
+    static int cached = 0;
+    if (cached)
+        return cached;
+    const char *env = getenv("PGWT_LOAD_MAX_EVENTS");
+    if (env && atoi(env) > 0)
+        cached = atoi(env);
+    else
+        cached = cache_max_events();
+    return cached;
+}
+
 /* Read events from a trace file for a MONO time range — on demand, no
  * caching. Opens file, seeks to the right blocks via block index, decodes
  * only the blocks that overlap [from_mono, to_mono]. Appends events at
  * *total (growing as needed) with timestamps left MONOTONIC. SAMPLES
  * records are normalized to interval shape (old_event = sampled event,
  * duration_ns = sample_period_ns) so the duration-based estimators apply
- * ASH math. */
+ * ASH math.
+ * DUR-9: `pid` != 0 pushes the pid filter into the load (events for other
+ * pids never enter the working array); *overloaded is set and the load
+ * stops when *total reaches load_max_events(). */
 static void load_file_range_mono(const char *path,
                                  uint64_t from_mono, uint64_t to_mono,
+                                 uint32_t pid,
                                  struct pgwt_trace_event **events,
-                                 int *total, int *cap)
+                                 int *total, int *cap, int *overloaded)
 {
     struct pgwt_event_reader reader;
     if (pgwt_reader_open(&reader, path) != 0)
@@ -717,6 +740,7 @@ static void load_file_range_mono(const char *path,
 
     int first_block = pgwt_reader_find_block(&reader, from_mono);
     struct pgwt_trace_event block_buf[PGWT_BLOCK_EVENTS];
+    int max_events = load_max_events();
 
     for (int b = first_block; b < reader.num_blocks; b++) {
         if (reader.block_index[b].timestamp_ns > to_mono)
@@ -731,7 +755,14 @@ static void load_file_range_mono(const char *path,
             uint64_t ts_mono = block_buf[i].timestamp_ns;
             if (ts_mono < from_mono) continue;
             if (ts_mono > to_mono) break;
+            if (pid != 0 && block_buf[i].pid != pid)
+                continue;
 
+            if (*total >= max_events) {
+                *overloaded = 1;
+                pgwt_reader_close(&reader);
+                return;
+            }
             if (*total >= *cap) {
                 *cap *= 2;
                 struct pgwt_trace_event *tmp = realloc(*events, *cap * sizeof(**events));
@@ -1298,14 +1329,26 @@ static struct pgwt_wfid window_fidelity(struct pgwt_server *srv,
  * the merge runs in the monotonic domain per clock generation).
  * When `info` is non-NULL it is filled with what actually contributed
  * (has_transitions / has_samples / sample_period_ns).
+ *
+ * DUR-9: `pid` != 0 is a pushdown of the request's pid filter — only that
+ * pid's events enter the working array, so a pid-filtered query over a long
+ * window costs memory proportional to ONE backend's events, not the whole
+ * window. Callers pass 0 when the compute needs cross-pid records that a
+ * uniform per-event filter would not see (variants reads every pid's
+ * exec/plan markers). The array is hard-bounded by load_max_events(): on
+ * overflow info->overloaded is set and handlers must emit the structured
+ * "window too large" error instead of rendering the partial result.
  */
 static struct pgwt_trace_event *
 server_load_events_fi(struct pgwt_server *srv,
                       uint64_t from_wall_ns, uint64_t to_wall_ns,
+                      uint32_t pid,
                       int *out_count, struct pgwt_load_info *info)
 {
     *out_count = 0;
     if (info) memset(info, 0, sizeof(*info));
+    int overloaded = 0;
+    int max_events = load_max_events();
 
     /* Rescan directory + refresh coverage/clock-domain state. */
     coverage_refresh(srv);
@@ -1327,7 +1370,8 @@ server_load_events_fi(struct pgwt_server *srv,
     int n_segs = 0;
     uint64_t sample_period_ns = 0;
 
-    for (int ci = 0; ci < srv->cov_count && n_segs < 256; ci++) {
+    for (int ci = 0; ci < srv->cov_count && n_segs < 256 && !overloaded;
+         ci++) {
         struct pgwt_file_cov *fc = &srv->cov[ci];
         if (!fc->valid)
             continue;
@@ -1350,20 +1394,26 @@ server_load_events_fi(struct pgwt_server *srv,
 
         if (fc->is_current) {
             /* On-demand: read only blocks in [from, to] */
-            load_file_range_mono(fc->path, from_m, to_m,
-                                 &events, &total, &cap);
+            load_file_range_mono(fc->path, from_m, to_m, pid,
+                                 &events, &total, &cap, &overloaded);
         } else {
             struct file_cache_entry *ce = get_cached_immutable(srv, fc->path);
             if (!ce || !ce->events) {
                 /* Cache miss (file too large or alloc failed) */
-                load_file_range_mono(fc->path, from_m, to_m,
-                                     &events, &total, &cap);
+                load_file_range_mono(fc->path, from_m, to_m, pid,
+                                     &events, &total, &cap, &overloaded);
             } else {
                 for (int i = 0; i < ce->count; i++) {
                     uint64_t ts = ce->events[i].timestamp_ns;
                     if (ts < from_m) continue;
                     if (ts > to_m) break;
+                    if (pid != 0 && ce->events[i].pid != pid)
+                        continue;
 
+                    if (total >= max_events) {
+                        overloaded = 1;
+                        break;
+                    }
                     if (total >= cap) {
                         cap *= 2;
                         struct pgwt_trace_event *tmp =
@@ -1439,7 +1489,13 @@ server_load_events_fi(struct pgwt_server *srv,
         info->has_transitions = has_transitions;
         info->has_samples = has_samples;
         info->sample_period_ns = has_samples ? sample_period_ns : 0;
+        info->overloaded = overloaded;
     }
+    if (overloaded)
+        fprintf(stderr, "ERROR: window too large: the requested range holds "
+                "more than %d events%s — narrow the time range%s\n",
+                max_events, pid ? " for this pid" : "",
+                pid ? "" : " or add a pid/query filter");
 
     *out_count = total;
     return events;
@@ -1577,6 +1633,28 @@ static void emit_unavailable(uint64_t req_id, enum pgwt_fidelity fid)
     emit_json(root);
 }
 
+/* DUR-9: the raw-load hard bound fired — the loaded array is PARTIAL.
+ * Rendering it would silently under-report; emit a structured error the
+ * client can present ("window too large") instead. Frees the partial array
+ * and returns 1 when the handler must stop. */
+static int reject_overload(const struct pgwt_request *req,
+                           struct pgwt_trace_event *events,
+                           const struct pgwt_load_info *info)
+{
+    if (!info->overloaded)
+        return 0;
+    free(events);
+    cJSON *root = cJSON_CreateObject();
+    cJSON_AddNumberToObject(root, "id", (double)req->id);
+    cJSON_AddStringToObject(root, "error", "window too large");
+    cJSON_AddStringToObject(root, "code", "window_too_large");
+    cJSON_AddNumberToObject(root, "max_events", load_max_events());
+    cJSON_AddStringToObject(root, "hint",
+        "narrow the time range or add a pid/query filter");
+    emit_json(root);
+    return 1;
+}
+
 /* ── Command handlers ─────────────────────────────────────── */
 
 static void handle_info(struct pgwt_server *srv, struct pgwt_request *req)
@@ -1634,7 +1712,9 @@ static void handle_aas(struct pgwt_server *srv, struct pgwt_request *req)
     } else {
         int count;
         struct pgwt_trace_event *events =
-            server_load_events_fi(srv, req->from_ns, req->to_ns, &count, &linfo);
+            server_load_events_fi(srv, req->from_ns, req->to_ns,
+                                  req->filter.pid, &count, &linfo);
+        if (reject_overload(req, events, &linfo)) return;
         pgwt_compute_aas(events, count, &req->filter, from, to, num_buckets,
                          detail_events, AAS_MAX_EVENT_SERIES, &aas);
         free(events);
@@ -1718,7 +1798,9 @@ static void handle_time_model(struct pgwt_server *srv, struct pgwt_request *req)
     } else {
         int count;
         struct pgwt_trace_event *events =
-            server_load_events_fi(srv, req->from_ns, req->to_ns, &count, &linfo);
+            server_load_events_fi(srv, req->from_ns, req->to_ns,
+                                  req->filter.pid, &count, &linfo);
+        if (reject_overload(req, events, &linfo)) return;
         pgwt_compute_time_model(events, count, &req->filter, wall_ms, &tm);
         free(events);
     }
@@ -1784,7 +1866,9 @@ static void handle_top_events(struct pgwt_server *srv, struct pgwt_request *req)
     } else {
         int count;
         struct pgwt_trace_event *events =
-            server_load_events_fi(srv, req->from_ns, req->to_ns, &count, &linfo);
+            server_load_events_fi(srv, req->from_ns, req->to_ns,
+                                  req->filter.pid, &count, &linfo);
+        if (reject_overload(req, events, &linfo)) return;
         pgwt_compute_top_events(events, count, &req->filter, wall_ms, &res);
         free(events);
     }
@@ -1855,7 +1939,9 @@ static void handle_top_sessions(struct pgwt_server *srv, struct pgwt_request *re
     } else {
         int count;
         struct pgwt_trace_event *events =
-            server_load_events_fi(srv, req->from_ns, req->to_ns, &count, &linfo);
+            server_load_events_fi(srv, req->from_ns, req->to_ns,
+                                  req->filter.pid, &count, &linfo);
+        if (reject_overload(req, events, &linfo)) return;
         pgwt_compute_top_sessions(events, count, &req->filter, wall_ms, &res);
         free(events);
     }
@@ -1908,9 +1994,12 @@ static void handle_top_queries(struct pgwt_server *srv, struct pgwt_request *req
 
     /* Use summaries for large ranges (>120s) for the class breakdown.
      * Always load raw events for lifecycle stats (exec/plan counts).
-     * Large files are read on-demand (not cached) so this is safe. */
-    all_events = server_load_events_fi(srv, req->from_ns, req->to_ns, &ecount,
-                                       &linfo);
+     * Large files are read on-demand (not cached) so this is safe.
+     * No pid pushdown: the lifecycle stats below read exec/plan markers
+     * across ALL pids (markers never pass the uniform filter). */
+    all_events = server_load_events_fi(srv, req->from_ns, req->to_ns, 0,
+                                       &ecount, &linfo);
+    if (reject_overload(req, all_events, &linfo)) return;
     if (!has_event_filter && should_use_summaries(srv, req, &wfid)) {
         pgwt_compute_top_queries_from_summaries(srv->trace_dir, from, to,
                                                  &req->filter, wall_ms, &res);
@@ -2162,7 +2251,9 @@ static void handle_heatmap(struct pgwt_server *srv, struct pgwt_request *req)
         int count;
         struct pgwt_load_info linfo = {0};
         struct pgwt_trace_event *events =
-            server_load_events_fi(srv, req->from_ns, req->to_ns, &count, &linfo);
+            server_load_events_fi(srv, req->from_ns, req->to_ns,
+                                  req->filter.pid, &count, &linfo);
+        if (reject_overload(req, events, &linfo)) return;
         enum pgwt_fidelity fid = load_fidelity(&linfo);
         if (pgwt_fidelity_unavailable(PGWT_REQ_EXACT, fid)) {
             free(events);
@@ -2229,7 +2320,9 @@ static void handle_session_timeline(struct pgwt_server *srv, struct pgwt_request
     int count;
     struct pgwt_load_info linfo = {0};
     struct pgwt_trace_event *events =
-        server_load_events_fi(srv, req->from_ns, req->to_ns, &count, &linfo);
+        server_load_events_fi(srv, req->from_ns, req->to_ns,
+                              req->filter.pid, &count, &linfo);
+    if (reject_overload(req, events, &linfo)) return;
 
     /* First pass: count matching events and collect unique PIDs */
     uint32_t pids[TIMELINE_MAX_PIDS];
@@ -2402,7 +2495,9 @@ static void handle_transitions(struct pgwt_server *srv, struct pgwt_request *req
     int count;
     struct pgwt_load_info linfo = {0};
     struct pgwt_trace_event *events =
-        server_load_events_fi(srv, req->from_ns, req->to_ns, &count, &linfo);
+        server_load_events_fi(srv, req->from_ns, req->to_ns,
+                              req->filter.pid, &count, &linfo);
+    if (reject_overload(req, events, &linfo)) return;
 
     /* Transitions need real old→new order: EXACT-required. */
     enum pgwt_fidelity fid = load_fidelity(&linfo);
@@ -2498,7 +2593,9 @@ static void handle_fingerprints(struct pgwt_server *srv, struct pgwt_request *re
     int count;
     struct pgwt_load_info linfo = {0};
     struct pgwt_trace_event *events =
-        server_load_events_fi(srv, req->from_ns, req->to_ns, &count, &linfo);
+        server_load_events_fi(srv, req->from_ns, req->to_ns,
+                              req->filter.pid, &count, &linfo);
+    if (reject_overload(req, events, &linfo)) return;
 
     /* Fingerprints aggregate transition sequences: EXACT-required. */
     enum pgwt_fidelity fid = load_fidelity(&linfo);
@@ -2552,7 +2649,9 @@ static void handle_lock_chains(struct pgwt_server *srv, struct pgwt_request *req
     int count;
     struct pgwt_load_info linfo = {0};
     struct pgwt_trace_event *events =
-        server_load_events_fi(srv, req->from_ns, req->to_ns, &count, &linfo);
+        server_load_events_fi(srv, req->from_ns, req->to_ns,
+                              req->filter.pid, &count, &linfo);
+    if (reject_overload(req, events, &linfo)) return;
 
     /* Lock-chain inference needs real wait/CPU overlap intervals: EXACT. */
     enum pgwt_fidelity fid = load_fidelity(&linfo);
@@ -2591,7 +2690,9 @@ static void handle_interference(struct pgwt_server *srv, struct pgwt_request *re
     int count;
     struct pgwt_load_info linfo = {0};
     struct pgwt_trace_event *events =
-        server_load_events_fi(srv, req->from_ns, req->to_ns, &count, &linfo);
+        server_load_events_fi(srv, req->from_ns, req->to_ns,
+                              req->filter.pid, &count, &linfo);
+    if (reject_overload(req, events, &linfo)) return;
 
     /* Interference scoring needs real simultaneous-wait overlap: EXACT. */
     enum pgwt_fidelity fid = load_fidelity(&linfo);
@@ -2630,7 +2731,9 @@ static void handle_concurrency(struct pgwt_server *srv, struct pgwt_request *req
     int count;
     struct pgwt_load_info linfo = {0};
     struct pgwt_trace_event *events =
-        server_load_events_fi(srv, req->from_ns, req->to_ns, &count, &linfo);
+        server_load_events_fi(srv, req->from_ns, req->to_ns,
+                              req->filter.pid, &count, &linfo);
+    if (reject_overload(req, events, &linfo)) return;
 
     /* Burst detection needs real simultaneous-wait intervals: EXACT. */
     enum pgwt_fidelity fid = load_fidelity(&linfo);
@@ -2748,7 +2851,12 @@ static void handle_variants(struct pgwt_server *srv, struct pgwt_request *req)
     int count;
     struct pgwt_load_info linfo = {0};
     struct pgwt_trace_event *events =
-        server_load_events_fi(srv, req->from_ns, req->to_ns, &count, &linfo);
+        server_load_events_fi(srv, req->from_ns, req->to_ns,
+                              /* no pid pushdown: variants read every pid's
+                               * exec/plan markers, which never pass the
+                               * uniform per-event filter */ 0,
+                              &count, &linfo);
+    if (reject_overload(req, events, &linfo)) return;
 
     /* Variants are built from marker-delimited transition sequences, which
      * only exist in full-fidelity data: EXACT-required. */
@@ -3018,7 +3126,14 @@ static void dump_summary(struct pgwt_server *srv)
     int count;
     struct pgwt_load_info linfo = {0};
     struct pgwt_trace_event *events =
-        server_load_events_fi(srv, from, to, &count, &linfo);
+        server_load_events_fi(srv, from, to, 0, &count, &linfo);
+    if (linfo.overloaded) {
+        printf("ERROR: window too large — more than %d events in range; "
+               "use the JSON interface with a narrower range\n",
+               load_max_events());
+        free(events);
+        return;
+    }
 
     /* Count sample vs transition records so a sampled-mode trace is visible
      * at a glance (A2 evidence: SAMPLES blocks landed). */

--- a/src/summary_reader.c
+++ b/src/summary_reader.c
@@ -57,7 +57,10 @@ int pgwt_summary_reader_open(struct pgwt_summary_reader *r, const char *path)
         FILE *mf = fopen(meta_path, "r");
         if (mf) {
             int committed = 0;
-            if (fscanf(mf, "%d", &committed) == 1 && committed > 0) {
+            /* DUR-7: cap the committed count (it sizes an allocation) and
+             * sanity-check each block header, exactly like event_reader. */
+            if (fscanf(mf, "%d", &committed) == 1 && committed > 0 &&
+                committed < PGWT_MAX_READ_BLOCKS) {
                 fseek(r->fp, (long)sizeof(struct pgwt_trace_file_header),
                       SEEK_SET);
                 r->block_index = malloc(committed *
@@ -67,7 +70,8 @@ int pgwt_summary_reader_open(struct pgwt_summary_reader *r, const char *path)
                     struct pgwt_summary_block_header bh;
                     while (r->num_blocks < committed &&
                            fread(&bh, sizeof(bh), 1, r->fp) == 1 &&
-                           bh.compressed_size > 0) {
+                           bh.compressed_size > 0 &&
+                           bh.compressed_size <= PGWT_MAX_BLOCK_COMPRESSED) {
                         long off = ftell(r->fp) - (long)sizeof(bh);
                         r->block_index[r->num_blocks].file_offset = (uint64_t)off;
                         r->block_index[r->num_blocks].timestamp_ns = bh.wall_ns;
@@ -93,7 +97,7 @@ int pgwt_summary_reader_open(struct pgwt_summary_reader *r, const char *path)
         uint32_t nb = 0;
         if (fseek(r->fp, -4, SEEK_END) == 0 &&
             fread(&nb, sizeof(nb), 1, r->fp) == 1 &&
-            nb > 0 && nb < 100000) {
+            nb > 0 && nb < PGWT_MAX_READ_BLOCKS) {
             long index_start = ftell(r->fp) - 4
                              - (long)nb * (long)sizeof(struct pgwt_block_index_entry);
             if (index_start >= (long)sizeof(struct pgwt_trace_file_header)) {
@@ -102,8 +106,24 @@ int pgwt_summary_reader_open(struct pgwt_summary_reader *r, const char *path)
                 if (r->block_index &&
                     fread(r->block_index, sizeof(struct pgwt_block_index_entry),
                           nb, r->fp) == nb) {
-                    r->num_blocks = (int)nb;
-                    have_index = 1;
+                    /* DUR-7: verify the index shape before trusting it
+                     * (see event_reader.c Strategy 2). */
+                    int valid =
+                        r->block_index[0].file_offset ==
+                        sizeof(struct pgwt_trace_file_header);
+                    for (uint32_t i = 1; valid && i < nb; i++)
+                        if (r->block_index[i].file_offset <=
+                                r->block_index[i - 1].file_offset ||
+                            r->block_index[i].file_offset >=
+                                (uint64_t)index_start)
+                            valid = 0;
+                    if (valid) {
+                        r->num_blocks = (int)nb;
+                        have_index = 1;
+                    } else {
+                        free(r->block_index);
+                        r->block_index = NULL;
+                    }
                 } else {
                     free(r->block_index);
                     r->block_index = NULL;
@@ -124,7 +144,9 @@ int pgwt_summary_reader_open(struct pgwt_summary_reader *r, const char *path)
         r->num_blocks = 0;
         struct pgwt_summary_block_header bh;
         while (fread(&bh, sizeof(bh), 1, r->fp) == 1 &&
-               bh.compressed_size > 0 && bh.uncompressed_size > 0) {
+               bh.compressed_size > 0 && bh.uncompressed_size > 0 &&
+               bh.compressed_size <= PGWT_MAX_BLOCK_COMPRESSED &&
+               bh.uncompressed_size <= PGWT_MAX_BLOCK_COMPRESSED) {
             if (r->num_blocks >= cap) {
                 cap *= 2;
                 struct pgwt_block_index_entry *tmp =

--- a/src/summary_writer.c
+++ b/src/summary_writer.c
@@ -398,6 +398,153 @@ int pgwt_summary_deserialize(const uint8_t *in, size_t in_size,
     return 0;
 }
 
+/* ── Startup recovery (DUR-1) ─────────────────────────────── */
+
+/* Same contract as the trace writer's recovery: a leftover current.summary
+ * is finalized (torn tail dropped, footer appended) and renamed aside to a
+ * collision-safe archive — NEVER truncated. */
+static void recover_current_summary(struct pgwt_summary_writer *w)
+{
+    char cur[512], meta[600], meta_tmp[600];
+    snprintf(cur, sizeof(cur), "%s/current.summary", w->trace_dir);
+    snprintf(meta, sizeof(meta), "%s/current.summary.meta", w->trace_dir);
+    snprintf(meta_tmp, sizeof(meta_tmp), "%s/current.summary.meta.tmp",
+             w->trace_dir);
+
+    unlink(meta_tmp);   /* torn meta write — always stale */
+
+    struct stat st;
+    if (stat(cur, &st) != 0) {
+        unlink(meta);
+        return;
+    }
+
+    int committed = 0;
+    {
+        FILE *mf = fopen(meta, "r");
+        if (mf) {
+            if (fscanf(mf, "%d", &committed) != 1)
+                committed = 0;
+            fclose(mf);
+        }
+    }
+
+    FILE *fp = fopen(cur, "r+b");
+    struct pgwt_trace_file_header hdr;
+    if (!fp) {
+        fprintf(stderr, "WARN: cannot open %s for recovery: %s "
+                "(leaving it in place)\n", cur, strerror(errno));
+        return;
+    }
+    if (fread(&hdr, sizeof(hdr), 1, fp) != 1 ||
+        hdr.magic != PGWT_SUMMARY_MAGIC ||
+        (hdr.version != 1 && hdr.version != PGWT_SUMMARY_VERSION)) {
+        fclose(fp);
+        char aside[600];
+        snprintf(aside, sizeof(aside), "%s.corrupt.%lld", cur,
+                 (long long)time(NULL));
+        if (rename(cur, aside) == 0)
+            fprintf(stderr, "WARN: %s has an unreadable header — preserved "
+                    "as %s\n", cur, aside);
+        unlink(meta);
+        pgwt_fsync_dir(w->trace_dir);
+        return;
+    }
+
+    long fsize = (long)st.st_size;
+    struct pgwt_block_index_entry *idx = NULL;
+    int nidx = 0, cap = 0;
+    long pos = (long)sizeof(hdr);
+    struct pgwt_summary_block_header bh;
+    while (nidx < PGWT_MAX_READ_BLOCKS) {
+        if (fseek(fp, pos, SEEK_SET) != 0 ||
+            fread(&bh, sizeof(bh), 1, fp) != 1)
+            break;
+        if (bh.compressed_size == 0 || bh.uncompressed_size == 0 ||
+            bh.compressed_size > PGWT_MAX_BLOCK_COMPRESSED ||
+            bh.uncompressed_size > PGWT_MAX_BLOCK_COMPRESSED)
+            break;
+        long end = pos + (long)sizeof(bh) + (long)bh.compressed_size;
+        if (end > fsize)
+            break;   /* torn tail */
+        if (nidx >= cap) {
+            int newcap = cap ? cap * 2 : 256;
+            struct pgwt_block_index_entry *tmp =
+                realloc(idx, newcap * sizeof(*tmp));
+            if (!tmp)
+                break;
+            idx = tmp;
+            cap = newcap;
+        }
+        idx[nidx++] = (struct pgwt_block_index_entry){
+            .timestamp_ns = bh.wall_ns,
+            .file_offset = (uint64_t)pos,
+        };
+        pos = end;
+    }
+
+    if (committed > nidx)
+        fprintf(stderr, "ERROR: recovery of %s found %d complete blocks but "
+                "the meta high-watermark says %d were committed\n",
+                cur, nidx, committed);
+
+    if (nidx == 0) {
+        free(idx);
+        fclose(fp);
+        if (fsize > (long)sizeof(hdr)) {
+            char aside[600];
+            snprintf(aside, sizeof(aside), "%s.corrupt.%lld", cur,
+                     (long long)time(NULL));
+            if (rename(cur, aside) == 0)
+                fprintf(stderr, "WARN: %s had no complete block — preserved "
+                        "as %s\n", cur, aside);
+        } else {
+            unlink(cur);
+        }
+        unlink(meta);
+        pgwt_fsync_dir(w->trace_dir);
+        return;
+    }
+
+    int finalize_failed = 0;
+    if (ftruncate(fileno(fp), (off_t)pos) != 0)
+        finalize_failed = 1;
+    if (!finalize_failed && fseek(fp, pos, SEEK_SET) == 0) {
+        for (int i = 0; i < nidx && !finalize_failed; i++)
+            if (fwrite(&idx[i], sizeof(idx[i]), 1, fp) != 1)
+                finalize_failed = 1;
+        uint32_t nb = (uint32_t)nidx;
+        if (!finalize_failed && fwrite(&nb, sizeof(nb), 1, fp) != 1)
+            finalize_failed = 1;
+    } else {
+        finalize_failed = 1;
+    }
+    fflush(fp);
+    fsync(fileno(fp));
+    fclose(fp);
+    free(idx);
+    if (finalize_failed)
+        fprintf(stderr, "WARN: could not append a footer to recovered %s "
+                "(%s) — archiving anyway\n", cur, strerror(errno));
+
+    time_t start_sec = (time_t)(hdr.start_time_ns / 1000000000ULL);
+    struct tm tm;
+    localtime_r(&start_sec, &tm);
+    char dest[512];
+    if (pgwt_archive_path_nonclobber(w->trace_dir, &tm, ".summary.lz4",
+                                     dest, sizeof(dest)) != 0 ||
+        rename(cur, dest) != 0) {
+        fprintf(stderr, "WARN: cannot archive recovered %s: %s "
+                "(leaving it in place; it will NOT be truncated)\n",
+                cur, strerror(errno));
+        return;
+    }
+    unlink(meta);
+    pgwt_fsync_dir(w->trace_dir);
+    fprintf(stderr, "INFO: recovered previous current.summary: %d blocks "
+            "-> %s\n", nidx, dest);
+}
+
 /* ── File operations ──────────────────────────────────────── */
 
 static int write_footer(struct pgwt_summary_writer *w)
@@ -417,7 +564,13 @@ static int open_summary_file(struct pgwt_summary_writer *w)
     snprintf(w->current_path, sizeof(w->current_path),
              "%s/current.summary", w->trace_dir);
 
-    w->fp = fopen(w->current_path, "wb");
+    /* DUR-1: never truncate an existing current.summary ("wbx"); recover
+     * and retry if one (re)appeared after init. */
+    w->fp = fopen(w->current_path, "wbx");
+    if (!w->fp && errno == EEXIST) {
+        recover_current_summary(w);
+        w->fp = fopen(w->current_path, "wbx");
+    }
     if (!w->fp) {
         fprintf(stderr, "WARN: cannot create %s: %s\n",
                 w->current_path, strerror(errno));
@@ -578,6 +731,10 @@ int pgwt_summary_writer_init(struct pgwt_summary_writer *w,
 
     /* Directory already created by event_writer */
 
+    /* DUR-1: recover (finalize + archive) any current.summary a previous
+     * daemon left behind — never truncate it. */
+    recover_current_summary(w);
+
     /* Allocate scratch buffers.
      * Worst case: 1024 events × 156 + 1024 sessions × 32 + 2048 queries × 36
      *           = 159744 + 32768 + 73728 = ~260 KB uncompressed */
@@ -661,19 +818,25 @@ int pgwt_summary_check_rotation(struct pgwt_summary_writer *w)
                 (unsigned long)w->total_bytes_written);
     }
 
+    /* DUR-5: archives are durable once rotated. */
+    fflush(w->fp);
+    fsync(fileno(w->fp));
     fclose(w->fp);
     w->fp = NULL;
 
-    /* Rename current.summary → YYYY-MM-DD_HH.summary.lz4 */
+    /* Rename current.summary → YYYY-MM-DD_HH[.N].summary.lz4 (DUR-2:
+     * collision-safe — see the trace writer's rotation comment). */
     time_t file_start_sec = (time_t)(w->clock_offset_wall_ns / 1000000000ULL);
     struct tm file_tm;
     localtime_r(&file_start_sec, &file_tm);
     char new_path[512];
-    snprintf(new_path, sizeof(new_path), "%s/%04d-%02d-%02d_%02d.summary.lz4",
-             w->trace_dir,
-             file_tm.tm_year + 1900, file_tm.tm_mon + 1,
-             file_tm.tm_mday, file_tm.tm_hour);
-    rename(w->current_path, new_path);
+    if (pgwt_archive_path_nonclobber(w->trace_dir, &file_tm, ".summary.lz4",
+                                     new_path, sizeof(new_path)) == 0)
+        rename(w->current_path, new_path);
+    else
+        fprintf(stderr, "WARN: no free archive name for %s — leaving it as "
+                "current.summary (it will be recovered on next start)\n",
+                w->current_path);
 
     /* Remove meta file */
     {
@@ -682,6 +845,7 @@ int pgwt_summary_check_rotation(struct pgwt_summary_writer *w)
                  w->trace_dir);
         unlink(meta_path);
     }
+    pgwt_fsync_dir(w->trace_dir);
 
     /* Reset stats */
     w->total_records_written = 0;
@@ -703,6 +867,8 @@ int pgwt_summary_close(struct pgwt_summary_writer *w)
                 (unsigned long)w->total_bytes_written);
     }
 
+    fflush(w->fp);
+    fsync(fileno(w->fp));
     fclose(w->fp);
     w->fp = NULL;
     return 0;

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -13,7 +13,7 @@ LIBBPF_LIB ?= -lbpf
 TESTS     = test_wait_event test_cmdline test_event_writer test_event_reader \
             test_trace_v2 test_sampler test_anomaly test_coop test_bucket \
             test_pg13_resolve test_discovery_pie test_discovery_nopie \
-            test_replay_fidelity \
+            test_replay_fidelity test_durability test_query_text \
             gen_test_traces gen_bench_traces test_concurrent_rw cross_validate \
             dump_markers
 
@@ -114,6 +114,24 @@ test_replay_fidelity: test_replay_fidelity.c ../src/event_reader.c \
                       $(BUILD)/server_wait_event.o $(BUILD)/server_spawn.o \
                       $(BUILD)/server_cJSON.o
 	$(CC) $(CFLAGS) -o $@ $^ -llz4 -lz
+
+# test_durability: T5 file-lifecycle guarantees (DUR-1/2/3/7/8) — crash
+# recovery (kill -9 matrix), collision-safe archive names, size-cap
+# retention, meta/footer sanity caps, ~1 s SAMPLES batching. Server build
+# (no BPF skeleton) — the writers/readers are BPF-free.
+test_durability: test_durability.c $(BUILD)/server_event_writer.o \
+                 $(BUILD)/server_event_reader.o \
+                 $(BUILD)/server_summary_writer.o \
+                 $(BUILD)/server_summary_reader.o \
+                 $(BUILD)/server_wait_event.o $(BUILD)/server_spawn.o \
+                 $(BUILD)/server_cJSON.o
+	$(CC) $(CFLAGS) -DPGWT_SERVER -o $@ $^ -llz4 -lz
+
+# test_query_text: T5 DUR-4/10 — query_texts.jsonl append + dedup-on-load +
+# bounded compaction + cap logging + permissions. Compiles query_text.c
+# directly (BPF-free).
+test_query_text: test_query_text.c ../src/query_text.c
+	$(CC) $(CFLAGS) -o $@ $^
 
 # Server-build objects for gen_test_traces
 SERVER_OBJS = $(BUILD)/server_event_writer.o $(BUILD)/server_summary_writer.o \

--- a/tests/run_all.sh
+++ b/tests/run_all.sh
@@ -122,6 +122,7 @@ if [[ -x "$PROJECT_DIR/pgwt-server" ]] && [[ -x "$SCRIPT_DIR/gen_test_traces" ]]
     run_test "test_data_summary_honesty" python3 "$SCRIPT_DIR/test_data_summary_honesty.py"
     run_test "test_data_markers" python3 "$SCRIPT_DIR/test_data_markers.py"
     run_test "test_data_categories" python3 "$SCRIPT_DIR/test_data_categories.py"
+    run_test "test_data_window_bound" python3 "$SCRIPT_DIR/test_data_window_bound.py"
     run_test "test_current_trace" python3 "$SCRIPT_DIR/test_current_trace.py"
     run_test "test_protocol_drift" python3 "$SCRIPT_DIR/test_protocol_drift.py"
 else

--- a/tests/server_harness.py
+++ b/tests/server_harness.py
@@ -25,10 +25,11 @@ GEN_BIN = os.path.join(SCRIPT_DIR, "gen_test_traces")
 class ServerHarness:
     """Manages a pgwt-server subprocess for testing."""
 
-    def __init__(self, trace_dir):
+    def __init__(self, trace_dir, env=None):
         self.trace_dir = trace_dir
         self.proc = None
         self._next_id = 1
+        self._extra_env = env  # extra environment vars for pgwt-server
 
     def __enter__(self):
         self.start()
@@ -40,12 +41,17 @@ class ServerHarness:
     def start(self):
         if not os.path.exists(SERVER_BIN):
             raise FileNotFoundError(f"pgwt-server not found at {SERVER_BIN}")
+        env = None
+        if self._extra_env:
+            env = dict(os.environ)
+            env.update({k: str(v) for k, v in self._extra_env.items()})
         self.proc = subprocess.Popen(
             [SERVER_BIN, self.trace_dir],
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             text=True,
+            env=env,
         )
         # Query info to get time range, then expand slightly so all events
         # in the first/last block are included
@@ -130,7 +136,14 @@ def generate_traces(scenario, output_dir=None, wall_offset_ns=None, rotate=None)
         )
 
     scenario_json = json.dumps(scenario)
-    cmd = [GEN_BIN, "-o", output_dir, "--inline", scenario_json]
+    if len(scenario_json) > 65536:
+        # Large scenarios exceed the OS argv limit — pass via a file.
+        scenario_path = os.path.join(output_dir, "_scenario.json")
+        with open(scenario_path, "w") as f:
+            f.write(scenario_json)
+        cmd = [GEN_BIN, "-o", output_dir, "-s", scenario_path]
+    else:
+        cmd = [GEN_BIN, "-o", output_dir, "--inline", scenario_json]
     if wall_offset_ns is not None:
         cmd += ["--wall-offset", str(wall_offset_ns)]
     if rotate is not None:

--- a/tests/test_concurrent_rw.c
+++ b/tests/test_concurrent_rw.c
@@ -76,6 +76,21 @@ static void writer_process(void)
             ts += ev.duration_ns;
         }
 
+        /* Also push a sampler tick per cycle so the DUR-8 batched-SAMPLES
+         * path races the reader exactly like tiered mode does. */
+        {
+            struct pgwt_trace_event samples[8];
+            for (int i = 0; i < 8; i++) {
+                samples[i] = (struct pgwt_trace_event){
+                    .timestamp_ns = ts,
+                    .pid = 2000 + (uint32_t)i,
+                    .new_event = 0x0A000015,
+                    .query_id = 54321,
+                };
+            }
+            pgwt_writer_push_samples(&w, samples, 8, 100000000ULL);
+        }
+
         /* Sleep to simulate real daemon timing */
         usleep(WRITE_INTERVAL_MS * 1000);
     }

--- a/tests/test_data_window_bound.py
+++ b/tests/test_data_window_bound.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""test_data_window_bound.py — T5/DUR-9: raw-load memory bound + pid pushdown.
+
+A pid-filtered long-window query used to force the raw path to load EVERY
+event in range into one unbounded doubling array. The fix:
+
+  1. pid pushdown — with a pid filter, only that pid's events enter the
+     working array;
+  2. a hard bound (load_max_events, PGWT_LOAD_MAX_EVENTS env override for
+     tests) — exceeding it yields a structured "window too large" error,
+     never an OOM and never a silently partial result.
+
+Scenario: 10 pids × 2,000 events = 20,000 events. Bound set to 5,000:
+  - unfiltered query  → structured error (20,000 > 5,000);
+  - pid-filtered query → succeeds (2,000 < 5,000) and its numbers are
+    correct — proof the filter is applied DURING load, not after.
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(__file__))
+from server_harness import (
+    ServerHarness, generate_traces, cleanup_traces, TestRunner,
+    CPU, IO_DATA_FILE_READ,
+)
+
+BASE_TS = 10_000_000_000_000
+NUM_PIDS = 10
+EVENTS_PER_PID = 2_000
+DUR_NS = 1_000_000  # 1 ms per event
+
+
+def build_scenario():
+    events = []
+    for p in range(NUM_PIDS):
+        pid = 1000 + p
+        ts = BASE_TS + p * 1_000
+        for i in range(EVENTS_PER_PID):
+            ts += DUR_NS
+            events.append({"pid": pid, "ts": ts, "dur": DUR_NS,
+                           "old": IO_DATA_FILE_READ, "new": CPU, "qid": 42})
+    events.sort(key=lambda e: e["ts"])
+    return {
+        "backends": [{"pid": 1000 + p, "type": "client", "user": "u",
+                      "db": "d"} for p in range(NUM_PIDS)],
+        "queries": [{"id": 42, "text": "SELECT 1"}],
+        "events": events,
+    }
+
+
+def main():
+    t = TestRunner("window_bound")
+    trace_dir = generate_traces(build_scenario())
+    try:
+        with ServerHarness(trace_dir,
+                           env={"PGWT_LOAD_MAX_EVENTS": 5_000}) as srv:
+            # Unfiltered: 20k events > 5k bound → structured error.
+            resp = srv.query("time_model")
+            t.check("error" in resp, "unfiltered long window returns error")
+            t.check_eq(resp.get("code"), "window_too_large",
+                       "error carries the window_too_large code")
+            t.check("max_events" in resp, "error carries the bound")
+            t.check("rows" not in resp,
+                    "no partial data rendered alongside the error")
+
+            # Same window, pid filter: pushdown loads only 2k events.
+            resp = srv.query("time_model", filters={"pid": 1001})
+            t.check("error" not in resp,
+                    "pid-filtered query under the bound succeeds "
+                    "(pushdown, not post-filter)")
+            expected_ms = EVENTS_PER_PID * DUR_NS / 1e6
+            rows = {r["name"]: r for r in resp.get("rows", [])}
+            t.check_approx(rows.get("IO", {}).get("ms", -1), expected_ms,
+                           0.01, "pid-filtered IO time exact")
+
+            # Every raw-path view must reject, not truncate.
+            for cmd in ("aas", "top_events", "top_sessions", "top_queries",
+                        "heatmap", "session_timeline", "transitions",
+                        "fingerprints", "lock_chains", "interference",
+                        "concurrency", "variants"):
+                resp = srv.query(cmd)
+                t.check(resp.get("code") == "window_too_large",
+                        f"{cmd}: structured error, not partial data")
+
+        # Sanity: with the default (RAM-derived) bound the same trace loads.
+        with ServerHarness(trace_dir) as srv:
+            resp = srv.query("time_model")
+            t.check("error" not in resp,
+                    "default bound loads the full window")
+    finally:
+        cleanup_traces(trace_dir)
+
+    return 0 if t.summary() else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_durability.c
+++ b/tests/test_durability.c
@@ -1,0 +1,808 @@
+/* test_durability.c — Phase T5 regression tests (DUR-1/2/3/5/7/8)
+ *
+ * Covers the file-lifecycle guarantees:
+ *   DUR-1: a daemon crash (kill -9) never erases the previous current.trace/
+ *          current.summary — restart recovers it into a readable archive;
+ *          torn tails are dropped, committed blocks survive.
+ *   DUR-2: rotation and recovery never clobber an existing archive
+ *          (numeric-suffix collision-safe names; covers restart-in-the-same-
+ *          hour and the DST-fold case, which produce the same target name).
+ *   DUR-3: size-based retention (--retention-gb): oldest archives deleted
+ *          first, live current files never touched; orphaned meta files
+ *          cleaned.
+ *   DUR-7: a corrupt meta high-watermark or block header never drives the
+ *          reader into a huge allocation or a garbage index.
+ *   DUR-8: SAMPLES pushes are batched ~1 s per block (not per tick), the
+ *          per-block period preserves the SMP-3 weights, a period jump cuts
+ *          a new block, and the block index stays time-sorted when
+ *          transitions and samples interleave.
+ *
+ * Server build (-DPGWT_SERVER): no BPF needed, runs in CI's server jobs.
+ */
+#include "event_writer.h"
+#include "event_reader.h"
+#include "summary_writer.h"
+#include "summary_reader.h"
+#include "pg_wait_tracer.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <signal.h>
+#include <sys/wait.h>
+#include <sys/stat.h>
+#include <sys/time.h>
+#include <dirent.h>
+#include <time.h>
+#include <errno.h>
+
+static int tests_run = 0;
+static int tests_passed = 0;
+
+#define CHECK(cond, fmt, ...) do { \
+    tests_run++; \
+    if (cond) { tests_passed++; } \
+    else { printf("  FAIL(%d): " fmt "\n", __LINE__, ##__VA_ARGS__); } \
+} while (0)
+
+#define BASE_DIR "/tmp/pgwt_durability_test"
+
+/* ── helpers ────────────────────────────────────────────── */
+
+static void rm_rf(const char *dir)
+{
+    char cmd[600];
+    snprintf(cmd, sizeof(cmd), "rm -rf %s", dir);
+    if (system(cmd) != 0) { /* ignore */ }
+}
+
+static char *path_of(const char *dir, const char *name)
+{
+    static char buf[600];
+    snprintf(buf, sizeof(buf), "%s/%s", dir, name);
+    return buf;
+}
+
+static int file_exists(const char *dir, const char *name)
+{
+    struct stat st;
+    return stat(path_of(dir, name), &st) == 0;
+}
+
+static long file_size(const char *dir, const char *name)
+{
+    struct stat st;
+    if (stat(path_of(dir, name), &st) != 0)
+        return -1;
+    return (long)st.st_size;
+}
+
+/* Count directory entries whose name ends with `suffix`. */
+static int count_suffix(const char *dir, const char *suffix)
+{
+    DIR *d = opendir(dir);
+    if (!d) return -1;
+    int n = 0;
+    size_t sl = strlen(suffix);
+    struct dirent *e;
+    while ((e = readdir(d)) != NULL) {
+        size_t nl = strlen(e->d_name);
+        if (nl >= sl && strcmp(e->d_name + nl - sl, suffix) == 0)
+            n++;
+    }
+    closedir(d);
+    return n;
+}
+
+/* First entry matching suffix (caller copies). */
+static int find_suffix(const char *dir, const char *suffix, char *out,
+                       size_t out_size)
+{
+    DIR *d = opendir(dir);
+    if (!d) return -1;
+    int found = -1;
+    size_t sl = strlen(suffix);
+    struct dirent *e;
+    while ((e = readdir(d)) != NULL) {
+        size_t nl = strlen(e->d_name);
+        if (nl >= sl && strcmp(e->d_name + nl - sl, suffix) == 0) {
+            snprintf(out, out_size, "%s/%s", dir, e->d_name);
+            found = 0;
+            break;
+        }
+    }
+    closedir(d);
+    return found;
+}
+
+static struct pgwt_trace_event mk_event(uint64_t ts, uint32_t pid,
+                                        uint32_t old_ev, uint64_t dur,
+                                        uint64_t qid)
+{
+    struct pgwt_trace_event ev = {0};
+    ev.timestamp_ns = ts;
+    ev.pid = pid;
+    ev.old_event = old_ev;
+    ev.new_event = 0;
+    ev.duration_ns = dur;
+    ev.query_id = qid;
+    return ev;
+}
+
+/* Push exactly `blocks` full blocks of transitions; returns final ts. */
+static uint64_t push_blocks(struct pgwt_event_writer *w, uint64_t ts,
+                            int blocks)
+{
+    for (int b = 0; b < blocks; b++) {
+        for (int i = 0; i < PGWT_BLOCK_EVENTS; i++) {
+            struct pgwt_trace_event ev =
+                mk_event(ts, 1000 + (i % 4), 0x0A000001, 1000, 42);
+            pgwt_writer_push_event(w, &ev);
+            ts += 1000;
+        }
+    }
+    return ts;
+}
+
+static int read_meta_committed(const char *dir, const char *name)
+{
+    FILE *f = fopen(path_of(dir, name), "r");
+    if (!f) return -1;
+    int committed = -1;
+    if (fscanf(f, "%d", &committed) != 1)
+        committed = -1;
+    fclose(f);
+    return committed;
+}
+
+/* Total decoded events across all blocks of a trace file. */
+static long count_events_in_file(const char *path, int *num_blocks)
+{
+    struct pgwt_event_reader r;
+    if (pgwt_reader_open(&r, path) != 0) {
+        if (num_blocks) *num_blocks = -1;
+        return -1;
+    }
+    if (num_blocks) *num_blocks = r.num_blocks;
+    static struct pgwt_trace_event buf[PGWT_BLOCK_EVENTS];
+    long total = 0;
+    for (int b = 0; b < r.num_blocks; b++) {
+        int n = pgwt_reader_decode_block(&r, b, buf, PGWT_BLOCK_EVENTS);
+        if (n > 0)
+            total += n;
+    }
+    pgwt_reader_close(&r);
+    return total;
+}
+
+/* ── DUR-1: kill -9 → restart recovers committed data ─────── */
+
+/* Child: write 2 committed blocks, then hang. Parent kills it with SIGKILL
+ * once the meta high-watermark reaches 2 — a REAL post-flush kill -9. */
+static void test_recover_after_sigkill(void)
+{
+    printf("--- DUR-1: kill -9 post-flush, restart recovers ---\n");
+    const char *dir = BASE_DIR "/kill9";
+    rm_rf(dir);
+
+    pid_t child = fork();
+    if (child == 0) {
+        struct pgwt_event_writer *w = calloc(1, sizeof(*w));
+        if (pgwt_writer_init(w, dir, 18, 24, NULL) != 0)
+            _exit(1);
+        push_blocks(w, 1000000000000ULL, 2);
+        /* 100 buffered (uncommitted) events on top — the "unflushed tail" */
+        uint64_t ts = 2000000000000ULL;
+        for (int i = 0; i < 100; i++) {
+            struct pgwt_trace_event ev = mk_event(ts, 1000, 0x0A000001, 10, 1);
+            pgwt_writer_push_event(w, &ev);
+            ts += 10;
+        }
+        for (;;) pause();
+    }
+    CHECK(child > 0, "fork");
+
+    /* Wait for the meta watermark to commit 2 blocks, then SIGKILL. */
+    int committed = -1;
+    for (int i = 0; i < 500; i++) {
+        committed = read_meta_committed(dir, "current.trace.meta");
+        if (committed >= 2)
+            break;
+        usleep(10000);
+    }
+    CHECK(committed == 2, "child committed 2 blocks (got %d)", committed);
+    kill(child, SIGKILL);
+    waitpid(child, NULL, 0);
+
+    CHECK(file_exists(dir, "current.trace"), "current.trace left behind");
+
+    /* Restart: init must recover, never truncate. */
+    struct pgwt_event_writer *w2 = calloc(1, sizeof(*w2));
+    CHECK(pgwt_writer_init(w2, dir, 18, 24, NULL) == 0, "restart init");
+    CHECK(!file_exists(dir, "current.trace"),
+          "current.trace archived on restart");
+    CHECK(!file_exists(dir, "current.trace.meta"), "stale meta removed");
+    CHECK(count_suffix(dir, ".trace.lz4") == 1, "one archive present");
+
+    char archive[600];
+    CHECK(find_suffix(dir, ".trace.lz4", archive, sizeof(archive)) == 0,
+          "archive found");
+    int nb = 0;
+    long events = count_events_in_file(archive, &nb);
+    CHECK(nb == 2, "recovered archive has 2 blocks (got %d)", nb);
+    CHECK(events == 2 * PGWT_BLOCK_EVENTS,
+          "all committed events readable (got %ld)", events);
+
+    pgwt_writer_close(w2);
+    pgwt_writer_destroy(w2);
+    free(w2);
+}
+
+/* Mid-block kill: a torn tail (partial block header/payload) after the
+ * committed blocks must be dropped by recovery, never crash a reader. */
+static void test_recover_torn_tail(void)
+{
+    printf("--- DUR-1: torn tail (kill mid-block-write) ---\n");
+    const char *dir = BASE_DIR "/torn";
+    rm_rf(dir);
+
+    struct pgwt_event_writer *w = calloc(1, sizeof(*w));
+    CHECK(pgwt_writer_init(w, dir, 18, 24, NULL) == 0, "init");
+    push_blocks(w, 1000000000000ULL, 1);
+    /* Simulate kill -9 mid-fwrite: release the fd without footer, then
+     * append a plausible-but-truncated block (header claims more payload
+     * than the file holds). */
+    fclose(w->fp);
+    w->fp = NULL;
+    pgwt_writer_destroy(w);
+    free(w);
+
+    FILE *f = fopen(path_of(dir, "current.trace"), "ab");
+    CHECK(f != NULL, "append torn tail");
+    struct pgwt_trace_block_header torn = {
+        .first_timestamp_ns = 3000000000000ULL,
+        .last_timestamp_ns = 3000000001000ULL,
+        .num_events = 100,
+        .compressed_size = 5000,   /* payload NOT fully written */
+        .uncompressed_size = 6000,
+        .block_type = 0,
+    };
+    fwrite(&torn, sizeof(torn), 1, f);
+    uint8_t junk[123];
+    memset(junk, 0xAB, sizeof(junk));
+    fwrite(junk, 1, sizeof(junk), f);   /* only 123 of 5000 bytes */
+    fclose(f);
+
+    /* Also leave a torn meta tmp (kill mid-meta-rename). */
+    f = fopen(path_of(dir, "current.trace.meta.tmp"), "w");
+    if (f) { fprintf(f, "1"); fclose(f); }
+
+    struct pgwt_event_writer *w2 = calloc(1, sizeof(*w2));
+    CHECK(pgwt_writer_init(w2, dir, 18, 24, NULL) == 0, "restart init");
+    CHECK(!file_exists(dir, "current.trace.meta.tmp"),
+          "torn meta tmp removed");
+    char archive[600];
+    CHECK(find_suffix(dir, ".trace.lz4", archive, sizeof(archive)) == 0,
+          "archive exists");
+    int nb = 0;
+    long events = count_events_in_file(archive, &nb);
+    CHECK(nb == 1, "torn tail dropped, 1 committed block (got %d)", nb);
+    CHECK(events == PGWT_BLOCK_EVENTS, "committed events intact (got %ld)",
+          events);
+    pgwt_writer_close(w2);
+    pgwt_writer_destroy(w2);
+    free(w2);
+}
+
+/* Restart twice within one hour: BOTH archives must survive (DUR-1+2). */
+static void test_restart_twice_same_hour(void)
+{
+    printf("--- DUR-1/2: two restarts in one hour keep both archives ---\n");
+    const char *dir = BASE_DIR "/twice";
+    rm_rf(dir);
+
+    for (int round = 0; round < 2; round++) {
+        struct pgwt_event_writer *w = calloc(1, sizeof(*w));
+        CHECK(pgwt_writer_init(w, dir, 18, 24, NULL) == 0, "init %d", round);
+        push_blocks(w, 1000000000000ULL + (uint64_t)round * 1000000000ULL, 1);
+        /* crash: no footer, no close */
+        fclose(w->fp);
+        w->fp = NULL;
+        pgwt_writer_destroy(w);
+        free(w);
+    }
+    /* Third start recovers round 2's file. */
+    struct pgwt_event_writer *w = calloc(1, sizeof(*w));
+    CHECK(pgwt_writer_init(w, dir, 18, 24, NULL) == 0, "third init");
+    int archives = count_suffix(dir, ".trace.lz4");
+    CHECK(archives == 2, "both archives present (got %d)", archives);
+
+    /* Each archive must decode its full block. */
+    DIR *d = opendir(dir);
+    struct dirent *e;
+    while ((e = readdir(d)) != NULL) {
+        if (!strstr(e->d_name, ".trace.lz4"))
+            continue;
+        int nb = 0;
+        long events = count_events_in_file(path_of(dir, e->d_name), &nb);
+        CHECK(events == PGWT_BLOCK_EVENTS, "%s readable (%ld events)",
+              e->d_name, events);
+    }
+    closedir(d);
+    pgwt_writer_close(w);
+    pgwt_writer_destroy(w);
+    free(w);
+}
+
+/* Empty / header-only / garbage current.trace handling. */
+static void test_recover_degenerate_files(void)
+{
+    printf("--- DUR-1: degenerate current.trace forms ---\n");
+    const char *dir = BASE_DIR "/degen";
+    rm_rf(dir);
+    mkdir(BASE_DIR, 0755);
+    mkdir(dir, 0755);
+
+    /* Garbage (wrong magic) file must be preserved as *.corrupt.<ts>. */
+    FILE *f = fopen(path_of(dir, "current.trace"), "w");
+    fprintf(f, "this is not a trace file, but it is somebody's data");
+    fclose(f);
+
+    struct pgwt_event_writer *w = calloc(1, sizeof(*w));
+    CHECK(pgwt_writer_init(w, dir, 18, 24, NULL) == 0, "init over garbage");
+    CHECK(!file_exists(dir, "current.trace"), "garbage moved aside");
+    CHECK(count_suffix(dir, ".trace.lz4") == 0, "garbage NOT archived");
+    int corrupt = 0;
+    DIR *d = opendir(dir);
+    struct dirent *e;
+    while ((e = readdir(d)) != NULL)
+        if (strstr(e->d_name, ".corrupt."))
+            corrupt++;
+    closedir(d);
+    CHECK(corrupt == 1, "garbage preserved as .corrupt (got %d)", corrupt);
+    pgwt_writer_destroy(w);
+    free(w);
+}
+
+/* ── DUR-2: rotation must not clobber an existing archive ─── */
+
+static void test_rotation_collision(void)
+{
+    printf("--- DUR-2: rotation onto an existing archive name ---\n");
+    const char *dir = BASE_DIR "/rotcol";
+    rm_rf(dir);
+
+    struct pgwt_event_writer *w = calloc(1, sizeof(*w));
+    CHECK(pgwt_writer_init(w, dir, 18, 24, NULL) == 0, "init");
+    push_blocks(w, 1000000000000ULL, 1);
+
+    /* Pre-create the exact archive name this rotation would use (what a
+     * restart-mid-hour or DST fold produces). */
+    time_t start_sec = (time_t)(w->file_start_wall_ns / 1000000000ULL);
+    struct tm tm;
+    localtime_r(&start_sec, &tm);
+    char victim[600];
+    snprintf(victim, sizeof(victim), "%s/%04d-%02d-%02d_%02d.trace.lz4",
+             dir, tm.tm_year + 1900, tm.tm_mon + 1, tm.tm_mday, tm.tm_hour);
+    FILE *f = fopen(victim, "w");
+    fprintf(f, "PRECIOUS");
+    fclose(f);
+
+    /* Force rotation (fake an hour change). */
+    w->current_hour -= 1;
+    CHECK(pgwt_writer_check_rotation(w) == 0, "rotation");
+    CHECK(w->fp == NULL, "rotated (file closed)");
+
+    /* The pre-existing archive is intact; the rotated file got a suffix. */
+    f = fopen(victim, "r");
+    char buf[32] = {0};
+    if (f) { if (fread(buf, 1, 8, f) != 8) buf[0] = 0; fclose(f); }
+    CHECK(strncmp(buf, "PRECIOUS", 8) == 0,
+          "existing archive NOT clobbered");
+    CHECK(count_suffix(dir, ".trace.lz4") == 2,
+          "rotated file archived under a suffixed name");
+
+    char suffixed[600];
+    snprintf(suffixed, sizeof(suffixed), "%s/%04d-%02d-%02d_%02d.1.trace.lz4",
+             dir, tm.tm_year + 1900, tm.tm_mon + 1, tm.tm_mday, tm.tm_hour);
+    int nb = 0;
+    long events = count_events_in_file(suffixed, &nb);
+    CHECK(events == PGWT_BLOCK_EVENTS,
+          "suffixed archive readable (%ld events)", events);
+
+    /* Discovery must see the suffixed archive. */
+    struct pgwt_trace_file_entry entries[16];
+    int nfiles = pgwt_scan_trace_files(dir, entries, 16);
+    CHECK(nfiles >= 1, "scan_trace_files finds suffixed archives (%d)",
+          nfiles);
+
+    pgwt_writer_destroy(w);
+    free(w);
+}
+
+/* ── DUR-8: SAMPLES batching ─────────────────────────────── */
+
+static void push_sample_tick(struct pgwt_event_writer *w, uint64_t ts,
+                             int nsamples, uint64_t period)
+{
+    static struct pgwt_trace_event batch[64];
+    for (int i = 0; i < nsamples; i++) {
+        batch[i] = (struct pgwt_trace_event){0};
+        batch[i].timestamp_ns = ts;
+        batch[i].pid = 2000 + i;
+        batch[i].new_event = 0x0A000001;
+        batch[i].query_id = 7;
+    }
+    pgwt_writer_push_samples(w, batch, nsamples, period);
+}
+
+static void test_sample_batching(void)
+{
+    printf("--- DUR-8: ~1 s SAMPLES batching ---\n");
+    const char *dir = BASE_DIR "/batch";
+    rm_rf(dir);
+
+    struct pgwt_event_writer *w = calloc(1, sizeof(*w));
+    CHECK(pgwt_writer_init(w, dir, 18, 24, NULL) == 0, "init");
+
+    /* 25 ticks at 10 Hz (100 ms apart), 10 samples each = 2.4 s span.
+     * Old behavior: 25 blocks. Batched: one block per ~1 s → 3 blocks. */
+    uint64_t t0 = 1000000000000ULL;
+    uint64_t period = 100000000ULL;   /* 100 ms */
+    for (int tick = 0; tick < 25; tick++)
+        push_sample_tick(w, t0 + tick * period, 10, period);
+
+    /* Nothing on disk breaches per-tick blocks: committed block count must
+     * be well under the tick count while the batch is pending. */
+    int committed = read_meta_committed(dir, "current.trace.meta");
+    CHECK(committed >= 1 && committed <= 3,
+          "batched blocks committed, not per-tick (%d for 25 ticks)",
+          committed);
+
+    pgwt_writer_close(w);
+
+    char cur[600];
+    snprintf(cur, sizeof(cur), "%s/current.trace", dir);
+    struct pgwt_event_reader r;
+    CHECK(pgwt_reader_open(&r, cur) == 0, "reader open");
+    CHECK(r.num_blocks >= 2 && r.num_blocks <= 4,
+          "25 ticks → ~3 blocks (got %d)", r.num_blocks);
+
+    long total = 0;
+    static struct pgwt_trace_event buf[PGWT_BLOCK_EVENTS];
+    for (int b = 0; b < r.num_blocks; b++) {
+        struct pgwt_block_info bi;
+        int n = pgwt_reader_decode_block_info(&r, b, buf, PGWT_BLOCK_EVENTS,
+                                              &bi);
+        CHECK(bi.block_type == PGWT_BLOCK_SAMPLES, "block %d is SAMPLES", b);
+        CHECK(bi.sample_period_ns == period,
+              "block %d period preserved (%llu)", b,
+              (unsigned long long)bi.sample_period_ns);
+        for (int i = 0; i < n; i++) {
+            if (!(buf[i].flags & PGWT_EVENT_FLAG_SAMPLE))
+                break;
+            total++;
+        }
+    }
+    CHECK(total == 250, "all 250 samples decoded (got %ld)", total);
+    pgwt_reader_close(&r);
+    pgwt_writer_destroy(w);
+    free(w);
+}
+
+static void test_sample_period_jump_cuts_block(void)
+{
+    printf("--- DUR-8: SMP-3 stall tick gets its own block ---\n");
+    const char *dir = BASE_DIR "/stall";
+    rm_rf(dir);
+
+    struct pgwt_event_writer *w = calloc(1, sizeof(*w));
+    CHECK(pgwt_writer_init(w, dir, 18, 24, NULL) == 0, "init");
+
+    uint64_t t0 = 1000000000000ULL;
+    uint64_t nominal = 100000000ULL;   /* 100 ms */
+    /* 3 normal ticks, then a stalled tick weighted 500 ms (SMP-3), then 2
+     * normal ticks. The stall tick must not share a block. */
+    push_sample_tick(w, t0 + 0 * nominal, 5, nominal);
+    push_sample_tick(w, t0 + 1 * nominal, 5, nominal);
+    push_sample_tick(w, t0 + 2 * nominal, 5, nominal);
+    push_sample_tick(w, t0 + 8 * nominal, 5, 500000000ULL);
+    push_sample_tick(w, t0 + 9 * nominal, 5, nominal);
+    push_sample_tick(w, t0 + 10 * nominal, 5, nominal);
+    pgwt_writer_close(w);
+
+    char cur[600];
+    snprintf(cur, sizeof(cur), "%s/current.trace", dir);
+    struct pgwt_event_reader r;
+    CHECK(pgwt_reader_open(&r, cur) == 0, "reader open");
+    CHECK(r.num_blocks == 3, "period jumps cut blocks (got %d)",
+          r.num_blocks);
+
+    /* Verify per-block periods: 100 ms, 500 ms, 100 ms — the total
+     * estimated time (Σ count × period) must equal the exact per-tick sum. */
+    uint64_t total_weight = 0;
+    static struct pgwt_trace_event buf[PGWT_BLOCK_EVENTS];
+    for (int b = 0; b < r.num_blocks; b++) {
+        struct pgwt_block_info bi;
+        int n = pgwt_reader_decode_block_info(&r, b, buf, PGWT_BLOCK_EVENTS,
+                                              &bi);
+        total_weight += (uint64_t)n * bi.sample_period_ns;
+    }
+    uint64_t expected = 5 * (5 * nominal + 500000000ULL);
+    CHECK(total_weight == expected,
+          "SMP-3 weights preserved exactly (%llu vs %llu)",
+          (unsigned long long)total_weight, (unsigned long long)expected);
+    pgwt_reader_close(&r);
+    pgwt_writer_destroy(w);
+    free(w);
+}
+
+static void test_interleaved_index_sorted(void)
+{
+    printf("--- DUR-8: interleaved transitions+samples keep index sorted ---\n");
+    const char *dir = BASE_DIR "/interleave";
+    rm_rf(dir);
+
+    struct pgwt_event_writer *w = calloc(1, sizeof(*w));
+    CHECK(pgwt_writer_init(w, dir, 18, 24, NULL) == 0, "init");
+
+    uint64_t ts = 1000000000000ULL;
+    uint64_t period = 100000000ULL;
+    /* Interleave: transitions trickle in while sample ticks arrive; the
+     * transitions block fills much later than the first pending samples. */
+    for (int round = 0; round < 30; round++) {
+        for (int i = 0; i < 700; i++) {   /* 700 transitions per round */
+            struct pgwt_trace_event ev = mk_event(ts, 1000, 0x0A000001, 100, 1);
+            pgwt_writer_push_event(w, &ev);
+            ts += 100000;   /* 0.1 ms apart → 70 ms per round */
+        }
+        push_sample_tick(w, ts, 8, period);
+        ts += period / 2;
+    }
+    pgwt_writer_close(w);
+
+    char cur[600];
+    snprintf(cur, sizeof(cur), "%s/current.trace", dir);
+    struct pgwt_event_reader r;
+    CHECK(pgwt_reader_open(&r, cur) == 0, "reader open");
+    CHECK(r.num_blocks >= 4, "several blocks written (%d)", r.num_blocks);
+    int sorted = 1;
+    for (int b = 1; b < r.num_blocks; b++)
+        if (r.block_index[b].timestamp_ns < r.block_index[b - 1].timestamp_ns)
+            sorted = 0;
+    CHECK(sorted, "block index sorted by first timestamp");
+    pgwt_reader_close(&r);
+    pgwt_writer_destroy(w);
+    free(w);
+}
+
+/* ── DUR-7: corrupt meta / block headers must not break the reader ── */
+
+static void test_meta_sanity_caps(void)
+{
+    printf("--- DUR-7: corrupt meta and block headers ---\n");
+    const char *dir = BASE_DIR "/meta";
+    rm_rf(dir);
+
+    struct pgwt_event_writer *w = calloc(1, sizeof(*w));
+    CHECK(pgwt_writer_init(w, dir, 18, 24, NULL) == 0, "init");
+    push_blocks(w, 1000000000000ULL, 1);
+    fflush(w->fp);
+
+    char cur[600];
+    snprintf(cur, sizeof(cur), "%s/current.trace", dir);
+
+    /* Absurd committed count: reader must cap, fall back, and still read
+     * the one real block (never a multi-GB allocation). */
+    FILE *f = fopen(path_of(dir, "current.trace.meta"), "w");
+    fprintf(f, "999999999\n");
+    fclose(f);
+    int nb = 0;
+    long events = count_events_in_file(cur, &nb);
+    CHECK(nb == 1, "absurd meta count rejected, scan fallback (%d)", nb);
+    CHECK(events == PGWT_BLOCK_EVENTS, "data still readable (%ld)", events);
+
+    /* Meta claims 3 committed but only 1 block exists: reader stops at
+     * what's really there. */
+    f = fopen(path_of(dir, "current.trace.meta"), "w");
+    fprintf(f, "3\n");
+    fclose(f);
+    events = count_events_in_file(cur, &nb);
+    CHECK(nb == 1, "meta over-claim clamped to real blocks (%d)", nb);
+
+    /* Garbage block header after the real block, meta claiming 2: the
+     * meta-path scan must stop at the invalid header (same caps as the
+     * fallback scan). */
+    f = fopen(cur, "ab");
+    struct pgwt_trace_block_header bad = {
+        .first_timestamp_ns = 1,
+        .last_timestamp_ns = 2,
+        .num_events = 4000000000u,          /* > PGWT_BLOCK_EVENTS */
+        .compressed_size = 4000000000u,     /* > 10 MB cap */
+        .uncompressed_size = 4000000000u,
+        .block_type = 0,
+    };
+    fwrite(&bad, sizeof(bad), 1, f);
+    fclose(f);
+    f = fopen(path_of(dir, "current.trace.meta"), "w");
+    fprintf(f, "2\n");
+    fclose(f);
+    events = count_events_in_file(cur, &nb);
+    CHECK(nb == 1, "garbage block header stops the meta scan (%d)", nb);
+    CHECK(events == PGWT_BLOCK_EVENTS, "real data unaffected (%ld)", events);
+
+    /* Recovery over the same garbage must also survive and archive 1 block. */
+    fclose(w->fp);
+    w->fp = NULL;
+    pgwt_writer_destroy(w);
+    free(w);
+    struct pgwt_event_writer *w2 = calloc(1, sizeof(*w2));
+    CHECK(pgwt_writer_init(w2, dir, 18, 24, NULL) == 0, "recovery init");
+    char archive[600];
+    CHECK(find_suffix(dir, ".trace.lz4", archive, sizeof(archive)) == 0,
+          "recovered archive exists");
+    events = count_events_in_file(archive, &nb);
+    CHECK(nb == 1 && events == PGWT_BLOCK_EVENTS,
+          "recovered archive intact (%d blocks, %ld events)", nb, events);
+    pgwt_writer_destroy(w2);
+    free(w2);
+}
+
+/* ── DUR-3: size-based retention + orphan cleanup ─────────── */
+
+static void write_fake_archive(const char *dir, const char *name, int kb)
+{
+    FILE *f = fopen(path_of(dir, name), "w");
+    char buf[1024];
+    memset(buf, 'x', sizeof(buf));
+    for (int i = 0; i < kb; i++)
+        fwrite(buf, 1, sizeof(buf), f);
+    fclose(f);
+}
+
+static void test_size_cap_retention(void)
+{
+    printf("--- DUR-3: --retention-gb size cap ---\n");
+    const char *dir = BASE_DIR "/sizecap";
+    rm_rf(dir);
+    mkdir(BASE_DIR, 0755);
+    mkdir(dir, 0755);
+
+    write_fake_archive(dir, "2025-01-01_10.trace.lz4", 100);
+    write_fake_archive(dir, "2025-01-01_11.trace.lz4", 100);
+    write_fake_archive(dir, "2025-01-01_11.1.trace.lz4", 100); /* recovered */
+    write_fake_archive(dir, "2025-01-01_12.trace.lz4", 100);
+    write_fake_archive(dir, "2025-01-01_10.summary.lz4", 50);
+    write_fake_archive(dir, "current.trace", 10);
+    write_fake_archive(dir, "query_texts.jsonl", 5);
+
+    struct pgwt_event_writer *w = calloc(1, sizeof(*w));
+    snprintf(w->trace_dir, sizeof(w->trace_dir), "%s", dir);
+    w->retention_hours = 0;              /* hours-based retention off */
+    w->retention_bytes = 280 * 1024;     /* forces deleting oldest ~2 files */
+
+    CHECK(pgwt_writer_cleanup_old_files(w) == 0, "cleanup runs");
+
+    CHECK(file_exists(dir, "current.trace"), "live current.trace kept");
+    CHECK(file_exists(dir, "query_texts.jsonl"), "sidecar kept");
+    CHECK(!file_exists(dir, "2025-01-01_10.trace.lz4"),
+          "oldest archive deleted first");
+    CHECK(!file_exists(dir, "2025-01-01_10.summary.lz4"),
+          "oldest summary deleted too");
+    CHECK(file_exists(dir, "2025-01-01_12.trace.lz4"),
+          "newest archive kept");
+
+    /* Total remaining must fit the cap. */
+    long total = 0;
+    DIR *d = opendir(dir);
+    struct dirent *e;
+    while ((e = readdir(d)) != NULL) {
+        long s = file_size(dir, e->d_name);
+        if (s > 0)
+            total += s;
+    }
+    closedir(d);
+    CHECK(total <= 280 * 1024, "disk usage under the cap (%ld)", total);
+
+    /* Orphan meta cleanup: current.trace.meta with NO current.trace, aged. */
+    rm_rf(dir);
+    mkdir(dir, 0755);
+    write_fake_archive(dir, "current.trace.meta", 1);
+    write_fake_archive(dir, "current.summary.meta.tmp", 1);
+    struct timeval old_tv[2];
+    gettimeofday(&old_tv[0], NULL);
+    old_tv[0].tv_sec -= 7200;
+    old_tv[1] = old_tv[0];
+    utimes(path_of(dir, "current.trace.meta"), old_tv);
+    utimes(path_of(dir, "current.summary.meta.tmp"), old_tv);
+    w->retention_bytes = 0;
+    CHECK(pgwt_writer_cleanup_old_files(w) == 0, "orphan cleanup runs");
+    CHECK(!file_exists(dir, "current.trace.meta"), "orphan meta removed");
+    CHECK(!file_exists(dir, "current.summary.meta.tmp"),
+          "orphan meta tmp removed");
+
+    /* A meta belonging to a LIVE current.trace must be kept even when old. */
+    write_fake_archive(dir, "current.trace", 1);
+    write_fake_archive(dir, "current.trace.meta", 1);
+    utimes(path_of(dir, "current.trace.meta"), old_tv);
+    CHECK(pgwt_writer_cleanup_old_files(w) == 0, "cleanup runs");
+    CHECK(file_exists(dir, "current.trace.meta"),
+          "live file's meta NOT treated as orphan");
+
+    free(w);
+}
+
+/* ── DUR-1: summary writer recovery ───────────────────────── */
+
+static void test_summary_recovery(void)
+{
+    printf("--- DUR-1: current.summary recovery ---\n");
+    const char *dir = BASE_DIR "/summary";
+    rm_rf(dir);
+    mkdir(BASE_DIR, 0755);
+    mkdir(dir, 0755);
+
+    struct pgwt_summary_writer *w = calloc(1, sizeof(*w));
+    CHECK(pgwt_summary_writer_init(w, dir, 24, NULL) == 0, "init");
+    /* Two seconds of events → 2 blocks (flush on second boundary + explicit) */
+    for (int s = 0; s < 2; s++) {
+        for (int i = 0; i < 50; i++) {
+            struct pgwt_trace_event ev =
+                mk_event(1000000000000ULL + (uint64_t)s * 1000000000ULL
+                         + i * 1000000, 1000 + i % 3, 0x0A000001, 500000, 9);
+            pgwt_summary_push_event(w, &ev);
+        }
+        pgwt_summary_flush(w);
+    }
+    CHECK(read_meta_committed(dir, "current.summary.meta") == 2,
+          "2 summary blocks committed");
+    /* Crash: no footer. */
+    fclose(w->fp);
+    w->fp = NULL;
+    pgwt_summary_destroy(w);
+    free(w);
+
+    struct pgwt_summary_writer *w2 = calloc(1, sizeof(*w2));
+    CHECK(pgwt_summary_writer_init(w2, dir, 24, NULL) == 0, "restart init");
+    CHECK(!file_exists(dir, "current.summary"), "current.summary archived");
+    CHECK(count_suffix(dir, ".summary.lz4") == 1, "summary archive present");
+
+    char archive[600];
+    CHECK(find_suffix(dir, ".summary.lz4", archive, sizeof(archive)) == 0,
+          "archive found");
+    struct pgwt_summary_reader r;
+    CHECK(pgwt_summary_reader_open(&r, archive) == 0, "summary reader open");
+    CHECK(r.num_blocks == 2, "2 blocks recovered (got %d)", r.num_blocks);
+    struct pgwt_summary_accum *acc = malloc(sizeof(*acc));
+    CHECK(pgwt_summary_reader_decode_block(&r, 0, acc) == 0, "block decodes");
+    CHECK(acc->num_events > 0, "decoded block has events");
+    free(acc);
+    pgwt_summary_reader_close(&r);
+    pgwt_summary_destroy(w2);
+    free(w2);
+}
+
+/* ── main ─────────────────────────────────────────────────── */
+
+int main(void)
+{
+    printf("=== test_durability (T5: DUR-1/2/3/7/8) ===\n");
+    mkdir(BASE_DIR, 0755);
+
+    test_recover_after_sigkill();
+    test_recover_torn_tail();
+    test_restart_twice_same_hour();
+    test_recover_degenerate_files();
+    test_rotation_collision();
+    test_sample_batching();
+    test_sample_period_jump_cuts_block();
+    test_interleaved_index_sorted();
+    test_meta_sanity_caps();
+    test_size_cap_retention();
+    test_summary_recovery();
+
+    rm_rf(BASE_DIR);
+    printf("\n%d/%d tests passed\n", tests_passed, tests_run);
+    return tests_passed == tests_run ? 0 : 1;
+}

--- a/tests/test_query_text.c
+++ b/tests/test_query_text.c
@@ -1,0 +1,229 @@
+/* test_query_text.c — Phase T5 regression tests (DUR-4/10)
+ *
+ *   DUR-4:  query_texts.jsonl is append-opened + deduped-on-load, never
+ *           truncated (retained traces reference the ids across restarts);
+ *           compaction only under an explicit size threshold, atomic, and
+ *           never dropping untracked lines.
+ *   DUR-10: the 4096-id table capping out is logged (visible via the
+ *           cap_logged flag here) and the file gets trace-file permissions.
+ *
+ * Links src/query_text.c directly — no BPF, no daemon.
+ */
+#include "query_text.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/stat.h>
+
+static int tests_run = 0;
+static int tests_passed = 0;
+
+#define CHECK(cond, fmt, ...) do { \
+    tests_run++; \
+    if (cond) { tests_passed++; } \
+    else { printf("  FAIL(%d): " fmt "\n", __LINE__, ##__VA_ARGS__); } \
+} while (0)
+
+#define TEST_DIR "/tmp/pgwt_query_text_test"
+
+static void rm_rf(const char *dir)
+{
+    char cmd[300];
+    snprintf(cmd, sizeof(cmd), "rm -rf %s", dir);
+    if (system(cmd) != 0) { /* ignore */ }
+}
+
+static const char *jsonl_path(void)
+{
+    static char p[300];
+    snprintf(p, sizeof(p), "%s/query_texts.jsonl", TEST_DIR);
+    return p;
+}
+
+static int count_lines(void)
+{
+    FILE *f = fopen(jsonl_path(), "r");
+    if (!f) return -1;
+    int n = 0, c;
+    while ((c = fgetc(f)) != EOF)
+        if (c == '\n')
+            n++;
+    fclose(f);
+    return n;
+}
+
+static void test_append_and_dedup(void)
+{
+    printf("--- DUR-4: append-open + dedup-on-load ---\n");
+    rm_rf(TEST_DIR);
+    mkdir(TEST_DIR, 0755);
+
+    struct pgwt_query_text_capture *qt = calloc(1, sizeof(*qt));
+
+    /* First run: capture 3 ids. */
+    CHECK(pgwt_qt_init(qt, TEST_DIR, 0, 0, (gid_t)-1) == 0, "init 1");
+    pgwt_qt_store(qt, 101, "SELECT 1", 0);
+    pgwt_qt_store(qt, 102, "SELECT 2", 0);
+    pgwt_qt_store(qt, 103, "SELECT 3 -- with \"quotes\"\nand newline", 0);
+    pgwt_qt_close(qt);
+    CHECK(count_lines() == 3, "3 lines after first run (got %d)",
+          count_lines());
+
+    /* Restart: the old code truncated here — the whole DUR-4 bug. */
+    memset(qt, 0, sizeof(*qt));
+    CHECK(pgwt_qt_init(qt, TEST_DIR, 0, 0, (gid_t)-1) == 0, "init 2");
+    CHECK(qt->num_seen == 3, "3 ids loaded from disk (got %d)", qt->num_seen);
+    CHECK(count_lines() == 3, "restart did NOT truncate (got %d lines)",
+          count_lines());
+
+    /* Re-storing a known id must not duplicate; a new id must append. */
+    pgwt_qt_store(qt, 102, "SELECT 2", 0);
+    CHECK(count_lines() == 3, "known id not re-written (got %d)",
+          count_lines());
+    pgwt_qt_store(qt, 104, "SELECT 4", 0);
+    CHECK(count_lines() == 4, "new id appended (got %d)", count_lines());
+    pgwt_qt_close(qt);
+
+    /* Negative (signed) query_id round-trips through load. */
+    memset(qt, 0, sizeof(*qt));
+    CHECK(pgwt_qt_init(qt, TEST_DIR, 0, 0, (gid_t)-1) == 0, "init 3");
+    pgwt_qt_store(qt, (uint64_t)(int64_t)-5555, "SELECT -1", 0);
+    pgwt_qt_close(qt);
+    memset(qt, 0, sizeof(*qt));
+    CHECK(pgwt_qt_init(qt, TEST_DIR, 0, 0, (gid_t)-1) == 0, "init 4");
+    int before = count_lines();
+    pgwt_qt_store(qt, (uint64_t)(int64_t)-5555, "SELECT -1", 0);
+    CHECK(count_lines() == before, "negative id deduped on load");
+    pgwt_qt_close(qt);
+    free(qt);
+}
+
+static void test_torn_line_tolerated(void)
+{
+    printf("--- DUR-4: torn last line (crash mid-append) ---\n");
+    /* Append a torn line (no trailing newline, invalid JSON). */
+    FILE *f = fopen(jsonl_path(), "a");
+    fprintf(f, "{\"q\":\"99");
+    fclose(f);
+
+    struct pgwt_query_text_capture *qt = calloc(1, sizeof(*qt));
+    CHECK(pgwt_qt_init(qt, TEST_DIR, 0, 0, (gid_t)-1) == 0,
+          "init over torn line");
+    CHECK(qt->num_seen >= 5, "intact ids still loaded (got %d)",
+          qt->num_seen);
+    pgwt_qt_close(qt);
+    free(qt);
+}
+
+static void test_compaction(void)
+{
+    printf("--- DUR-4: compaction under explicit threshold ---\n");
+    rm_rf(TEST_DIR);
+    mkdir(TEST_DIR, 0755);
+
+    /* Build a file with duplicate lines (pre-dedup-era format). */
+    FILE *f = fopen(jsonl_path(), "w");
+    for (int round = 0; round < 3; round++)
+        for (int id = 1; id <= 10; id++)
+            fprintf(f, "{\"q\":\"%d\",\"t\":\"SELECT %d -- round %d\","
+                    "\"ts\":1}\n", id, id, round);
+    fclose(f);
+    long size_before = 0;
+    {
+        struct stat st;
+        stat(jsonl_path(), &st);
+        size_before = (long)st.st_size;
+    }
+
+    /* Below threshold: no compaction. */
+    struct pgwt_query_text_capture *qt = calloc(1, sizeof(*qt));
+    CHECK(pgwt_qt_init(qt, TEST_DIR, 0, 0, (gid_t)-1) == 0, "init");
+    CHECK(count_lines() == 30, "below threshold: file untouched (got %d)",
+          count_lines());
+    CHECK(qt->num_seen == 10, "10 unique ids loaded (got %d)", qt->num_seen);
+    pgwt_qt_close(qt);
+
+    /* Force the threshold below the file size: compaction must dedup to
+     * first occurrences, atomically. */
+    setenv("PGWT_QT_COMPACT_BYTES", "64", 1);
+    memset(qt, 0, sizeof(*qt));
+    CHECK(pgwt_qt_init(qt, TEST_DIR, 0, 0, (gid_t)-1) == 0, "init compact");
+    unsetenv("PGWT_QT_COMPACT_BYTES");
+    CHECK(count_lines() == 10, "compacted to unique ids (got %d)",
+          count_lines());
+    struct stat st;
+    stat(jsonl_path(), &st);
+    CHECK((long)st.st_size < size_before, "file shrank");
+    char tmp[300];
+    snprintf(tmp, sizeof(tmp), "%s.tmp", jsonl_path());
+    CHECK(access(tmp, F_OK) != 0, "no tmp file left behind");
+
+    /* First occurrence wins: round 0 text kept. */
+    f = fopen(jsonl_path(), "r");
+    char line[256];
+    int first_ok = 0;
+    if (fgets(line, sizeof(line), f))
+        first_ok = strstr(line, "round 0") != NULL;
+    fclose(f);
+    CHECK(first_ok, "first-seen text kept by compaction");
+
+    /* Capture still works after compaction. */
+    pgwt_qt_store(qt, 999, "SELECT 999", 0);
+    CHECK(count_lines() == 11, "append works after compaction (got %d)",
+          count_lines());
+    pgwt_qt_close(qt);
+    free(qt);
+}
+
+static void test_cap_logged(void)
+{
+    printf("--- DUR-10: id-table cap is loud (log-once flag) ---\n");
+    rm_rf(TEST_DIR);
+    mkdir(TEST_DIR, 0755);
+
+    struct pgwt_query_text_capture *qt = calloc(1, sizeof(*qt));
+    CHECK(pgwt_qt_init(qt, TEST_DIR, 0, 0, (gid_t)-1) == 0, "init");
+
+    fprintf(stderr, "  (expect one WARN about the id table below)\n");
+    for (uint64_t id = 1; id <= QT_HT_SIZE + 5; id++)
+        pgwt_qt_store(qt, id, "SELECT cap", 0);
+    CHECK(qt->num_seen == QT_HT_SIZE, "table filled (got %d)", qt->num_seen);
+    CHECK(qt->cap_logged, "cap logged once");
+    CHECK(count_lines() == QT_HT_SIZE, "exactly table-size lines (got %d)",
+          count_lines());
+    pgwt_qt_close(qt);
+    free(qt);
+}
+
+static void test_permissions(void)
+{
+    printf("--- DUR-10: file gets trace-file permissions ---\n");
+    rm_rf(TEST_DIR);
+    mkdir(TEST_DIR, 0755);
+
+    struct pgwt_query_text_capture *qt = calloc(1, sizeof(*qt));
+    /* Use our own gid — always permitted. */
+    CHECK(pgwt_qt_init(qt, TEST_DIR, 0, 0, getgid()) == 0, "init with gid");
+    pgwt_qt_store(qt, 1, "SELECT 1", 0);
+    struct stat st;
+    CHECK(stat(jsonl_path(), &st) == 0, "file exists");
+    CHECK((st.st_mode & 07777) == 0640,
+          "mode 0640 like trace files (got %o)", st.st_mode & 07777);
+    pgwt_qt_close(qt);
+    free(qt);
+}
+
+int main(void)
+{
+    printf("=== test_query_text (T5: DUR-4/10) ===\n");
+    test_append_and_dedup();
+    test_torn_line_tolerated();
+    test_compaction();
+    test_cap_logged();
+    test_permissions();
+    rm_rf(TEST_DIR);
+    printf("\n%d/%d tests passed\n", tests_passed, tests_run);
+    return tests_passed == tests_run ? 0 : 1;
+}

--- a/tests/unit_tests.list
+++ b/tests/unit_tests.list
@@ -17,6 +17,8 @@ test_sampler
 test_anomaly
 test_coop
 test_concurrent_rw
+test_durability
+test_query_text
 test_pg13_resolve
 test_discovery_pie
 test_discovery_nopie


### PR DESCRIPTION
Phase T5 of the Trust Milestone (docs/TRUST_MILESTONE_PLAN.md). Owns file
LIFECYCLE: open/recover/rotate/retention/fsync for traces + summaries +
query_texts, reader hardening, and the DUR-9 raw-load memory bound.

## Findings fixed

- **DUR-1 (critical)** — `fopen("wb")` on `current.trace`/`current.summary`
  erased up to an hour of committed data on every restart. Writers now open
  with `"wbx"` and RECOVER any leftover current file at startup: committed
  blocks scanned (reader-grade sanity caps + payload-in-file check), torn
  tail dropped, real footer appended + fsynced, renamed aside to a
  collision-safe archive. Unreadable leftovers are preserved as
  `*.corrupt.<ts>` — existing data is never truncated or deleted.
- **DUR-2** — rotation renamed onto hour-derived names, clobbering an
  existing archive on restart-mid-hour or a DST fold. Rotation and recovery
  now pick `YYYY-MM-DD_HH.N.trace.lz4` when the base name exists. Naming
  stays LOCAL time (documented decision in docs/TRACE_FORMAT.md — operators
  correlate with server logs; collision safety, not unique naming, protects
  data); discovery/retention already accept the suffixed form (verified by
  test + live run).
- **DUR-3** — new `--retention-gb <G>` (fractional GiB) size cap: oldest
  archives (trace/summary/suffixed/corrupt) deleted first, never the live
  current files or sidecars; loud WARN if the live files alone exceed the
  cap. Orphaned `current.*.meta` / `*.meta.tmp` / `*.jsonl.tmp` cleaned once
  provably stale (>1 h). Hours-based retention unchanged and now also covers
  recovered/corrupt files.
- **DUR-4** — `query_texts.jsonl` append-open + dedup-on-load (bounded by
  the fixed 4096-slot table); atomic compaction (first line per id,
  untracked lines kept) only above 32 MB; torn last lines tolerated.
- **DUR-9** — pid predicate pushdown into the raw load (a pid-filtered long
  window now costs one backend's events, not the whole window) + a hard
  bound (immutable-cache budget; `PGWT_LOAD_MAX_EVENTS` test override). On
  overflow every raw-path view returns a structured
  `{"error":"window too large","code":"window_too_large",...}` — never OOM,
  never silently partial data. Variants/top_queries keep pid 0 (their
  lifecycle stats read cross-pid markers that never pass the uniform filter).
- **DUR-5/6** — fsync policy chosen, measured, documented: fsync on
  rotation/close/recovery + dir fsync after renames; per-block writes stay
  page-cache committed. Measured 0.067 ms/block vs 0.963 ms/block (~14×)
  for per-block fsync (ext4/SSD test host). Daemon crash loses at most the
  unflushed tail; power loss can lose only the in-progress hour (documented).
  `docs/TRACE_FORMAT.md` is the new authoritative v2 spec (endianness/
  packing, block types, markers, meta high-watermark protocol, caps,
  lifecycle, durability, retention).
- **DUR-7** — meta-path scan now has the same sanity caps as the fallback
  scan; committed counts capped before sizing allocations; footer indexes
  shape-validated (first offset == header, strictly increasing, in-bounds);
  unknown block types skipped, never mis-decoded. Both readers.
- **DUR-8** — SAMPLES batched ~1 s per block (~10× fewer blocks at 10 Hz)
  at a type-agnostic buffering layer; count-weighted mean period preserves
  SMP-3 weights exactly in aggregate, period jumps (stall ticks) cut their
  own block; ordered flushes keep the block index sorted; writer forces
  early rotation at 1 M blocks so the (raised, 4 Mi) reader footer cap can
  never be hit — verified for 1000 Hz × 1024 backends.
- **DUR-10** — id-table cap logged once; jsonl gets trace-file perms
  (0640 + `--trace-group`); PII documented in TRACE_FORMAT.md + README.

## Tests (fail before / pass after)

- `tests/test_durability.c` — kill -9 matrix (real SIGKILL post-flush with
  meta-watermark sync, torn tail mid-block, torn meta tmp mid-rename), two
  restarts in one hour → both archives, rotation collision, degenerate
  files, batching + stall-tick weights + index sortedness, corrupt
  meta/header caps, size-cap + orphan retention, summary recovery (84 checks).
- `tests/test_query_text.c` — append/dedup/compaction/cap/perms (28 checks).
- `tests/test_data_window_bound.py` — bound fires as the structured error
  on all 12 raw-path views; pid pushdown proven by succeeding under a bound
  the unfiltered window exceeds.
- `test_concurrent_rw` extended with a sampler tick per cycle (the reader-
  vs-writer race now covers the batched-SAMPLES path).

## Verification on the live test host (root + PG 18.4 + BPF)

- full `make` + `make -C tests check`: all green (incl. ASan builds of the
  new writer/reader/query_text paths).
- all `tests/test_data_*.py` green.
- `tests/ci_smoke.sh`: 26/26 tiered + 26/26 full + 11/11 deterministic +
  15/15 state-map-loud — the capture path reads live traces through the
  changed writer/reader.
- live daemon: kill -9 mid-hour → restart recovered 6 blocks/414 events +
  2 summary blocks into archives; pgwt-server merged both generations;
  second restart in the same hour produced the `.1` suffixed archive.

Acceptance (plan): a daemon crash loses at most the unflushed tail, never a
committed hour; disk usage provably bounded (hours + `--retention-gb`).