### PR TITLE
T2: AAS semantics — one definition, all paths (AAS-1, SMP-5, study defects 1-3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,8 +198,11 @@ jobs:
           [ "$V" = "16" ] && FLAGS="--expect-unsupported"
           # sudo strips the environment: pass PATH (psql/pgbench) and
           # GITHUB_STEP_SUMMARY (the loud watchpoint-skip note) through.
+          # BPFTOOL: the uprobe run_cnt assertion (T2) needs a working
+          # bpftool inside the sudo environment.
           sudo env "PATH=/usr/lib/postgresql/$V/bin:$PATH" \
             "GITHUB_STEP_SUMMARY=$GITHUB_STEP_SUMMARY" \
+            "BPFTOOL=$BPFTOOL" \
             tests/ci_smoke.sh --pg-version "$V" $FLAGS
 
   web-ui:

--- a/src/anomaly.c
+++ b/src/anomaly.c
@@ -17,10 +17,9 @@
 
 /* ── Pure rule core (no BPF, no escalation) ───────────────────────────── */
 
-/* The on-CPU sample is never recorded by the sampler (build_batch skips
- * event 0). Idle waits (Activity class, Client:ClientRead) ARE in the batch
- * but must be excluded from "active sessions" exactly as the AAS/DB-Time views
- * do. We inline the same predicate here to keep the pure core dependency-free
+/* Idle waits (Activity class, Client:ClientRead) ARE in the batch but must
+ * be excluded from "active sessions" exactly as the AAS/DB-Time views do. We
+ * inline the same predicate here to keep the pure core dependency-free
  * (pgwt_is_idle_event lives in wait_event.c, which the unit test does not
  * link); the definition must stay in sync with pgwt_is_idle_event(). */
 static bool sample_is_idle(uint32_t wei)
@@ -37,8 +36,17 @@ void pgwt_anomaly_metrics_from_batch(const struct pgwt_trace_event *samples,
     int locks = 0;
     for (int i = 0; i < n; i++) {
         uint32_t we = samples[i].new_event;
-        if (we == 0 || sample_is_idle(we))
-            continue;   /* on-CPU or idle: not an active session */
+        /* T2 (AAS-1): the decomposed model. we==0 records in the batch are
+         * first-class CPU samples (the sampler already applied the
+         * command-open gate / per-type policy) — an on-CPU session IS an
+         * active session, so a pure CPU storm must move this metric.
+         * io_worker samples never count (their busy time shadow-copies the
+         * requesting backends' AioIoCompletion waits and is surfaced as a
+         * utilization metric instead — docs/AAS_SEMANTICS_DECISION.md). */
+        if (samples[i].flags & PGWT_EVENT_FLAG_IO_WORKER)
+            continue;
+        if (we != 0 && sample_is_idle(we))
+            continue;   /* instrumented idle: not an active session */
         active++;
         if (WE_CLASS(we) == PG_WAIT_LOCK)
             locks++;

--- a/src/backend.c
+++ b/src/backend.c
@@ -169,8 +169,21 @@ static int preseed_state_map(struct pgwt_daemon *d, pid_t pid, uint64_t addr,
         }
 
         int state_fd = bpf_map__fd(d->skel->maps.state_map);
+        /* Preserve the command-open gate across the (re-)seed: the
+         * on_report_activity uprobe only fires on boundaries, so zeroing
+         * cmd_open here would mis-gate the backend until its next command
+         * flip (matters on tiered re-escalation mid-command). */
+        uint16_t prev_cmd_open = 0;
+        {
+            uint32_t k = pid;
+            struct pgwt_pid_state prev;
+            if (bpf_map_lookup_elem(state_fd, &k, &prev) == 0)
+                prev_cmd_open = prev.cmd_open;
+        }
         struct pgwt_pid_state init_state = {
             .last_event = current_wei,
+            .wp_live = 1,   /* a live watchpoint now owns last_event/last_ts */
+            .cmd_open = prev_cmd_open,
             .last_ts = attach_ts,
             .last_query_id = current_qid,
             .wait_event_addr = addr,
@@ -325,7 +338,8 @@ int pgwt_scan_existing_backends(struct pgwt_daemon *d)
          * else creates state_map entries in sampled mode). */
         if (!pgwt_mode_uses_watchpoints(d)) {
             be->attach_ts = now_ns();
-            pgwt_parse_cmdline(pid, &be->meta);
+            if (pgwt_parse_cmdline(pid, &be->meta) == 0)
+                be->meta_parsed = true;
             if (d->backend_meta)
                 pgwt_bm_write(d->backend_meta, pid, &be->meta);
 
@@ -362,7 +376,8 @@ int pgwt_scan_existing_backends(struct pgwt_daemon *d)
             continue;
         }
 
-        pgwt_parse_cmdline(pid, &be->meta);
+        if (pgwt_parse_cmdline(pid, &be->meta) == 0)
+            be->meta_parsed = true;
         if (d->backend_meta)
             pgwt_bm_write(d->backend_meta, pid, &be->meta);
 
@@ -585,7 +600,8 @@ int pgwt_handle_init(struct pgwt_daemon *d, pid_t pid, uint64_t addr)
         return -1;
     }
 
-    pgwt_parse_cmdline(pid, &be->meta);
+    if (pgwt_parse_cmdline(pid, &be->meta) == 0)
+        be->meta_parsed = true;
     if (d->backend_meta)
         pgwt_bm_write(d->backend_meta, pid, &be->meta);
 

--- a/src/backend.h
+++ b/src/backend.h
@@ -20,6 +20,11 @@ struct pgwt_backend {
     int      wp_addr_shared;
     uint64_t attach_ts;        /* monotonic ns when attached */
     bool     is_alive;
+    /* meta has been filled by pgwt_parse_cmdline. A zeroed meta reads as
+     * backend_type == CLIENT (enum value 0), which is WRONG for an unparsed
+     * entry — consumers must treat !meta_parsed as UNKNOWN. The sampled-tier
+     * fork path parses lazily (the process title is only set after init). */
+    bool     meta_parsed;
     struct pgwt_metadata meta;
 };
 

--- a/src/bpf/pg_wait_tracer.bpf.c
+++ b/src/bpf/pg_wait_tracer.bpf.c
@@ -38,6 +38,15 @@ volatile const u32 lightweight_mode = 0;   /* 0=full trace, 1=lightweight (no ri
 volatile const u32 skip_query_id = 0;      /* 1=skip query_id reads (saves 1 probe_read) */
 volatile const u64 debug_query_string_addr = 0; /* VA of debug_query_string global */
 
+/* Command-open gate (T2, docs/AAS_SEMANTICS_DECISION.md): per-PG-version
+ * BackendState enum values for the pgstat_report_activity uprobe. PG13-17:
+ * STATE_RUNNING=2, STATE_FASTPATH=4; PG18+ inserted STATE_STARTING so they
+ * shift to 3/5. 0 = gate unavailable (unknown version / attach failure):
+ * cmd_open then stays 0 and client-backend on-CPU samples are NOT recorded
+ * (loud daemon warning — under-count, never the ungated ~3x over-count). */
+volatile const u32 bs_state_running = 0;
+volatile const u32 bs_state_fastpath = 0;
+
 /* PG13 query attribution (Route B1): standard_ExecutorStart(QueryDesc*) uprobe
  * walks QueryDesc->plannedstmt->queryId (populated by pg_stat_statements' hook)
  * into the state_map query_id slot. 0 => disabled (the PG17+
@@ -231,6 +240,18 @@ int on_watchpoint(struct bpf_perf_event_data *ctx)
         /* Fast path: read wait_event directly (1 probe_read vs 2) */
         u32 new_event = read_wait_event_direct(st->wait_event_addr);
 
+        /* A sampled-tier seed entry (wp_live == 0) carries query_id /
+         * cmd_open only — its last_event/last_ts are NOT interval state.
+         * First watchpoint fire on such an entry (defensive: preseed runs
+         * before enable, CAP-8) starts interval tracking without closing a
+         * fabricated interval. */
+        if (!st->wp_live) {
+            st->last_event = new_event;
+            st->last_ts = bpf_ktime_get_ns();
+            st->wp_live = 1;
+            return 0;
+        }
+
         /* Skip redundant writes — watchpoint fires even if value unchanged */
         if (new_event == st->last_event)
             return 0;
@@ -245,12 +266,16 @@ int on_watchpoint(struct bpf_perf_event_data *ctx)
             /* Full trace: emit to ringbuf.
              * query_id comes from state_map cache, set by EXEC_START
              * marker (not read from shared memory here — avoids race
-             * where st_query_id and st_activity are out of sync). */
+             * where st_query_id and st_activity are out of sync).
+             * flags carries the command-open gate at emission so the LIVE
+             * accumulator can classify we==0 intervals; the trace encoding
+             * has no flags column (offline consumers use CMD markers). */
             struct pgwt_trace_event evt = {
                 .timestamp_ns = now,
                 .pid = pid,
                 .old_event = st->last_event,
                 .new_event = new_event,
+                .flags = st->cmd_open ? PGWT_EVENT_FLAG_CMD_OPEN : 0,
                 .duration_ns = duration,
                 .query_id = st->last_query_id,
             };
@@ -276,6 +301,7 @@ int on_watchpoint(struct bpf_perf_event_data *ctx)
         u32 new_event = read_wait_event(&wait_addr);
         struct pgwt_pid_state new_st = {
             .last_event = new_event,
+            .wp_live = 1,   /* created BY a live watchpoint */
             .last_ts = bpf_ktime_get_ns(),
             .last_query_id = 0,
             .be_entry_ptr = resolve_be_entry(),
@@ -354,23 +380,34 @@ int on_exit(struct trace_event_raw_sched_process_template *ctx)
     if (!st)
         return 0;
 
-    /* Close the last open interval */
     u64 now = bpf_ktime_get_ns();
-    u64 duration = now - st->last_ts;
 
-    if (lightweight_mode) {
-        accum_add(st->last_event, duration);
-    } else {
-        /* Emit final trace event (exit sentinel) */
-        struct pgwt_trace_event evt = {
-            .timestamp_ns = now,
-            .pid = pid,
-            .old_event = st->last_event,
-            .new_event = PGWT_EVENT_EXIT,
-            .duration_ns = duration,
-            .query_id = st->last_query_id,
-        };
-        emit_event(&evt);
+    /* Close the last open interval — ONLY if a live watchpoint was
+     * maintaining it. A sampled-tier seed entry (wp_live == 0) carries
+     * query_id/cmd_open only: last_ts is the SEED time, and "closing" it
+     * manufactured a phantom interval spanning the backend's whole sampled
+     * lifetime, mislabeled as its last_event (usually 0 = CPU) — T2 study
+     * defect 2: every pgbench disconnect back-filled ~120 s of phantom CPU
+     * into the trace. The sampled tier's data is the SAMPLES stream; there
+     * is no exact interval to close. */
+    if (st->wp_live) {
+        u64 duration = now - st->last_ts;
+
+        if (lightweight_mode) {
+            accum_add(st->last_event, duration);
+        } else {
+            /* Emit final trace event (exit sentinel) */
+            struct pgwt_trace_event evt = {
+                .timestamp_ns = now,
+                .pid = pid,
+                .old_event = st->last_event,
+                .new_event = PGWT_EVENT_EXIT,
+                .flags = st->cmd_open ? PGWT_EVENT_FLAG_CMD_OPEN : 0,
+                .duration_ns = duration,
+                .query_id = st->last_query_id,
+            };
+            emit_event(&evt);
+        }
     }
 
     /* Notify daemon */
@@ -510,6 +547,59 @@ int on_report_query_id(struct pt_regs *ctx)
     if (bpf_map_update_elem(&seen_query_ids, &query_id, &one, BPF_ANY))
         count_map_fail(PGWT_BPF_FAIL_SEEN_QIDS);
 
+    return 0;
+}
+
+/* ── Program: uprobe on pgstat_report_activity (command-open gate, T2) ────
+ * pgstat_report_activity(BackendState state, const char *cmd_str) is the
+ * function PostgreSQL itself uses to drive pg_stat_activity.state. Gating
+ * on it gives the tracer the exact same "active" window: query message
+ * received (STATE_RUNNING) -> command complete (STATE_IDLE /
+ * STATE_IDLEINTRANSACTION*), which INCLUDES parse, plan, bind, execute and
+ * commit/abort processing. The sampler reads cmd_open to decide whether a
+ * client backend's we==0 reading is a first-class CPU sample (in-command)
+ * or non-command churn (docs/AAS_SEMANTICS_DECISION.md: ungated counting
+ * measured ~3x true activity on chatty OLTP).
+ *
+ * While a watchpoint is live for the pid (full mode / tiered escalated),
+ * each gate FLIP also lands in the event stream as a CMD_START/CMD_END
+ * marker so offline consumers can classify exact-tier we==0 intervals the
+ * same way — no step artifact at tier switches.
+ *
+ * The uprobe only UPDATES existing state_map entries (like the query-id
+ * uprobes); entries are seeded by the scan/fork/preseed paths. Attached in
+ * every non-lightweight mode. */
+
+SEC("uprobe")
+int on_report_activity(struct pt_regs *ctx)
+{
+    if (!bs_state_running)
+        return 0;   /* gate unavailable for this PG version */
+
+    u32 state = (u32)PT_REGS_PARM1(ctx);
+    u32 pid = bpf_get_current_pid_tgid() >> 32;
+    struct pgwt_pid_state *st = bpf_map_lookup_elem(&state_map, &pid);
+    if (!st)
+        return 0;
+
+    u16 open = (state == bs_state_running || state == bs_state_fastpath)
+             ? 1 : 0;
+    if (st->cmd_open == open)
+        return 0;   /* no boundary crossed (e.g. RUNNING -> RUNNING) */
+    st->cmd_open = open;
+
+    if (!lightweight_mode && st->wp_live) {
+        u32 marker = open ? PGWT_MARKER_CMD_START : PGWT_MARKER_CMD_END;
+        struct pgwt_trace_event evt = {
+            .timestamp_ns = bpf_ktime_get_ns(),
+            .pid = pid,
+            .old_event = marker,
+            .new_event = marker,
+            .duration_ns = 0,
+            .query_id = st->last_query_id,
+        };
+        emit_event(&evt);
+    }
     return 0;
 }
 

--- a/src/compute.c
+++ b/src/compute.c
@@ -171,6 +171,170 @@ int pgwt_filter_matches(const struct pgwt_filter *f,
     return 1;
 }
 
+/* ── T2: category tagging pass (docs/AAS_SEMANTICS_DECISION.md) ──────── */
+
+/* Per-pid sweep state for pgwt_tag_events. Open-addressing hash on pid. */
+#define TAG_HT_SIZE 4096
+#define TAG_HT_MASK (TAG_HT_SIZE - 1)
+struct tag_pid_state {
+    uint32_t pid;          /* 0 = empty slot */
+    uint32_t cat_flag;     /* category flag from the pid table */
+    uint8_t  cat_resolved;
+    uint8_t  plan_open, exec_open;
+    uint8_t  cmd_open, seen_cmd;
+    uint64_t cmd_anchor;   /* start of the current open run / last record end */
+    uint64_t banked_ns;    /* closed command-open ns since the last record */
+};
+
+static uint32_t pid_cat_lookup(const struct pgwt_pid_cat *cats, int n,
+                               uint32_t pid)
+{
+    int lo = 0, hi = n - 1;
+    while (lo <= hi) {
+        int mid = lo + (hi - lo) / 2;
+        if (cats[mid].pid == pid)
+            return cats[mid].flag;
+        if (cats[mid].pid < pid)
+            lo = mid + 1;
+        else
+            hi = mid - 1;
+    }
+    return 0;   /* unknown pid: foreground (conservative) */
+}
+
+static struct tag_pid_state *tag_pid_get(struct tag_pid_state *ht, uint32_t pid)
+{
+    int h = hash32(pid, TAG_HT_MASK);
+    for (int probe = 0; probe < TAG_HT_SIZE; probe++) {
+        if (ht[h].pid == pid)
+            return &ht[h];
+        if (ht[h].pid == 0) {
+            ht[h].pid = pid;
+            return &ht[h];
+        }
+        h = (h + 1) & TAG_HT_MASK;
+    }
+    return NULL;   /* table full — untagged records stay foreground */
+}
+
+void pgwt_tag_events(struct pgwt_trace_event *events, int count,
+                     const struct pgwt_pid_cat *cats, int n_cats)
+{
+    struct tag_pid_state *ht = calloc(TAG_HT_SIZE, sizeof(*ht));
+    if (!ht)
+        return;   /* untagged: everything foreground, CPU stays CPU */
+
+    for (int i = 0; i < count; i++) {
+        struct pgwt_trace_event *ev = &events[i];
+        struct tag_pid_state *st = tag_pid_get(ht, ev->pid);
+        if (!st)
+            continue;
+
+        /* Markers drive the per-pid windows and are otherwise left alone. */
+        if (PGWT_IS_MARKER(ev->old_event)) {
+            uint64_t ts = ev->timestamp_ns;
+            switch (ev->old_event) {
+            case PGWT_MARKER_PLAN_START: st->plan_open = 1; break;
+            case PGWT_MARKER_PLAN_END:   st->plan_open = 0; break;
+            case PGWT_MARKER_EXEC_START: st->exec_open = 1; break;
+            case PGWT_MARKER_EXEC_END:   st->exec_open = 0; break;
+            case PGWT_MARKER_CMD_START:
+                st->seen_cmd = 1;
+                if (!st->cmd_open) {
+                    st->cmd_open = 1;
+                    st->cmd_anchor = ts;
+                }
+                break;
+            case PGWT_MARKER_CMD_END:
+                st->seen_cmd = 1;
+                if (st->cmd_open) {
+                    st->banked_ns += ts - st->cmd_anchor;
+                    st->cmd_open = 0;
+                }
+                /* A command closing also closes any stale plan/exec window
+                 * (an EXEC_END lost to a ringbuf drop must not leak the
+                 * window across statements). */
+                st->plan_open = 0;
+                st->exec_open = 0;
+                break;
+            default:
+                break;   /* escalation markers: pid 0, no per-pid state */
+            }
+            continue;
+        }
+
+        if (!st->cat_resolved) {
+            st->cat_flag = pid_cat_lookup(cats, n_cats, ev->pid);
+            st->cat_resolved = 1;
+        }
+        ev->flags |= st->cat_flag;
+
+        if (ev->flags & PGWT_EVENT_FLAG_SAMPLE) {
+            /* Sampled tier: no plan/exec markers exist. Cheap phase
+             * attribution — a foreground sample carrying a query_id is
+             * execution; without one it is command overhead. */
+            if (st->cat_flag == 0 && ev->query_id != 0)
+                ev->flags |= PGWT_EVENT_FLAG_EXEC;
+            continue;
+        }
+
+        /* Exact record: interval [t1 - dur, t1). */
+        uint64_t t1 = ev->timestamp_ns;
+        uint64_t t0 = t1 - ev->duration_ns;
+        if (st->plan_open) ev->flags |= PGWT_EVENT_FLAG_PLAN;
+        if (st->exec_open) ev->flags |= PGWT_EVENT_FLAG_EXEC;
+
+        if (st->seen_cmd) {
+            /* Command-open ns inside this interval: the banked closed runs
+             * plus the currently-open run clipped to the interval. Records
+             * for one pid are contiguous in an exact span, so banked time
+             * since the previous record belongs to this interval. */
+            uint64_t open_ns = st->banked_ns;
+            if (st->cmd_open) {
+                uint64_t a = st->cmd_anchor > t0 ? st->cmd_anchor : t0;
+                if (t1 > a)
+                    open_ns += t1 - a;
+            }
+            st->banked_ns = 0;
+            if (st->cmd_open)
+                st->cmd_anchor = t1;
+
+            /* Majority rule: an interval more than half inside a command
+             * window is in-command (bounded by one interval's length —
+             * we==0 intervals are µs-ms vs multi-second buckets). */
+            int in_cmd = ev->duration_ns == 0
+                       ? st->cmd_open
+                       : (open_ns * 2 >= ev->duration_ns);
+            if (in_cmd)
+                ev->flags |= PGWT_EVENT_FLAG_CMD_OPEN;
+
+            /* The decision table: we==0 OUTSIDE a command is idle
+             * post/between-command time, not CPU. Foreground pids only —
+             * background processes never report activity states. */
+            if (ev->old_event == 0 && st->cat_flag == 0 && !in_cmd)
+                ev->old_event = PGWT_WEI_NONCMD_CPU;
+        }
+    }
+    free(ht);
+}
+
+int pgwt_event_category(const struct pgwt_trace_event *ev)
+{
+    if (ev->flags & PGWT_EVENT_FLAG_IO_WORKER)
+        return PGWT_CAT_IO_WORKER;
+    if (pgwt_is_idle_event(ev->old_event))
+        return -1;
+    if (ev->flags & PGWT_EVENT_FLAG_MAINT)
+        return PGWT_CAT_MAINT;
+    if (ev->flags & PGWT_EVENT_FLAG_BACKGROUND)
+        return PGWT_CAT_BG;
+    if (ev->flags & PGWT_EVENT_FLAG_PLAN)
+        return PGWT_CAT_FG_PLAN;
+    if (ev->flags & PGWT_EVENT_FLAG_EXEC)
+        return PGWT_CAT_FG_EXEC;
+    return PGWT_CAT_FG_CMD;
+}
+
 /* ── AAS Buckets ──────────────────────────────────────────── */
 
 /* Hash table entry for per-event total accumulation (pass 1) */
@@ -228,6 +392,13 @@ void pgwt_compute_aas(const struct pgwt_trace_event *events, int count,
         if (!pgwt_filter_matches(f, ev) || pgwt_is_idle_event(ev->old_event))
             continue;
 
+        /* T2: io_worker records never enter the class AAS (or max_aas) —
+         * they appear only in their own category slot, so the headline AAS
+         * keeps the "≤ sessions doing work" invariant and stays comparable
+         * across io_method settings. */
+        int cat = pgwt_event_category(ev);
+        int io_worker = (cat == PGWT_CAT_IO_WORKER);
+
         /* Event covers [timestamp_ns - duration_ns, timestamp_ns) */
         uint64_t ev_start = ev->timestamp_ns - ev->duration_ns;
         uint64_t ev_end   = ev->timestamp_ns;
@@ -249,12 +420,16 @@ void pgwt_compute_aas(const struct pgwt_trace_event *events, int count,
             uint64_t b_end   = b_start + bucket_ns;
             uint64_t o_start = ev_start > b_start ? ev_start : b_start;
             uint64_t o_end   = ev_end < b_end ? ev_end : b_end;
-            if (o_end > o_start)
-                buckets[b].class_aas[class_idx] += (double)(o_end - o_start);
+            if (o_end > o_start) {
+                if (!io_worker)
+                    buckets[b].class_aas[class_idx] += (double)(o_end - o_start);
+                if (cat >= 0)
+                    buckets[b].cat_aas[cat] += (double)(o_end - o_start);
+            }
         }
 
         /* Per-event total for sorting (pass 1) */
-        if (evt_ht) {
+        if (evt_ht && !io_worker) {
             uint32_t h = ev->old_event & AAS_EVT_HT_MASK;
             while (evt_ht[h].total_ns > 0 && evt_ht[h].event_id != ev->old_event)
                 h = (h + 1) & AAS_EVT_HT_MASK;
@@ -263,7 +438,7 @@ void pgwt_compute_aas(const struct pgwt_trace_event *events, int count,
         }
     }
 
-    /* Convert accumulated ns → AAS (class buckets) */
+    /* Convert accumulated ns → AAS (class + category buckets) */
     double max_aas = 0.0;
     for (int i = 0; i < actual_buckets; i++) {
         double total = 0.0;
@@ -271,6 +446,8 @@ void pgwt_compute_aas(const struct pgwt_trace_event *events, int count,
             buckets[i].class_aas[c] /= (double)bucket_ns;
             total += buckets[i].class_aas[c];
         }
+        for (int c = 0; c < PGWT_NUM_CATS; c++)
+            buckets[i].cat_aas[c] /= (double)bucket_ns;
         if (total > max_aas)
             max_aas = total;
     }
@@ -315,6 +492,8 @@ void pgwt_compute_aas(const struct pgwt_trace_event *events, int count,
                 const struct pgwt_trace_event *ev = &events[i];
                 if (!pgwt_filter_matches(f, ev) || pgwt_is_idle_event(ev->old_event))
                     continue;
+                if (ev->flags & PGWT_EVENT_FLAG_IO_WORKER)
+                    continue;   /* T2: excluded from AAS in any view */
 
                 /* Find series index for this event */
                 int si = -1;
@@ -409,6 +588,11 @@ void pgwt_compute_time_model(const struct pgwt_trace_event *events, int count,
 
     double db_time_ns  = 0.0;
     double idle_time_ns = 0.0;
+    double cat_ns[PGWT_NUM_CATS] = {0};
+    /* io_worker busy%% needs the worker-pool size: count distinct io_worker
+     * pids seen in the window (a handful — io_workers defaults to 3). */
+    uint32_t iw_pids[64];
+    int n_iw_pids = 0;
 
     for (int i = 0; i < count; i++) {
         const struct pgwt_trace_event *ev = &events[i];
@@ -417,10 +601,28 @@ void pgwt_compute_time_model(const struct pgwt_trace_event *events, int count,
 
         double dur_ns = (double)ev->duration_ns;
 
+        /* T2: io_worker time is OUTSIDE DB Time/idle — busy time goes to
+         * its category slot (the utilization signal), idle time (their
+         * instrumented IoWorkerMain wait) is dropped from the model. */
+        if (ev->flags & PGWT_EVENT_FLAG_IO_WORKER) {
+            int seen = 0;
+            for (int k = 0; k < n_iw_pids; k++)
+                if (iw_pids[k] == ev->pid) { seen = 1; break; }
+            if (!seen && n_iw_pids < 64)
+                iw_pids[n_iw_pids++] = ev->pid;
+            if (!pgwt_is_idle_event(ev->old_event))
+                cat_ns[PGWT_CAT_IO_WORKER] += dur_ns;
+            continue;
+        }
+
         if (pgwt_is_idle_event(ev->old_event)) {
             idle_time_ns += dur_ns;
             continue;
         }
+
+        int cat = pgwt_event_category(ev);
+        if (cat >= 0)
+            cat_ns[cat] += dur_ns;
 
         db_time_ns += dur_ns;
         int cls_idx = pgwt_wait_class_index(ev->old_event);
@@ -431,6 +633,14 @@ void pgwt_compute_time_model(const struct pgwt_trace_event *events, int count,
         if (slot >= 0)
             ev_ht[slot].total_ns += dur_ns;
     }
+
+    for (int c = 0; c < PGWT_NUM_CATS; c++)
+        out->cat_ms[c] = cat_ns[c] / 1e6;
+    out->io_worker_busy_pct =
+        (n_iw_pids > 0 && wall_ms > 0)
+            ? 100.0 * (cat_ns[PGWT_CAT_IO_WORKER] / 1e6)
+              / ((double)n_iw_pids * wall_ms)
+            : 0.0;
 
     double db_time_ms  = db_time_ns / 1e6;
     double idle_ms     = idle_time_ns / 1e6;
@@ -584,6 +794,12 @@ void pgwt_compute_top_events(const struct pgwt_trace_event *events, int count,
         const struct pgwt_trace_event *ev = &events[i];
         if (!pgwt_filter_matches(f, ev) || pgwt_is_hidden_event(ev->old_event))
             continue;
+        /* T2: io_worker time never enters the DB-Time-ranked event list —
+         * it would double-represent the same I/O already counted in the
+         * requesting backends' AioIoCompletion waits. Their records stay
+         * in the raw trace/timeline; the utilization metric covers them. */
+        if (ev->flags & PGWT_EVENT_FLAG_IO_WORKER)
+            continue;
 
         /* Idle-but-visible events (Client:ClientRead) appear in the list
          * but are excluded from DB Time. Their time is not part of the
@@ -696,6 +912,8 @@ void pgwt_compute_top_sessions(const struct pgwt_trace_event *events, int count,
         const struct pgwt_trace_event *ev = &events[i];
         if (!pgwt_filter_matches(f, ev) || pgwt_is_idle_event(ev->old_event))
             continue;
+        if (ev->flags & PGWT_EVENT_FLAG_IO_WORKER)
+            continue;   /* T2: io_workers are not sessions doing DB work */
 
         uint32_t h = ev->pid % SESSION_HT_SIZE;
         while (ht[h].pid != 0 && ht[h].pid != ev->pid)
@@ -796,6 +1014,8 @@ void pgwt_compute_top_queries(const struct pgwt_trace_event *events, int count,
         const struct pgwt_trace_event *ev = &events[i];
         if (!pgwt_filter_matches(f, ev) || pgwt_is_idle_event(ev->old_event))
             continue;
+        if (ev->flags & PGWT_EVENT_FLAG_IO_WORKER)
+            continue;   /* T2: io_workers are structurally query-less */
         if (ev->query_id == 0)
             continue;
 

--- a/src/compute.h
+++ b/src/compute.h
@@ -42,6 +42,56 @@ static const char *pgwt_class_display[PGWT_NUM_CLASSES] = {
 /* Map wait_event_info → class index (0–10) */
 int pgwt_wait_class_index(uint32_t event_id);
 
+/* ── T2: decomposed AAS categories (docs/AAS_SEMANTICS_DECISION.md) ─────
+ * Every non-idle record falls in exactly one category:
+ *   fg planning / execution / command — client-backend (and parallel-
+ *     worker) work, split by the PLAN/EXEC marker windows; "command" is
+ *     in-command time outside both (parse, bind, commit/abort);
+ *   maintenance — autovacuum workers;
+ *   background — checkpointer / bgwriter / walwriter / other aux;
+ *   io_worker — PG18 io_method=worker processes: EXCLUDED from AAS and
+ *     DB Time (their busy time shadow-copies the requesting backends'
+ *     AioIoCompletion waits) but tracked for the busy%% utilization metric.
+ * Idle records (Activity class, ClientRead, non-command CPU) are category
+ * -1: excluded-but-visible, exactly as before. */
+#define PGWT_NUM_CATS 6
+#define PGWT_CAT_FG_PLAN   0
+#define PGWT_CAT_FG_EXEC   1
+#define PGWT_CAT_FG_CMD    2
+#define PGWT_CAT_MAINT     3
+#define PGWT_CAT_BG        4
+#define PGWT_CAT_IO_WORKER 5
+
+static const char *pgwt_cat_names[PGWT_NUM_CATS] = {
+    "planning", "execution", "command", "maintenance", "background",
+    "io_worker"
+};
+
+/* pid → category-flag table (PGWT_EVENT_FLAG_IO_WORKER/MAINT/BACKGROUND or
+ * 0 for foreground), sorted by pid, built from backends.jsonl metadata. */
+struct pgwt_pid_cat {
+    uint32_t pid;
+    uint32_t flag;
+};
+
+/* Annotation pass (T2) over a merged, time-ordered event array:
+ *   - stamps each record's flags with its pid's category flag;
+ *   - sweeps the PLAN/EXEC/CMD markers per pid and stamps FLAG_PLAN /
+ *     FLAG_EXEC / FLAG_CMD_OPEN on the records inside those windows;
+ *   - rewrites exact we==0 intervals that are MAJORITY-outside a command
+ *     window to PGWT_WEI_NONCMD_CPU (idle post-command time, per the
+ *     decision table). Only for pids that HAVE CMD markers in the window —
+ *     legacy traces and background processes keep all we==0 as CPU;
+ *   - samples: foreground samples with a query_id are tagged FLAG_EXEC
+ *     (the cheap sampled-tier phase attribution; plan/exec sub-windows
+ *     need the exact tier's markers).
+ * cats may be NULL/empty (no metadata: everything is foreground). */
+void pgwt_tag_events(struct pgwt_trace_event *events, int count,
+                     const struct pgwt_pid_cat *cats, int n_cats);
+
+/* Category of a tagged record: 0..PGWT_NUM_CATS-1, or -1 for idle. */
+int pgwt_event_category(const struct pgwt_trace_event *ev);
+
 /* ── Fidelity (trace format v2 — D3) ───────────────────────── */
 
 /* The fidelity of the data covering a queried time window.
@@ -128,6 +178,9 @@ int pgwt_filter_matches(const struct pgwt_filter *f,
 struct pgwt_aas_bucket {
     uint64_t start_ns;
     double   class_aas[PGWT_NUM_CLASSES];
+    /* T2: the same AAS decomposed by category. io_worker records appear
+     * ONLY here (their own slot) — never in class_aas or max_aas. */
+    double   cat_aas[PGWT_NUM_CATS];
 };
 
 #define AAS_MAX_EVENT_SERIES 16
@@ -173,6 +226,10 @@ struct pgwt_tm_result {
     double idle_time_ms;
     double aas;
     double wall_ms;
+    /* T2 category decomposition (raw path only; 0 on the summary path).
+     * cat_ms[PGWT_CAT_IO_WORKER] is io_worker BUSY ms — outside DB Time. */
+    double cat_ms[PGWT_NUM_CATS];
+    double io_worker_busy_pct;  /* busy ms / (io_worker pids × wall) × 100 */
 };
 
 void pgwt_compute_time_model(const struct pgwt_trace_event *events, int count,

--- a/src/control.c
+++ b/src/control.c
@@ -178,6 +178,21 @@ static cJSON *build_metrics(const struct pgwt_daemon *d)
     cJSON_AddBoolToObject(root, "sampler_healthy",
                           !(d->sampler && !d->sampler->health.healthy));
 
+    /* T2 decomposed-AAS observability (docs/AAS_SEMANTICS_DECISION.md):
+     * io_worker_busy_pct is the utilization signal that replaces counting
+     * io_workers in AAS (busy% over the last display interval; a sustained
+     * high value means the io_worker pool is near saturation).
+     * noncmd_cpu_samples_total counts client we==0 readings outside a
+     * command — observed but deliberately not recorded as activity. */
+    cJSON_AddNumberToObject(root, "io_worker_busy_pct",
+                            ctr->io_worker_busy_pct);
+    cjson_add_uint64(root, "io_worker_samples_total",
+                     ctr->io_worker_samples_total);
+    cjson_add_uint64(root, "io_worker_busy_total",
+                     ctr->io_worker_busy_total);
+    cjson_add_uint64(root, "noncmd_cpu_samples_total",
+                     ctr->noncmd_cpu_samples_total);
+
     /* Provider self-metrics. ringbuf_drops_total is the full tier's BPF-side
      * event_ringbuf drop count (A2 wired this; A0 deliberately omitted it). */
     struct pgwt_metrics pm;

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -171,11 +171,42 @@ static void handle_timer(struct pgwt_daemon *d)
             (double)(d->counters.samples_total - d->counters.prev_samples_total)
             / d->interval;
         d->counters.prev_samples_total = d->counters.samples_total;
+
+        /* T2: io_worker utilization over the last display interval. */
+        uint64_t iw_s = d->counters.io_worker_samples_total
+                      - d->counters.prev_io_worker_samples;
+        uint64_t iw_b = d->counters.io_worker_busy_total
+                      - d->counters.prev_io_worker_busy;
+        d->counters.io_worker_busy_pct =
+            iw_s > 0 ? 100.0 * (double)iw_b / (double)iw_s : 0.0;
+        d->counters.prev_io_worker_samples = d->counters.io_worker_samples_total;
+        d->counters.prev_io_worker_busy    = d->counters.io_worker_busy_total;
     }
 
     d->tick++;
     if (d->count > 0 && d->tick >= d->count)
         d->running = false;
+}
+
+/* SMP-5: arm the sampler timer ONE-SHOT with a +/-10% jittered period.
+ * Fixed-phase sampling aliases with periodic workloads (a job that wakes
+ * every 100 ms could hide from — or monopolize — a 10 Hz sampler forever);
+ * jittering each tick's phase breaks the lock-step. Total sample weight is
+ * unaffected: every tick is weighted by the MEASURED inter-tick elapsed
+ * time (SMP-3, pgwt_sampler_effective_period). */
+static void arm_sample_timer_jittered(struct pgwt_daemon *d)
+{
+    int hz = d->sample_rate_hz > 0 ? d->sample_rate_hz : 10;
+    uint64_t period_ns = 1000000000ULL / (uint64_t)hz;
+    uint64_t jitter = period_ns / 10;
+    /* period in [0.9p, 1.1p] — rand() is plenty for phase decorrelation. */
+    uint64_t armed = period_ns - jitter
+                   + (uint64_t)rand() % (2 * jitter + 1);
+    struct itimerspec sits = {
+        .it_value = { .tv_sec  = (time_t)(armed / 1000000000ULL),
+                      .tv_nsec = (long)(armed % 1000000000ULL) },
+    };
+    timerfd_settime(d->sample_timer_fd, 0, &sits, NULL);
 }
 
 static void handle_sample_timer(struct pgwt_daemon *d)
@@ -186,9 +217,13 @@ static void handle_sample_timer(struct pgwt_daemon *d)
      * those samples are gone. The sampler compensates by weighting each tick
      * with the MEASURED inter-tick elapsed time (see pgwt_sampler_poll), so
      * the loss is in resolution, not in total weight. Count it so a chronic
-     * stall is visible on the control socket. */
+     * stall is visible on the control socket. (One-shot arming makes >1
+     * unlikely, but a stalled daemon can still miss re-arms late.) */
     if (r == (ssize_t)sizeof(expirations) && expirations > 1)
         d->counters.sampler_ticks_missed_total += expirations - 1;
+    /* Re-arm FIRST so a slow poll delays the next tick (measured-elapsed
+     * weighting absorbs it) instead of bursting. */
+    arm_sample_timer_jittered(d);
     if (d->provider && d->provider->poll)
         d->provider->poll(d);
 }
@@ -302,6 +337,21 @@ int pgwt_daemon_init(struct pgwt_daemon *d)
     d->skel->rodata->st_query_id_offset = d->st_query_id_offset;
     d->skel->rodata->lightweight_mode = d->lightweight_mode;
     d->skel->rodata->skip_query_id = d->skip_query_id;
+
+    /* Command-open gate (T2): BackendState enum values for this PG version.
+     * PG13-17: STATE_RUNNING=2, STATE_FASTPATH=4. PG18 inserted
+     * STATE_STARTING after STATE_UNDEFINED, shifting them to 3/5 (verified
+     * against REL_13/16/17/18_STABLE backend_status.h/pgstat.h). An unknown
+     * version leaves 0 = gate disabled (loud warning below): client on-CPU
+     * samples are then NOT recorded — an honest under-count, never the
+     * ungated ~3x over-count. */
+    if (d->pg_major_version >= 18) {
+        d->skel->rodata->bs_state_running  = 3;
+        d->skel->rodata->bs_state_fastpath = 5;
+    } else if (d->pg_major_version >= 13) {
+        d->skel->rodata->bs_state_running  = 2;
+        d->skel->rodata->bs_state_fastpath = 4;
+    }
 
     /* PG13 query attribution (Route B1): the ExecutorStart uprobe walks
      * QueryDesc->plannedstmt->queryId into the state_map. Enabled only when
@@ -426,6 +476,42 @@ int pgwt_daemon_init(struct pgwt_daemon *d)
                     fprintf(stderr, "INFO: pgstat_report_query_id at offset 0x%lx\n",
                             (unsigned long)qid_func_off);
             }
+        }
+
+        /* Command-open gate uprobe (T2): pgstat_report_activity(state, ...)
+         * maintains cmd_open in the state_map — the pg_stat_activity
+         * state='active' window the sampler gates client on-CPU samples on,
+         * and (while watchpoints are live) the CMD_START/CMD_END markers the
+         * exact tier's we==0 classification uses. Attached in every
+         * non-lightweight mode, like the query_id uprobe. Failure is loud:
+         * without the gate, client CPU is not sampled — the CPU half of AAS
+         * silently disappears for client backends otherwise. */
+        {
+            uint64_t act_va = pgwt_find_symbol_offset(bin, "pgstat_report_activity");
+            uint64_t act_off = pgwt_vaddr_to_file_offset(bin, act_va);
+            if (act_off && d->skel->rodata->bs_state_running != 0) {
+                LIBBPF_OPTS(bpf_uprobe_opts, act_opts, .retprobe = false);
+                d->skel->links.on_report_activity =
+                    bpf_program__attach_uprobe_opts(d->skel->progs.on_report_activity,
+                                                    -1, bin, act_off, &act_opts);
+                if (d->verbose && d->skel->links.on_report_activity)
+                    fprintf(stderr, "INFO: pgstat_report_activity at offset 0x%lx "
+                            "(command-open gate)\n", (unsigned long)act_off);
+            }
+            d->cmd_gate_active = (d->skel->links.on_report_activity != NULL);
+            if (!d->skel->links.on_report_activity)
+                fprintf(stderr,
+                        "WARN: command-open gate unavailable (%s) — on-CPU "
+                        "samples for CLIENT backends will NOT be recorded; "
+                        "sampled AAS under-counts CPU-bound client activity. "
+                        "Background/parallel-worker CPU is unaffected.\n",
+                        act_va == 0
+                            ? "symbol 'pgstat_report_activity' not found"
+                            : (act_off == 0
+                                   ? "cannot translate VA to file offset"
+                                   : (d->skel->rodata->bs_state_running == 0
+                                          ? "unknown BackendState layout for this PG version"
+                                          : "uprobe attach failed")));
         }
 
         /* USDT marker probes write into event_ringbuf, which only the FULL
@@ -600,22 +686,16 @@ int pgwt_daemon_init(struct pgwt_daemon *d)
     timerfd_settime(d->timer_fd, 0, &its, NULL);
 
     /* High-rate sampler timer (sampled/tiered tiers): fires at sample_rate_hz
-     * independently of the per-second display interval. */
+     * independently of the per-second display interval. Armed ONE-SHOT with
+     * per-tick phase jitter (SMP-5) and re-armed after every poll. */
     if (d->provider && d->provider->fidelity == PGWT_FIDELITY_SAMPLED) {
         d->sample_timer_fd = timerfd_create(CLOCK_MONOTONIC, TFD_CLOEXEC);
         if (d->sample_timer_fd < 0) {
             perror("timerfd_create (sampler)");
             goto fail;
         }
-        int hz = d->sample_rate_hz > 0 ? d->sample_rate_hz : 10;
-        uint64_t period_ns = 1000000000ULL / (uint64_t)hz;
-        struct itimerspec sits = {
-            .it_interval = { .tv_sec = (time_t)(period_ns / 1000000000ULL),
-                             .tv_nsec = (long)(period_ns % 1000000000ULL) },
-            .it_value    = { .tv_sec = (time_t)(period_ns / 1000000000ULL),
-                             .tv_nsec = (long)(period_ns % 1000000000ULL) },
-        };
-        timerfd_settime(d->sample_timer_fd, 0, &sits, NULL);
+        srand((unsigned)(time(NULL) ^ getpid()));
+        arm_sample_timer_jittered(d);
     }
 
     /* Create signal fd */

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -385,7 +385,15 @@ int pgwt_daemon_init(struct pgwt_daemon *d)
          *           populated PlannedStmt.queryId. Same arg0 (QueryDesc*). */
         if (d->use_pg13_query_attr) {
             uint64_t es_va = pgwt_find_symbol_offset(bin, "standard_ExecutorStart");
-            uint64_t es_off = es_va > 0x400000 ? es_va - 0x400000 : es_va;
+            /* vaddr -> uprobe FILE offset via the ELF program headers. The
+             * old `va - 0x400000` non-PIE heuristic attached the probe to a
+             * dead byte on PIE builds — attach "succeeded", the probe never
+             * fired, query attribution was silently zero (study defect 1). */
+            uint64_t es_off = pgwt_vaddr_to_file_offset(bin, es_va);
+            if (es_va && !es_off)
+                fprintf(stderr, "WARN: cannot translate standard_ExecutorStart "
+                        "VA 0x%lx to a file offset in %s (PG13 query "
+                        "attribution disabled)\n", (unsigned long)es_va, bin);
             if (es_off) {
                 LIBBPF_OPTS(bpf_uprobe_opts, uprobe_opts, .retprobe = false);
                 d->skel->links.on_executor_start =
@@ -404,7 +412,11 @@ int pgwt_daemon_init(struct pgwt_daemon *d)
             }
         } else {
             uint64_t qid_func_va = pgwt_find_symbol_offset(bin, "pgstat_report_query_id");
-            uint64_t qid_func_off = qid_func_va > 0x400000 ? qid_func_va - 0x400000 : qid_func_va;
+            uint64_t qid_func_off = pgwt_vaddr_to_file_offset(bin, qid_func_va);
+            if (qid_func_va && !qid_func_off)
+                fprintf(stderr, "WARN: cannot translate pgstat_report_query_id "
+                        "VA 0x%lx to a file offset in %s (query attribution "
+                        "disabled)\n", (unsigned long)qid_func_va, bin);
             if (qid_func_off) {
                 LIBBPF_OPTS(bpf_uprobe_opts, uprobe_opts, .retprobe = false);
                 d->skel->links.on_report_query_id =

--- a/src/daemon.h
+++ b/src/daemon.h
@@ -45,6 +45,14 @@ struct pgwt_counters {
     uint64_t state_map_full_total;     /* userspace state_map inserts failed (map full, CAP-1) */
     uint64_t invalid_wait_reads_total; /* wait_event_info reads with a garbage class byte (CAP-2/5) */
     uint64_t sampler_ticks_missed_total; /* sampler timer expirations coalesced/missed (SMP-3) */
+
+    /* T2 decomposed-AAS observability (docs/AAS_SEMANTICS_DECISION.md). */
+    uint64_t noncmd_cpu_samples_total; /* client we==0 readings outside a command (not recorded) */
+    uint64_t io_worker_samples_total;  /* io_worker readings taken (excluded from AAS) */
+    uint64_t io_worker_busy_total;     /* ... of which busy (on-CPU or a real wait) */
+    uint64_t prev_io_worker_samples;   /* snapshots at previous display tick */
+    uint64_t prev_io_worker_busy;
+    double   io_worker_busy_pct;       /* busy% over the last display interval */
 };
 
 /* View modes */
@@ -151,6 +159,11 @@ struct pgwt_daemon {
     int         anomaly_cooldown_s;      /* --anomaly-cooldown-s (<0 = default) */
     int         anomaly_window_s;        /* --anomaly-window-s: per-trigger
                                           * escalation duration (<=0 = default) */
+    /* T2: the pgstat_report_activity uprobe attached and the BackendState
+     * layout is known — the command-open gate is live. When false, we==0
+     * classification falls back to the pre-T2 behavior (all exact CPU counts
+     * as CPU) instead of silently mislabeling everything idle. */
+    bool        cmd_gate_active;
     uint32_t    lightweight_mode;        /* 1 = BPF accumulator only (no ringbuf) */
     uint32_t    skip_query_id;          /* 1 = skip query_id reads in BPF */
     uint32_t    skip_usdt;             /* 1 = skip USDT query lifecycle probes */

--- a/src/discovery.c
+++ b/src/discovery.c
@@ -138,6 +138,57 @@ static uint64_t elf_base_vaddr(const char *binary)
     return (base == UINT64_MAX) ? 0 : base;
 }
 
+/* Translate an ELF virtual address (e.g. a symbol's st_value) to the FILE
+ * offset a uprobe attach needs, via the program headers: find the PT_LOAD
+ * segment containing the vaddr and return vaddr - p_vaddr + p_offset.
+ * Correct for both ET_EXEC (non-PIE, where p_vaddr embeds the fixed image
+ * base) and ET_DYN (PIE, where p_vaddr is already file-relative but text
+ * segments still have p_vaddr != p_offset under separate-code layouts).
+ *
+ * This replaces the old `va - 0x400000` heuristic (daemon.c), which silently
+ * attached uprobes to a dead byte on PIE builds (PGDG Ubuntu/EL9: the probe
+ * NEVER fired — run_cnt 0 — while attach "succeeded"; T2 study defect 1).
+ * Returns 0 if no PT_LOAD contains the vaddr (0 is never a valid probe
+ * offset — it is the ELF header). */
+uint64_t pgwt_vaddr_to_file_offset(const char *binary, uint64_t vaddr)
+{
+    if (vaddr == 0)
+        return 0;
+    if (elf_version(EV_CURRENT) == EV_NONE)
+        return 0;
+
+    int fd = open(binary, O_RDONLY);
+    if (fd < 0)
+        return 0;
+
+    Elf *elf = elf_begin(fd, ELF_C_READ, NULL);
+    if (!elf) {
+        close(fd);
+        return 0;
+    }
+
+    uint64_t off = 0;
+    size_t phnum = 0;
+    elf_getphdrnum(elf, &phnum);
+    for (size_t i = 0; i < phnum; i++) {
+        GElf_Phdr phdr;
+        if (gelf_getphdr(elf, i, &phdr) == NULL)
+            continue;
+        if (phdr.p_type != PT_LOAD)
+            continue;
+        /* p_filesz (not p_memsz): a vaddr in a segment's .bss tail has no
+         * file bytes and cannot host a probe. */
+        if (vaddr >= phdr.p_vaddr && vaddr < phdr.p_vaddr + phdr.p_filesz) {
+            off = vaddr - phdr.p_vaddr + phdr.p_offset;
+            break;
+        }
+    }
+
+    elf_end(elf);
+    close(fd);
+    return off;
+}
+
 uint64_t pgwt_resolve_symbol(const char *binary, const char *symbol,
                              pid_t pid)
 {

--- a/src/discovery.h
+++ b/src/discovery.h
@@ -36,6 +36,14 @@ uint64_t pgwt_find_load_base_in_maps(const char *maps_path,
 uint64_t pgwt_resolve_symbol(const char *binary, const char *symbol,
                              pid_t pid);
 
+/* Translate an ELF virtual address (a symbol's st_value) to the FILE offset
+ * a uprobe attach needs, via the PT_LOAD program header containing it:
+ * offset = vaddr - p_vaddr + p_offset. Correct for ET_EXEC and ET_DYN alike.
+ * Replaces the non-PIE `va - 0x400000` heuristic that silently attached
+ * uprobes to dead bytes on PIE builds (T2 study defect 1 / PR #24 class).
+ * Returns 0 if no PT_LOAD's file-backed range contains the vaddr. */
+uint64_t pgwt_vaddr_to_file_offset(const char *binary, uint64_t vaddr);
+
 /* Is addr inside a MAP_SHARED mapping of pid? 1 = shared, 0 = private or
  * not mapped, -1 = maps unreadable. The sampler may only BATCH-read
  * addresses that are shared (SMP-2): a process-local address mapped at the

--- a/src/escalation.c
+++ b/src/escalation.c
@@ -157,10 +157,18 @@ static void detach_all(struct pgwt_daemon *d)
             uint32_t key = (uint32_t)be->pid;
             struct pgwt_pid_state st;
             uint64_t qid = 0;
-            if (bpf_map_lookup_elem(state_fd, &key, &st) == 0)
+            uint16_t cmd_open = 0;
+            if (bpf_map_lookup_elem(state_fd, &key, &st) == 0) {
                 qid = st.last_query_id;   /* preserve the join key */
+                cmd_open = st.cmd_open;   /* preserve the command gate */
+            }
+            /* wp_live = 0: the entry is a query-id/cmd-gate seed again —
+             * on_exit must NOT close an interval from it (defect 2), and
+             * the next escalation's preseed re-arms it. */
             struct pgwt_pid_state seed = {
                 .last_event = 0,
+                .wp_live = 0,
+                .cmd_open = cmd_open,
                 .last_ts = now,
                 .last_query_id = qid,
                 .wait_event_addr = be->wp_addr,

--- a/src/event_stream.c
+++ b/src/event_stream.c
@@ -10,6 +10,7 @@
 #include "query_text.h"
 #include "map_reader.h"
 #include "wait_event.h"
+#include "sampler.h"   /* pgwt_backend_type_flag (T2 category mapping) */
 
 #include <string.h>
 #include <time.h>
@@ -49,6 +50,29 @@ int pgwt_handle_trace_event(void *ctx, void *data, size_t data_sz)
 
     /* Per-PID accumulation */
     struct pgwt_pid_accum *pa = pgwt_get_or_create_pid(acc, evt->pid);
+
+    /* T2 live classification (decomposed AAS, docs/AAS_SEMANTICS_DECISION.md).
+     * Resolve the pid's category ONCE against the registry and cache it in
+     * the accumulator (the hot path must not linear-scan 1024 entries per
+     * event). io_worker time never enters DB Time/AAS; a client backend's
+     * we==0 interval outside a command (BPF stamps the gate in flags) is
+     * post/between-command time — idle, not CPU. Both stay VISIBLE in the
+     * per-event stats; only the load accounting differs. */
+    int io_worker = 0;
+    int noncmd_cpu = 0;
+    if (pa) {
+        if (pa->cat_flag_plus1 == 0) {
+            struct pgwt_backend *be = pgwt_find_backend(&d->backends, evt->pid);
+            uint32_t f = (be && be->meta_parsed)
+                       ? pgwt_backend_type_flag(be->meta.backend_type) : 0;
+            pa->cat_flag_plus1 = f + 1;
+        }
+        uint32_t cat = pa->cat_flag_plus1 - 1;
+        io_worker = (cat == PGWT_EVENT_FLAG_IO_WORKER);
+        noncmd_cpu = (we == 0 && cat == 0 && d->cmd_gate_active
+                      && !(evt->flags & PGWT_EVENT_FLAG_CMD_OPEN));
+    }
+
     if (pa) {
         struct pgwt_event_stats *es = pgwt_get_or_create_event(pa, we);
         if (es) {
@@ -61,13 +85,15 @@ int pgwt_handle_trace_event(void *ctx, void *data, size_t data_sz)
                 es->histogram[bucket]++;
         }
 
-        if (we == 0) {
-            pa->cpu_time_ns += dur;
-        } else if (!pgwt_is_idle_event(we)) {
-            pa->wait_time_ns += dur;
+        if (!io_worker && !noncmd_cpu) {
+            if (we == 0) {
+                pa->cpu_time_ns += dur;
+            } else if (!pgwt_is_idle_event(we)) {
+                pa->wait_time_ns += dur;
+            }
+            if (we == 0 || !pgwt_is_idle_event(we))
+                pa->db_time_ns += dur;
         }
-        if (!pgwt_is_idle_event(we))
-            pa->db_time_ns += dur;
     }
 
     /* System-wide accumulation */
@@ -82,11 +108,15 @@ int pgwt_handle_trace_event(void *ctx, void *data, size_t data_sz)
             se->histogram[bucket]++;
     }
 
-    /* Time model by class */
-    pgwt_update_time_model(&acc->tm, we, dur);
+    /* Time model by class. io_worker time is excluded from DB Time; a
+     * non-command CPU interval lands in the idle (Activity) bucket. */
+    if (!io_worker)
+        pgwt_update_time_model(&acc->tm,
+                               noncmd_cpu ? WEI(PG_WAIT_ACTIVITY, 0) : we,
+                               dur);
 
     /* Query events */
-    if (evt->query_id != 0) {
+    if (evt->query_id != 0 && !io_worker) {
         struct pgwt_query_event_stats *qe =
             pgwt_get_or_create_query_event(acc, evt->query_id, we);
         if (qe) {

--- a/src/event_writer.h
+++ b/src/event_writer.h
@@ -29,7 +29,17 @@
  *                 This is what the A2 sampler writes. Each sample means
  *                 "at timestamp T, pid P was in event E"; A3 treats it as
  *                 a point observation worth `sample_period_ns`, never an
- *                 interval. */
+ *                 interval.
+ *
+ *                 Event id 0 (T2): a first-class CPU sample — "at T, pid P
+ *                 was on-CPU doing requested work". The capture side gates
+ *                 which we==0 readings are recorded (client backends only
+ *                 inside a command; background types always; see
+ *                 docs/AAS_SEMANTICS_DECISION.md), so consumers treat id 0
+ *                 exactly like any active sample. Pre-T2 writers never
+ *                 emitted id 0, so old traces read back unchanged; old
+ *                 readers decode id 0 as the CPU pseudo-event they already
+ *                 knew from transitions. No layout change. */
 enum pgwt_block_type {
     PGWT_BLOCK_TRANSITIONS = 0,
     PGWT_BLOCK_SAMPLES     = 1,

--- a/src/map_reader.c
+++ b/src/map_reader.c
@@ -170,6 +170,16 @@ void pgwt_read_state_map(struct pgwt_daemon *d)
 
     while (bpf_map_get_next_key(state_fd, &skey, &snext) == 0) {
         if (bpf_map_lookup_elem(state_fd, &snext, &sval) == 0) {
+            /* T2: entries without a live watchpoint are query-id/cmd-gate
+             * seeds — their last_event/last_ts are NOT interval state.
+             * Counting them fabricated an ever-growing open "CPU" interval
+             * per seeded backend (the live-view sibling of study defect 2).
+             * Only reached in tiered mode during escalation, where every
+             * ATTACHED backend has wp_live = 1 from the preseed. */
+            if (!sval.wp_live) {
+                skey = snext;
+                continue;
+            }
             uint64_t open_ns = now - sval.last_ts;
             uint32_t we = sval.last_event;
 

--- a/src/map_reader.h
+++ b/src/map_reader.h
@@ -21,6 +21,11 @@ struct pgwt_event_stats {
 struct pgwt_pid_accum {
     uint32_t pid;
     bool     active;          /* has data */
+    /* T2: cached process category for live accumulation (0 = not yet
+     * resolved against the registry; else 1 + a PGWT_EVENT_FLAG_* category
+     * bit or 1 + 0 for foreground). Lets the hot event path skip the linear
+     * registry scan after the first event of a pid. */
+    uint32_t cat_flag_plus1;
     int      num_events;
     uint64_t db_time_ns;      /* total non-idle time */
     uint64_t cpu_time_ns;     /* event=0 time */

--- a/src/pg_wait_tracer.h
+++ b/src/pg_wait_tracer.h
@@ -32,7 +32,21 @@ typedef uint64_t u64;
 /* Per-PID state in state_map */
 struct pgwt_pid_state {
     u32 last_event;     /* previous wait_event_info value (0 = on CPU) */
-    u32 _pad;           /* alignment */
+    /* wp_live: 1 while a LIVE hardware watchpoint maintains last_event /
+     * last_ts for this pid (full mode, or tiered while escalated). 0 for
+     * sampled-tier seeds, whose entries only carry query_id/cmd_open — their
+     * last_event/last_ts are NOT interval state. on_exit must only close an
+     * interval when wp_live is set: closing a seed entry fabricated a
+     * phantom full-window "CPU" interval per disconnect (T2 study defect 2:
+     * 4 clients x 120 s of phantom CPU in a trace whose sampler saw 0.017
+     * AAS). */
+    u16 wp_live;
+    /* cmd_open: 1 while a client backend is inside a command — the same
+     * window as pg_stat_activity state='active' (query message received ->
+     * command complete, incl. parse/plan/execute/commit). Maintained by the
+     * on_report_activity uprobe; read by the sampler to gate on-CPU (we==0)
+     * samples for client backends (docs/AAS_SEMANTICS_DECISION.md). */
+    u16 cmd_open;
     u64 last_ts;        /* ktime_ns of last transition */
     u64 last_query_id;  /* query_id set by on_report_query_id uprobe */
     u64 be_entry_ptr;   /* cached PgBackendStatus* (avoids 1 probe_read per event) */
@@ -67,12 +81,27 @@ struct pgwt_trace_event {
     u64 query_id;       /* active query during old_event */
 };
 
-/* flags bits — set by the trace reader, never on the wire/ringbuf.
- * SAMPLE marks a record decoded from a SAMPLES block: it is a point
- * observation (new_event = sampled event; old_event = 0; duration_ns = 0),
- * not a transition interval. A3's compute must treat it as worth one
- * sample_period_ns, not as an interval duration. */
-#define PGWT_EVENT_FLAG_SAMPLE  0x1U
+/* flags bits — NEVER persisted to the trace file (neither block layout
+ * encodes a flags column). Two producers annotate in memory:
+ *
+ *   - the trace reader sets SAMPLE on records decoded from a SAMPLES block:
+ *     a point observation (new_event = sampled event; old_event = 0;
+ *     duration_ns = 0), worth one sample_period_ns, never an interval;
+ *   - BPF/on_watchpoint sets CMD_OPEN on ringbuf transition events emitted
+ *     while the backend's command-open gate was set, so the LIVE accumulator
+ *     can classify we==0 intervals without a marker sweep (the offline
+ *     paths reconstruct the same gate from CMD_START/CMD_END markers);
+ *   - the sampler/server annotate CATEGORY bits (process-type driven) so
+ *     accumulation and the anomaly engine can apply the decomposed AAS
+ *     model (docs/AAS_SEMANTICS_DECISION.md) without a registry lookup per
+ *     consumer. */
+#define PGWT_EVENT_FLAG_SAMPLE     0x1U
+#define PGWT_EVENT_FLAG_CMD_OPEN   0x2U   /* command open at emission */
+#define PGWT_EVENT_FLAG_IO_WORKER  0x4U   /* pid is an io_worker (excluded from AAS/DB Time) */
+#define PGWT_EVENT_FLAG_MAINT      0x8U   /* pid is an autovacuum worker */
+#define PGWT_EVENT_FLAG_BACKGROUND 0x10U  /* pid is another aux process */
+#define PGWT_EVENT_FLAG_PLAN       0x20U  /* inside a PLAN marker window */
+#define PGWT_EVENT_FLAG_EXEC       0x40U  /* inside an EXEC marker window */
 
 #define PGWT_EVENT_EXIT  0xFFFFFFFFU  /* sentinel new_event for process exit */
 
@@ -98,7 +127,19 @@ struct pgwt_trace_event {
 #define PGWT_MARKER_ESCALATE_START 0xFFFFFFF4U  /* full-fidelity window opened */
 #define PGWT_MARKER_ESCALATE_END   0xFFFFFFF5U  /* full-fidelity window closed */
 
-#define PGWT_IS_MARKER(e) ((e) >= 0xFFFFFFF0U && (e) <= 0xFFFFFFF5U)
+/* Command-boundary markers (T2). Emitted by the on_report_activity uprobe
+ * (pgstat_report_activity state transitions) while a watchpoint is live for
+ * the pid, so the exact tier records the same command-open window the
+ * sampled tier gates on (pg_stat_activity state='active' semantics). The
+ * compute layer uses them to classify we==0 (on-CPU) intervals: in-command
+ * portions are CPU (foreground), the remainder is idle post-command time —
+ * keeping AAS continuous across tier switches. Same shape as the query
+ * markers: old_event = new_event = marker, duration_ns = 0, query_id = the
+ * pid's current query_id at the boundary. */
+#define PGWT_MARKER_CMD_START      0xFFFFFFF6U  /* command opened (state -> active) */
+#define PGWT_MARKER_CMD_END        0xFFFFFFF7U  /* command closed (state -> idle/idle-in-txn) */
+
+#define PGWT_IS_MARKER(e) ((e) >= 0xFFFFFFF0U && (e) <= 0xFFFFFFF7U)
 
 /* Pack/unpack the escalation marker payload carried in query_id. */
 #define PGWT_ESC_PACK(secs, reason) \

--- a/src/pg_wait_tracer.h
+++ b/src/pg_wait_tracer.h
@@ -188,6 +188,14 @@ struct pgwt_query_text_event {
 /* Client:ClientRead — idle between queries (like Oracle's SQL*Net message from client) */
 #define PG_WAIT_CLIENT_READ  ((PG_WAIT_CLIENT << 24) | 0x000000)
 
+/* Synthetic id for we==0 (on-CPU) exact intervals classified OUTSIDE a
+ * command window (T2 decomposed AAS): post/between-command time is idle per
+ * docs/AAS_SEMANTICS_DECISION.md. Activity class => excluded from load
+ * (pgwt_is_idle_event) and hidden from event lists (pgwt_is_hidden_event)
+ * exactly like other instrumented idle states. NEVER written to a trace —
+ * assigned by the compute-side tagging pass (pgwt_tag_events) only. */
+#define PGWT_WEI_NONCMD_CPU  (((uint32_t)PG_WAIT_ACTIVITY << 24) | 0x00FFFFFFU)
+
 /* ── wait_event_info reading classification (CAP-2/3/5) ─────────
  * A reading from a resolved wait_event_info address falls in one of three
  * classes. Only a NON-ZERO reading with a known class byte PROVES the

--- a/src/sampler.c
+++ b/src/sampler.c
@@ -124,24 +124,74 @@ int pgwt_sampler_read_targets(const struct pgwt_sample_target *targets, int n,
     return got;
 }
 
+/* T2 category flag for a backend type (docs/AAS_SEMANTICS_DECISION.md).
+ * Foreground (client, parallel worker) carries no flag; autovacuum workers
+ * are maintenance; io_workers are their own excluded-from-AAS class; every
+ * other aux process is background. UNKNOWN is treated as foreground/client
+ * (conservative: its CPU stays command-gated, its waits count as before). */
+uint32_t pgwt_backend_type_flag(enum pgwt_backend_type bt)
+{
+    switch (bt) {
+    case PGWT_BT_CLIENT:
+    case PGWT_BT_PARALLEL_WORKER:
+    case PGWT_BT_UNKNOWN:
+        return 0;                              /* foreground */
+    case PGWT_BT_AUTOVAC_WORKER:
+        return PGWT_EVENT_FLAG_MAINT;          /* maintenance */
+    case PGWT_BT_IO_WORKER:
+        return PGWT_EVENT_FLAG_IO_WORKER;      /* excluded from AAS/DB Time */
+    default:
+        return PGWT_EVENT_FLAG_BACKGROUND;     /* checkpointer, bgwriter, … */
+    }
+}
+
+/* T2 on-CPU (we==0) recording policy. Client backends (and UNKNOWN, which
+ * cannot prove otherwise) record CPU only inside a command — the
+ * pg_stat_activity state='active' window — because ungated we==0 counting
+ * measured ~3x true activity on chatty OLTP (between-command bookkeeping
+ * scales with transaction rate, not with work). Background types' parked
+ * states are instrumented Activity-class waits, so we==0 always means
+ * working; parallel workers exist only inside a query. */
+int pgwt_cpu_sample_recordable(enum pgwt_backend_type bt, int cmd_open)
+{
+    switch (bt) {
+    case PGWT_BT_CLIENT:
+    case PGWT_BT_UNKNOWN:
+        return cmd_open ? 1 : 0;
+    case PGWT_BT_LOGGER:
+        return 0;   /* not a PG-work process; never sampled as active */
+    default:
+        return 1;   /* background, maintenance, parallel worker, io_worker */
+    }
+}
+
 int pgwt_sampler_build_batch(const struct pgwt_sample_target *targets,
                              const uint32_t *vals, int n, uint64_t tick_ts,
                              struct pgwt_trace_event *out,
-                             uint64_t *invalid_reads)
+                             uint64_t *invalid_reads,
+                             uint64_t *noncmd_cpu_skipped)
 {
     int count = 0;
     for (int i = 0; i < n; i++) {
         uint32_t we = vals[i];
-        /* event 0 == on CPU: not a wait, no sample to record (ASH counts
-         * the active session via its non-idle waits and CPU separately;
-         * A3 derives CPU from coverage, not from on-CPU samples). */
-        if (we == 0)
-            continue;
 
-        /* CAP-2/5 backstop (all PG versions, every tick): a value with an
-         * unknown class byte is garbage from a wrong offset/address — it
-         * must NEVER be recorded as data. Count it so the daemon screams. */
-        if (pgwt_classify_wei(we) == PGWT_WEI_GARBAGE) {
+        /* event 0 == on CPU. T2 (AAS-1): a session on CPU IS an active
+         * session — record it as a first-class CPU sample, gated by the
+         * per-type policy above. (The old sampler skipped all we==0 and no
+         * coverage-derived CPU existed anywhere: a pure CPU storm produced
+         * AAS ~ 0 and the anomaly engine was blind to it.) */
+        if (we == 0) {
+            if (!pgwt_cpu_sample_recordable(targets[i].backend_type,
+                                            targets[i].cmd_open)) {
+                if (noncmd_cpu_skipped)
+                    (*noncmd_cpu_skipped)++;
+                continue;
+            }
+        } else if (pgwt_classify_wei(we) == PGWT_WEI_GARBAGE) {
+            /* CAP-2/5 backstop (all PG versions, every tick): a value with
+             * an unknown class byte is garbage from a wrong offset/address —
+             * it must NEVER be recorded as data. Count it so the daemon
+             * screams. */
             if (invalid_reads)
                 (*invalid_reads)++;
             continue;
@@ -151,8 +201,11 @@ int pgwt_sampler_build_batch(const struct pgwt_sample_target *targets,
         e->timestamp_ns = tick_ts;
         e->pid          = (uint32_t)targets[i].pid;
         e->old_event    = 0;       /* samples carry no previous state */
-        e->new_event    = we;      /* the sampled wait event */
-        e->flags        = 0;       /* SAMPLE flag is set by the reader */
+        e->new_event    = we;      /* the sampled wait event (0 = CPU) */
+        /* In-memory category tag (never persisted — the SAMPLES layout has
+         * no flags column; offline consumers re-derive the category from
+         * backends.jsonl). The SAMPLE flag itself is set by the reader. */
+        e->flags        = pgwt_backend_type_flag(targets[i].backend_type);
         e->duration_ns  = 0;       /* samples carry no duration */
         e->query_id     = targets[i].query_id;
     }
@@ -218,20 +271,27 @@ void pgwt_qid_index_sort(struct pgwt_qid_entry *entries, int n)
     qsort(entries, (size_t)n, sizeof(*entries), qid_entry_cmp);
 }
 
-uint64_t pgwt_qid_index_lookup(const struct pgwt_qid_entry *entries, int n,
-                               uint32_t pid)
+const struct pgwt_qid_entry *
+pgwt_qid_index_get(const struct pgwt_qid_entry *entries, int n, uint32_t pid)
 {
     int lo = 0, hi = n - 1;
     while (lo <= hi) {
         int mid = lo + (hi - lo) / 2;
         if (entries[mid].pid == pid)
-            return entries[mid].query_id;
+            return &entries[mid];
         if (entries[mid].pid < pid)
             lo = mid + 1;
         else
             hi = mid - 1;
     }
-    return 0;
+    return NULL;
+}
+
+uint64_t pgwt_qid_index_lookup(const struct pgwt_qid_entry *entries, int n,
+                               uint32_t pid)
+{
+    const struct pgwt_qid_entry *e = pgwt_qid_index_get(entries, n, pid);
+    return e ? e->query_id : 0;
 }
 
 /* ── Daemon-side provider hooks (need the BPF skeleton) ───────────────── */
@@ -257,21 +317,25 @@ static uint64_t mono_ns(void)
     return (uint64_t)ts.tv_sec * 1000000000ULL + ts.tv_nsec;
 }
 
-/* Read pid -> query_id from the BPF state_map, maintained by the
- * on_report_query_id uprobe. Returns 0 if unknown. Per-pid fallback for
+/* Read pid -> {query_id, cmd_open} from the BPF state_map, maintained by
+ * the on_report_query_id / on_report_activity uprobes. Per-pid fallback for
  * kernels without BPF_MAP_LOOKUP_BATCH (SMP-4). */
-static uint64_t lookup_query_id(struct pgwt_daemon *d, pid_t pid)
+static void lookup_pid_state(struct pgwt_daemon *d, pid_t pid,
+                             uint64_t *qid, int *cmd_open)
 {
+    *qid = 0;
+    *cmd_open = 0;
     if (!d->skel)
-        return 0;
+        return;
     int fd = bpf_map__fd(d->skel->maps.state_map);
     if (fd < 0)
-        return 0;
+        return;
     uint32_t key = (uint32_t)pid;
     struct pgwt_pid_state st;
-    if (bpf_map_lookup_elem(fd, &key, &st) == 0)
-        return st.last_query_id;
-    return 0;
+    if (bpf_map_lookup_elem(fd, &key, &st) == 0) {
+        *qid = st.last_query_id;
+        *cmd_open = st.cmd_open;
+    }
 }
 
 /* SMP-4: dump the whole state_map in (at most) a few BPF_MAP_LOOKUP_BATCH
@@ -321,6 +385,7 @@ static int dump_qid_index(struct pgwt_daemon *d, struct pgwt_sampler *s,
     for (int i = 0; i < total; i++) {
         out[i].pid = s->qid_keys[i];
         out[i].query_id = s->qid_vals[i].last_query_id;
+        out[i].cmd_open = s->qid_vals[i].cmd_open;
     }
     pgwt_qid_index_sort(out, total);
     return total;
@@ -443,8 +508,9 @@ static void pgwt_sampler_accumulate(struct pgwt_daemon *d,
         return;
 
     for (int i = 0; i < count; i++) {
-        uint32_t we  = samples[i].new_event;   /* sampled wait event */
+        uint32_t we  = samples[i].new_event;   /* sampled wait event (0 = CPU) */
         uint64_t dur = period_ns;              /* ASH weight per sample */
+        int io_worker = (samples[i].flags & PGWT_EVENT_FLAG_IO_WORKER) != 0;
 
         if (PGWT_IS_MARKER(we))
             continue;
@@ -462,9 +528,16 @@ static void pgwt_sampler_accumulate(struct pgwt_daemon *d,
                 if (bucket < HISTOGRAM_BUCKETS)
                     es->histogram[bucket]++;
             }
-            if (!pgwt_is_idle_event(we)) {
-                pa->wait_time_ns += dur;
-                pa->db_time_ns   += dur;
+            /* io_worker time never enters DB Time / AAS (T2): the event
+             * stats above keep it VISIBLE, the load accounting skips it. */
+            if (!io_worker) {
+                if (we == 0) {
+                    pa->cpu_time_ns += dur;   /* first-class CPU sample */
+                    pa->db_time_ns  += dur;
+                } else if (!pgwt_is_idle_event(we)) {
+                    pa->wait_time_ns += dur;
+                    pa->db_time_ns   += dur;
+                }
             }
         }
 
@@ -480,11 +553,12 @@ static void pgwt_sampler_accumulate(struct pgwt_daemon *d,
                 se->histogram[bucket]++;
         }
 
-        /* Time model by class */
-        pgwt_update_time_model(&acc->tm, we, dur);
+        /* Time model by class (io_worker time excluded from DB Time) */
+        if (!io_worker)
+            pgwt_update_time_model(&acc->tm, we, dur);
 
-        /* Query attribution */
-        if (samples[i].query_id != 0) {
+        /* Query attribution (io_workers are structurally query-less) */
+        if (samples[i].query_id != 0 && !io_worker) {
             struct pgwt_query_event_stats *qe =
                 pgwt_get_or_create_query_event(acc, samples[i].query_id, we);
             if (qe) {
@@ -498,8 +572,9 @@ static void pgwt_sampler_accumulate(struct pgwt_daemon *d,
 }
 
 /* One sampling tick. Build the target list from the live registry, read all
- * wait_event_info (shared-memory batch + per-pid fallbacks), encode non-CPU
- * readings, and push a SAMPLES block. Called from the daemon timer. */
+ * wait_event_info (shared-memory batch + per-pid fallbacks), encode wait
+ * readings AND policy-gated on-CPU readings (T2: we==0 is a first-class CPU
+ * sample), and push a SAMPLES block. Called from the daemon timer. */
 int pgwt_sampler_poll(struct pgwt_daemon *d)
 {
     struct pgwt_sampler *s = d->sampler;
@@ -558,6 +633,18 @@ int pgwt_sampler_poll(struct pgwt_daemon *d)
                 seed_state_entry(d, be->pid, be->wp_addr);
             }
         }
+        /* T2: classify the process ONCE it is far enough through init to
+         * have set its title (wp_addr resolved implies init done). The
+         * sampled-tier fork path never parsed cmdline at all, so every
+         * forked backend read as type 0 == client — io_workers, autovacuum
+         * and parallel workers were unclassifiable. */
+        if (!be->meta_parsed) {
+            if (pgwt_parse_cmdline(be->pid, &be->meta) == 0) {
+                be->meta_parsed = true;
+                if (d->backend_meta)
+                    pgwt_bm_write(d->backend_meta, be->pid, &be->meta);
+            }
+        }
         /* SMP-2: classify the address — only verified-shared addresses may
          * be batched through a foreign pid. */
         if (be->wp_addr_shared < 0)
@@ -566,9 +653,20 @@ int pgwt_sampler_poll(struct pgwt_daemon *d)
         targets[n].pid             = be->pid;
         targets[n].wait_event_addr = be->wp_addr;
         targets[n].is_shared       = be->wp_addr_shared;
-        targets[n].query_id        = (qidx_n >= 0)
-            ? pgwt_qid_index_lookup(qidx_buf, qidx_n, (uint32_t)be->pid)
-            : lookup_query_id(d, be->pid);
+        targets[n].backend_type    = be->meta_parsed ? be->meta.backend_type
+                                                     : PGWT_BT_UNKNOWN;
+        if (qidx_n >= 0) {
+            const struct pgwt_qid_entry *qe =
+                pgwt_qid_index_get(qidx_buf, qidx_n, (uint32_t)be->pid);
+            targets[n].query_id = qe ? qe->query_id : 0;
+            targets[n].cmd_open = qe ? qe->cmd_open : 0;
+        } else {
+            uint64_t qid = 0;
+            int cmd_open = 0;
+            lookup_pid_state(d, be->pid, &qid, &cmd_open);
+            targets[n].query_id = qid;
+            targets[n].cmd_open = cmd_open;
+        }
         n++;
     }
     if (n == 0)
@@ -604,10 +702,26 @@ int pgwt_sampler_poll(struct pgwt_daemon *d)
         break;
     }
 
+    /* io_worker utilization (T2): io_workers are EXCLUDED from AAS/DB Time
+     * (their busy time is a shadow copy of the requesting backends'
+     * AioIoCompletion waits — docs/AAS_SEMANTICS_DECISION.md) but their
+     * busy fraction is a genuine capacity signal. busy = any reading that
+     * is not an instrumented idle wait (IoWorkerMain) — i.e. on-CPU or a
+     * real wait like IO:DataFileRead. */
+    for (int i = 0; i < n; i++) {
+        if (targets[i].backend_type != PGWT_BT_IO_WORKER)
+            continue;
+        d->counters.io_worker_samples_total++;
+        uint32_t we = s->read_vals[i];
+        if (we == 0 || !pgwt_is_idle_event(we))
+            d->counters.io_worker_busy_total++;
+    }
+
     uint64_t invalid_before = d->counters.invalid_wait_reads_total;
     int count = pgwt_sampler_build_batch(targets, s->read_vals, n, tick_ts,
                                          s->samples,
-                                         &d->counters.invalid_wait_reads_total);
+                                         &d->counters.invalid_wait_reads_total,
+                                         &d->counters.noncmd_cpu_samples_total);
     if (d->counters.invalid_wait_reads_total != invalid_before
         && !d->invalid_wait_reads_logged) {
         d->invalid_wait_reads_logged = true;

--- a/src/sampler.h
+++ b/src/sampler.h
@@ -33,6 +33,7 @@
 #define PGWT_SAMPLER_H
 
 #include "pg_wait_tracer.h"
+#include "cmdline.h"   /* enum pgwt_backend_type — drives the we==0 policy */
 
 #include <stdint.h>
 #include <sys/types.h>
@@ -51,6 +52,13 @@ struct pgwt_sample_target {
     int      is_shared;       /* 1 = addr verified in a MAP_SHARED mapping
                                * (batchable); anything else = per-pid read
                                * only (SMP-2) */
+    /* T2 (docs/AAS_SEMANTICS_DECISION.md): the decomposed-AAS inputs.
+     * backend_type decides the on-CPU (we==0) policy and the category flag
+     * stamped on the sample; cmd_open is the pg_stat_activity
+     * state='active' gate (BPF on_report_activity uprobe) that decides
+     * whether a CLIENT backend's we==0 reading is a CPU sample. */
+    enum pgwt_backend_type backend_type;
+    int      cmd_open;
 };
 
 /* Sampler read-health tracking (SMP-1). Pure state machine (unit-testable):
@@ -116,16 +124,40 @@ void pgwt_sampler_metrics(struct pgwt_daemon *d, struct pgwt_metrics *m);
 int pgwt_sampler_read_targets(const struct pgwt_sample_target *targets, int n,
                               uint32_t *out_vals, uint64_t *read_faults);
 
-/* Build the SAMPLES batch from targets + their freshly-read values. A target
- * whose value is on-CPU (event 0) is skipped (no wait to record). A value
- * with an INVALID class byte (CAP-2/5: garbage from a wrong offset) is
- * skipped too and counted in *invalid_reads (may be NULL) — garbage must
+/* Build the SAMPLES batch from targets + their freshly-read values.
+ *
+ * On-CPU (we==0) policy — the T2 decision (docs/AAS_SEMANTICS_DECISION.md):
+ *   - CLIENT (and UNKNOWN/unclassified) backends: recorded as a first-class
+ *     CPU sample (event id 0) ONLY while the command-open gate is set —
+ *     the pg_stat_activity state='active' window. A we==0 reading with the
+ *     gate closed is between-command churn: NOT recorded as activity, but
+ *     counted in *noncmd_cpu_skipped (may be NULL) for observability.
+ *   - background process types (checkpointer, bgwriter, walwriter,
+ *     autovacuum workers, parallel workers, io_workers, ...): we==0 always
+ *     records as CPU — their parked states are instrumented Activity-class
+ *     waits, so on-CPU unambiguously means working.
+ *
+ * Every record is stamped with an in-memory category flag from the target's
+ * backend_type (FLAG_IO_WORKER / FLAG_MAINT / FLAG_BACKGROUND; client and
+ * parallel workers are the unflagged foreground). Flags are never persisted
+ * — the anomaly engine and the live accumulator consume them (io_worker
+ * records must not enter AAS/DB Time).
+ *
+ * A value with an INVALID class byte (CAP-2/5: garbage from a wrong offset)
+ * is skipped and counted in *invalid_reads (may be NULL) — garbage must
  * never be recorded as data. `tick_ts` is the sample timestamp stamped on
  * every record. Returns the number of sample records written into out. */
 int pgwt_sampler_build_batch(const struct pgwt_sample_target *targets,
                              const uint32_t *vals, int n, uint64_t tick_ts,
                              struct pgwt_trace_event *out,
-                             uint64_t *invalid_reads);
+                             uint64_t *invalid_reads,
+                             uint64_t *noncmd_cpu_skipped);
+
+/* T2: category flag (PGWT_EVENT_FLAG_*) for a backend type, and the we==0
+ * recording policy. Pure helpers shared by the sampler and the server-side
+ * category tagging. */
+uint32_t pgwt_backend_type_flag(enum pgwt_backend_type bt);
+int      pgwt_cpu_sample_recordable(enum pgwt_backend_type bt, int cmd_open);
 
 /* SMP-3: effective sample period for the tick at `now_ns`, given the
  * previous tick's timestamp (0 = first tick → nominal). Late/missed ticks
@@ -142,14 +174,18 @@ enum pgwt_sampler_health_action
 pgwt_sampler_health_note(struct pgwt_sampler_health *h, int n_targets,
                          int n_read, int err_no, uint64_t now_ns);
 
-/* SMP-4: pid -> query_id join index over a dumped state_map. Entries are
- * sorted in place by pid; lookup is a binary search. */
+/* SMP-4: pid -> {query_id, cmd_open} join index over a dumped state_map.
+ * Entries are sorted in place by pid; lookup is a binary search. */
 struct pgwt_qid_entry {
     uint32_t pid;
     uint64_t query_id;
+    int      cmd_open;    /* command-open gate from the state_map (T2) */
 };
 void     pgwt_qid_index_sort(struct pgwt_qid_entry *entries, int n);
 uint64_t pgwt_qid_index_lookup(const struct pgwt_qid_entry *entries, int n,
                                uint32_t pid);
+/* Full-entry variant (query_id + cmd_open). NULL on miss. */
+const struct pgwt_qid_entry *
+pgwt_qid_index_get(const struct pgwt_qid_entry *entries, int n, uint32_t pid);
 
 #endif /* PGWT_SAMPLER_H */

--- a/src/server.c
+++ b/src/server.c
@@ -231,6 +231,12 @@ struct pgwt_server {
     struct bm_entry *bm_map;
     int  bm_capacity;
     int  bm_count;
+
+    /* T2: pid → category-flag table (sorted by pid), derived from bm_map.
+     * Feeds pgwt_tag_events so every raw compute path can apply the
+     * decomposed-AAS model (io_worker exclusion, categories). */
+    struct pgwt_pid_cat *pid_cats;
+    int  n_pid_cats;
 };
 
 /* ── JSON request parsing (cJSON) ─────────────────────────── */
@@ -502,6 +508,50 @@ static void server_load_backends(struct pgwt_server *srv)
     if (srv->bm_count > 0)
         fprintf(stderr, "pgwt-server: loaded %d backend metadata entries\n",
                 srv->bm_count);
+}
+
+/* Map a backends.jsonl type string to its T2 category flag (mirrors
+ * pgwt_backend_type_flag over the pgwt_backend_type_name strings). */
+static uint32_t bm_type_to_cat_flag(const char *type)
+{
+    if (strcmp(type, "io_worker") == 0)
+        return PGWT_EVENT_FLAG_IO_WORKER;
+    if (strcmp(type, "autovac_worker") == 0)
+        return PGWT_EVENT_FLAG_MAINT;
+    if (strcmp(type, "client") == 0 || strcmp(type, "parallel_worker") == 0
+        || strcmp(type, "unknown") == 0)
+        return 0;   /* foreground */
+    return PGWT_EVENT_FLAG_BACKGROUND;
+}
+
+static int pid_cat_cmp(const void *a, const void *b)
+{
+    uint32_t pa = ((const struct pgwt_pid_cat *)a)->pid;
+    uint32_t pb = ((const struct pgwt_pid_cat *)b)->pid;
+    return (pa > pb) - (pa < pb);
+}
+
+/* Build the sorted pid → category-flag table from the loaded bm_map. */
+static void server_build_pid_cats(struct pgwt_server *srv)
+{
+    free(srv->pid_cats);
+    srv->pid_cats = NULL;
+    srv->n_pid_cats = 0;
+    if (srv->bm_count <= 0 || !srv->bm_map)
+        return;
+    srv->pid_cats = calloc((size_t)srv->bm_count, sizeof(*srv->pid_cats));
+    if (!srv->pid_cats)
+        return;
+    int n = 0;
+    for (int i = 0; i < srv->bm_capacity && n < srv->bm_count; i++) {
+        if (srv->bm_map[i].pid == 0)
+            continue;
+        srv->pid_cats[n].pid  = srv->bm_map[i].pid;
+        srv->pid_cats[n].flag = bm_type_to_cat_flag(srv->bm_map[i].type);
+        n++;
+    }
+    qsort(srv->pid_cats, (size_t)n, sizeof(*srv->pid_cats), pid_cat_cmp);
+    srv->n_pid_cats = n;
 }
 
 /* ── Event caching + on-demand loading ────────────────────── */
@@ -1352,6 +1402,23 @@ server_load_events_fi(struct pgwt_server *srv,
                     continue;   /* exact data is authoritative here */
                 has_samples = 1;
             } else {
+                /* T2 backstop (study defect 2): an EXIT record whose closing
+                 * interval lies OUTSIDE exact coverage in a generation that
+                 * has sampled coverage is a phantom — pre-fix daemons
+                 * "closed" sampled-tier seed entries at process exit,
+                 * back-filling the backend's whole sampled lifetime as one
+                 * interval (usually CPU) that the SAMPLES stream already
+                 * covers. The producer is fixed (wp_live gate in BPF); this
+                 * drop keeps already-recorded traces honest. Real full-mode
+                 * exit intervals lie inside exact coverage and are kept. */
+                if (events[i].new_event == PGWT_EVENT_EXIT
+                    && gc && gc->n_sampled > 0) {
+                    uint64_t mid = events[i].timestamp_ns
+                                 - events[i].duration_ns / 2;
+                    if (!(gc->n_exact > 0 &&
+                          spans_contain(gc->exact, gc->n_exact, mid)))
+                        continue;   /* phantom exit interval */
+                }
                 has_transitions = 1;
             }
             events[kept] = events[i];
@@ -1361,6 +1428,12 @@ server_load_events_fi(struct pgwt_server *srv,
         }
     }
     total = kept;
+
+    /* T2: annotate the merged window with categories (pid types from
+     * backends.jsonl) and the PLAN/EXEC/CMD marker windows; classify exact
+     * we==0 intervals against the command gate. One pass feeding every raw
+     * estimator (docs/AAS_SEMANTICS_DECISION.md). */
+    pgwt_tag_events(events, total, srv->pid_cats, srv->n_pid_cats);
 
     if (info) {
         info->has_transitions = has_transitions;
@@ -1386,6 +1459,9 @@ static void server_destroy(struct pgwt_server *srv)
     qt_map_clear(srv);
     free(srv->bm_map);
     srv->bm_map = NULL;
+    free(srv->pid_cats);
+    srv->pid_cats = NULL;
+    srv->n_pid_cats = 0;
 }
 
 /* ── Server init ──────────────────────────────────────────── */
@@ -1424,6 +1500,7 @@ static int server_init(struct pgwt_server *srv, const char *trace_dir)
 
     server_load_query_texts(srv);
     server_load_backends(srv);
+    server_build_pid_cats(srv);
 
     return 0;
 }
@@ -1517,6 +1594,7 @@ static void handle_info(struct pgwt_server *srv, struct pgwt_request *req)
     srv->bm_capacity = 0;
     srv->bm_count = 0;
     server_load_backends(srv);
+    server_build_pid_cats(srv);
 
     cJSON *root = cJSON_CreateObject();
     cJSON_AddNumberToObject(root, "id", (double)req->id);
@@ -1601,6 +1679,16 @@ static void handle_aas(struct pgwt_server *srv, struct pgwt_request *req)
             for (int c = 0; c < PGWT_NUM_CLASSES; c++)
                 cJSON_AddNumberToObject(b, pgwt_class_names[c],
                                         aas.buckets[i].class_aas[c]);
+            /* T2 (additive): the same AAS decomposed by category.
+             * io_worker appears ONLY here — excluded from the class AAS
+             * above and from max_aas. Raw path only (summaries carry no
+             * category data). */
+            if (!from_summaries) {
+                cJSON *cat = cJSON_AddObjectToObject(b, "cat");
+                for (int c = 0; c < PGWT_NUM_CATS; c++)
+                    cJSON_AddNumberToObject(cat, pgwt_cat_names[c],
+                                            aas.buckets[i].cat_aas[c]);
+            }
             cJSON_AddItemToArray(buckets_arr, b);
         }
     }
@@ -1655,6 +1743,24 @@ static void handle_time_model(struct pgwt_server *srv, struct pgwt_request *req)
     cJSON_AddNumberToObject(root, "idle_time_ms", tm.idle_time_ms);
     cJSON_AddNumberToObject(root, "aas", tm.aas);
     cJSON_AddNumberToObject(root, "wall_ms", tm.wall_ms);
+
+    /* T2 (additive): category decomposition + io_worker utilization. Raw
+     * path only — summaries carry no category data. cat "io_worker" ms is
+     * OUTSIDE DB Time (utilization, not load). */
+    if (!from_summaries) {
+        cJSON *cats = cJSON_AddArrayToObject(root, "categories");
+        for (int c = 0; c < PGWT_NUM_CATS; c++) {
+            cJSON *r = cJSON_CreateObject();
+            cJSON_AddStringToObject(r, "name", pgwt_cat_names[c]);
+            cJSON_AddNumberToObject(r, "ms", tm.cat_ms[c]);
+            cJSON_AddNumberToObject(r, "aas",
+                                    tm.wall_ms > 0 ? tm.cat_ms[c] / tm.wall_ms
+                                                   : 0.0);
+            cJSON_AddItemToArray(cats, r);
+        }
+        cJSON_AddNumberToObject(root, "io_worker_busy_pct",
+                                tm.io_worker_busy_pct);
+    }
     emit_json(root);
 
     free(tm.rows);

--- a/src/wait_event.c
+++ b/src/wait_event.c
@@ -545,6 +545,11 @@ const char *pgwt_class_name(uint32_t wei)
 const char *pgwt_event_name(uint32_t wei)
 {
     if (wei == 0) return "CPU";
+    /* T2 synthetic id: on-CPU time OUTSIDE a command window, classified
+     * idle by the compute tagging pass (Activity class => excluded +
+     * hidden like other instrumented idle states). Named so it never
+     * renders as "Unknown" where hidden events do surface (timeline). */
+    if (wei == PGWT_WEI_NONCMD_CPU) return "NonCommandCpu";
 
     int cls = WE_CLASS(wei);
     int id  = WE_EVENT(wei);

--- a/tests/ci_smoke.sh
+++ b/tests/ci_smoke.sh
@@ -159,6 +159,15 @@ run_section "capture smoke: --mode tiered (live view + trace file)" \
 run_section "state_map full is loud (CAP-1, --mode tiered)" \
     python3 "$SCRIPT_DIR/test_state_map_loud.py" --pid "$PM_PID"
 
+# ── T2 item 0: the uprobes must actually FIRE (bpftool run_cnt). ──
+# Guards the PIE dead-offset class (study defect 1): attach "succeeds",
+# the probe never runs, attribution is silently zero. PG13 exercises the
+# standard_ExecutorStart route; every version exercises the T2
+# command-open gate probe (pgstat_report_activity).
+run_section "uprobes fire on this binary layout (T2, run_cnt > 0)" \
+    python3 "$SCRIPT_DIR/test_uprobe_fired.py" --pid "$PM_PID" \
+        ${PG_VERSION:+--pg-version "$PG_VERSION"}
+
 # ── Full mode: hard when watchpoints exist; loud skip when they don't ──
 if [[ "$WP" == "yes" ]]; then
     run_section "capture smoke: --mode full (live view + trace file)" \

--- a/tests/cross_validate.c
+++ b/tests/cross_validate.c
@@ -46,6 +46,50 @@ static struct evt_acc *acc_find(struct evt_acc *t, uint32_t id)
     return &t[h];
 }
 
+/* ── T2: exact-tier command gate (mirror of pgwt_tag_events) ──────────
+ * The sampled tier records client we==0 only while a command is open, so
+ * the exact side must classify its we==0 intervals the same way or the
+ * comparison (and AAS across tier switches) would diverge by construction
+ * on chatty workloads. Per-pid sweep over the CMD_START/CMD_END markers;
+ * majority rule per interval. Pids with no CMD markers keep all we==0 as
+ * CPU (background processes / legacy traces). */
+#define CMD_HT 1024
+struct cmd_state {
+    uint32_t pid;       /* 0 = empty */
+    int      seen_cmd, cmd_open;
+    uint64_t anchor, banked;
+};
+
+static struct cmd_state *cmd_get(struct cmd_state *ht, uint32_t pid)
+{
+    uint32_t h = (pid * 2654435761u) % CMD_HT;
+    while (ht[h].pid && ht[h].pid != pid)
+        h = (h + 1) % CMD_HT;
+    if (!ht[h].pid) ht[h].pid = pid;
+    return &ht[h];
+}
+
+/* Returns 1 if the we==0 interval ending at t1 (mono) is majority
+ * in-command; also consumes the banked open time. */
+static int cmd_interval_open(struct cmd_state *st, uint64_t t1, uint64_t dur)
+{
+    if (!st->seen_cmd)
+        return 1;   /* no gate info: legacy behavior (CPU) */
+    uint64_t t0 = t1 > dur ? t1 - dur : 0;
+    uint64_t open_ns = st->banked;
+    if (st->cmd_open) {
+        uint64_t a = st->anchor > t0 ? st->anchor : t0;
+        if (t1 > a)
+            open_ns += t1 - a;
+    }
+    st->banked = 0;
+    if (st->cmd_open)
+        st->anchor = t1;
+    if (dur == 0)
+        return st->cmd_open;
+    return open_ns * 2 >= dur;
+}
+
 int main(int argc, char **argv)
 {
     if (argc < 2) {
@@ -121,7 +165,8 @@ int main(int argc, char **argv)
      * sample counts if its timestamp falls inside. */
     struct evt_acc *table = calloc(MAX_DISTINCT, sizeof(*table));
     struct pgwt_trace_event *evs = malloc(MAX_EVENTS * sizeof(*evs));
-    if (!table || !evs) { perror("malloc"); return 1; }
+    struct cmd_state *cmd_ht = calloc(CMD_HT, sizeof(*cmd_ht));
+    if (!table || !evs || !cmd_ht) { perror("malloc"); return 1; }
 
     double total_sampled_ns = 0, total_exact_ns = 0;
     int n_samples = 0;
@@ -142,7 +187,9 @@ int main(int argc, char **argv)
                     if (w < win_from || w >= win_to)
                         continue;
                     uint32_t ev = e->new_event;
-                    if (ev == 0 || pgwt_is_idle_event(ev))
+                    /* T2: we==0 samples are first-class CPU (the capture
+                     * side already applied the command gate). */
+                    if (ev != 0 && pgwt_is_idle_event(ev))
                         continue;
                     double contrib = (double)info.sample_period_ns;
                     acc_find(table, ev)->sampled_ns += contrib;
@@ -150,7 +197,33 @@ int main(int argc, char **argv)
                     n_samples++;
                 } else { /* TRANSITIONS */
                     uint32_t ev = e->old_event;
-                    if (PGWT_IS_MARKER(ev) || ev == 0 || pgwt_is_idle_event(ev))
+                    /* CMD markers drive the exact-tier command gate. */
+                    if (ev == PGWT_MARKER_CMD_START || ev == PGWT_MARKER_CMD_END) {
+                        struct cmd_state *st = cmd_get(cmd_ht, e->pid);
+                        st->seen_cmd = 1;
+                        if (ev == PGWT_MARKER_CMD_START && !st->cmd_open) {
+                            st->cmd_open = 1;
+                            st->anchor = e->timestamp_ns;
+                        } else if (ev == PGWT_MARKER_CMD_END && st->cmd_open) {
+                            st->banked += e->timestamp_ns - st->anchor;
+                            st->cmd_open = 0;
+                        }
+                        continue;
+                    }
+                    if (PGWT_IS_MARKER(ev))
+                        continue;
+                    /* Every exact interval consumes the pid's banked
+                     * command-open time (the sweep is per-interval);
+                     * the verdict matters only for we==0. */
+                    int in_cmd = cmd_interval_open(cmd_get(cmd_ht, e->pid),
+                                                   e->timestamp_ns,
+                                                   e->duration_ns);
+                    if (pgwt_is_idle_event(ev))
+                        continue;
+                    /* T2: exact we==0 intervals count as CPU only when
+                     * majority in-command — the same definition the
+                     * sampled side captured with. */
+                    if (ev == 0 && !in_cmd)
                         continue;
                     uint64_t end = pgwt_reader_mono_to_wall(&r, e->timestamp_ns);
                     uint64_t dur = e->duration_ns;
@@ -246,5 +319,6 @@ int main(int argc, char **argv)
 
     free(table);
     free(evs);
+    free(cmd_ht);
     return ok ? 0 : 1;
 }

--- a/tests/mock_server.py
+++ b/tests/mock_server.py
@@ -98,6 +98,16 @@ def _make_aas_buckets():
             "activity": 0.0,
             "extension": round(0.9 + 0.05 * (i % 3), 4),
             "unknown": 0.0,
+            # T2 (additive): the same AAS decomposed by category.
+            # io_worker appears ONLY here, never in the class keys above.
+            "cat": {
+                "planning": 0.05,
+                "execution": round(2.0 + 0.4 * (i % 5), 4),
+                "command": 0.3,
+                "maintenance": 0.1,
+                "background": 0.05,
+                "io_worker": round(0.5 + 0.1 * (i % 3), 4),
+            },
         })
     return buckets
 
@@ -137,6 +147,17 @@ _CANNED["time_model"] = {
     "db_time_ms": 12500,
     "idle_time_ms": 45000,
     "aas": 3.47,
+    # T2 (additive): category decomposition + io_worker utilization
+    # (raw path; io_worker ms is OUTSIDE DB Time).
+    "categories": [
+        {"name": "planning",    "ms": 400,   "aas": 0.11},
+        {"name": "execution",   "ms": 9000,  "aas": 2.50},
+        {"name": "command",     "ms": 1600,  "aas": 0.44},
+        {"name": "maintenance", "ms": 900,   "aas": 0.25},
+        {"name": "background",  "ms": 600,   "aas": 0.17},
+        {"name": "io_worker",   "ms": 2400,  "aas": 0.67},
+    ],
+    "io_worker_busy_pct": 22.2,
     "rows": [
         {"indent": 0, "name": "DB Time",  "ms": 12500, "pct": 100.0, "aas": 3.47},
         {"indent": 1, "name": "CPU*",     "ms": 4800,  "pct": 38.4,  "aas": 1.33},
@@ -458,6 +479,11 @@ class DaemonState:
             "anomaly_dropped_budget_total": 1,
             "anomaly_dropped_cooldown_total": 0,
             "anomaly_baseline_aas": 1.85,
+            # T2 decomposed-AAS observability
+            "io_worker_busy_pct": 22.2,
+            "io_worker_samples_total": 18000,
+            "io_worker_busy_total": 4000,
+            "noncmd_cpu_samples_total": 120000,
         }
 
     def escalate(self, duration_s, reason):

--- a/tests/run_all.sh
+++ b/tests/run_all.sh
@@ -121,6 +121,7 @@ if [[ -x "$PROJECT_DIR/pgwt-server" ]] && [[ -x "$SCRIPT_DIR/gen_test_traces" ]]
     run_test "test_data_esc_coverage" python3 "$SCRIPT_DIR/test_data_esc_coverage.py"
     run_test "test_data_summary_honesty" python3 "$SCRIPT_DIR/test_data_summary_honesty.py"
     run_test "test_data_markers" python3 "$SCRIPT_DIR/test_data_markers.py"
+    run_test "test_data_categories" python3 "$SCRIPT_DIR/test_data_categories.py"
     run_test "test_current_trace" python3 "$SCRIPT_DIR/test_current_trace.py"
     run_test "test_protocol_drift" python3 "$SCRIPT_DIR/test_protocol_drift.py"
 else

--- a/tests/test_accuracy.py
+++ b/tests/test_accuracy.py
@@ -287,6 +287,13 @@ def test_db_time_sanity(pm_pid):
 def test_io_count_cross_check(pm_pid):
     """Compare tracer IO:DataFileRead count against pg_stat_io reads.
 
+    COUNTS, deliberately not time (T2 study Q3): pg_stat_io.read_time's
+    INSTR_TIME window covers per-op AIO bookkeeping + per-page completion
+    work (~9us + ~1.7us/page more than the wait_event set/clear window),
+    so a time ratio floats 0.55-0.90 with mean op latency — the historical
+    "0.80 async overlap" was instrumentation-window overhead, not overlap
+    and not data loss. Counts agree to +/-0.2% when windows align.
+
     Strategy: use pgbench TPC-B (not -S) which does updates and generates
     real IO.  Start pgbench first, let backends attach, THEN reset pg_stat_io
     and start the tracer measurement window simultaneously.

--- a/tests/test_anomaly.c
+++ b/tests/test_anomaly.c
@@ -258,9 +258,11 @@ static void test_metrics_from_batch(void)
 {
     printf("--- metrics_from_batch: AAS + lock-fraction derivation ---\n");
 
-    /* A batch as build_batch would produce: on-CPU (event 0) is already
-     * absent. Mix of Lock, LWLock, IO and idle (ClientRead / Activity). */
-    struct pgwt_trace_event batch[6];
+    /* A batch as build_batch would produce (T2: gated on-CPU records are
+     * first-class CPU samples with new_event == 0). Mix of CPU, Lock,
+     * LWLock, IO and idle (ClientRead / Activity), plus an io_worker
+     * record that must be excluded. */
+    struct pgwt_trace_event batch[8];
     memset(batch, 0, sizeof(batch));
     batch[0].new_event = WEI(PG_WAIT_LOCK, 0x03);     /* active, lock */
     batch[1].new_event = WEI(PG_WAIT_LOCK, 0x01);     /* active, lock */
@@ -268,12 +270,16 @@ static void test_metrics_from_batch(void)
     batch[3].new_event = WEI(PG_WAIT_IO, 0x10);       /* active, not lock */
     batch[4].new_event = WEI(PG_WAIT_CLIENT, 0);      /* idle (ClientRead) */
     batch[5].new_event = WEI(PG_WAIT_ACTIVITY, 0x02); /* idle (Activity) */
+    batch[6].new_event = 0;                           /* on-CPU: ACTIVE (T2) */
+    batch[7].new_event = WEI(PG_WAIT_IO, 0x10);       /* io_worker: excluded */
+    batch[7].flags     = PGWT_EVENT_FLAG_IO_WORKER;
 
     double aas = -1, frac = -1;
-    pgwt_anomaly_metrics_from_batch(batch, 6, &aas, &frac);
-    /* Active = 4 (the two idle excluded); locks = 2 → fraction 0.5. */
-    CHECK(aas == 4.0, "aas=%.1f expected 4", aas);
-    CHECK(frac == 0.5, "lock_fraction=%.2f expected 0.50", frac);
+    pgwt_anomaly_metrics_from_batch(batch, 8, &aas, &frac);
+    /* Active = 5 (two idle + the io_worker excluded, the CPU sample
+     * included); locks = 2 → fraction 0.4. */
+    CHECK(aas == 5.0, "aas=%.1f expected 5", aas);
+    CHECK(frac == 0.4, "lock_fraction=%.2f expected 0.40", frac);
 
     /* All-idle batch → AAS 0, fraction 0 (no divide-by-zero). */
     struct pgwt_trace_event idle[2];
@@ -283,6 +289,66 @@ static void test_metrics_from_batch(void)
     pgwt_anomaly_metrics_from_batch(idle, 2, &aas, &frac);
     CHECK(aas == 0.0, "all-idle aas=%.1f expected 0", aas);
     CHECK(frac == 0.0, "all-idle frac=%.2f expected 0", frac);
+}
+
+/* ── Test 8b: a pure CPU storm must be able to trip the AAS rule (AAS-1) ─ */
+static void test_cpu_storm_fires(void)
+{
+    printf("--- CPU storm: we==0 samples drive the AAS rule ---\n");
+
+    struct pgwt_anomaly a;
+    pgwt_anomaly_init(&a, true, 10);
+    a.aas_factor = 3.0;
+    a.aas_ticks  = 3;
+
+    uint64_t clk = TICK_NS;
+    warm_baseline(&a, 1.0, &clk);   /* quiet baseline ~1 */
+
+    /* A CPU-storm batch: 8 client backends all on-CPU inside a command —
+     * exactly the incident class the pre-T2 sampler was blind to (it
+     * reported AAS 0.017 for a machine-saturating -S run; study Q4). */
+    struct pgwt_trace_event storm[8];
+    memset(storm, 0, sizeof(storm));   /* new_event = 0 = CPU, no flags */
+
+    int fired = 0;
+    for (int t = 0; t < 5; t++) {
+        double aas = -1, frac = -1;
+        pgwt_anomaly_metrics_from_batch(storm, 8, &aas, &frac);
+        CHECK(aas == 8.0, "storm tick aas=%.1f expected 8", aas);
+        struct pgwt_anomaly_decision d = pgwt_anomaly_eval(&a, aas, frac, clk);
+        clk += TICK_NS;
+        if (d.action == PGWT_ANOMALY_FIRE) {
+            CHECK(d.fired_mask & PGWT_RULE_AAS, "CPU storm fires the AAS rule");
+            fired = 1;
+            break;
+        }
+    }
+    CHECK(fired, "sustained CPU storm must FIRE (the anomaly engine was "
+          "blind to exactly this before T2)");
+
+    /* The same storm made of io_worker records must NOT fire — io_workers
+     * are excluded from AAS by decision. */
+    struct pgwt_anomaly b;
+    pgwt_anomaly_init(&b, true, 10);
+    b.aas_factor = 3.0;
+    b.aas_ticks  = 3;
+    clk = TICK_NS;
+    warm_baseline(&b, 1.0, &clk);
+    struct pgwt_trace_event iostorm[8];
+    memset(iostorm, 0, sizeof(iostorm));
+    for (int i = 0; i < 8; i++) {
+        iostorm[i].new_event = WEI(PG_WAIT_IO, 0x01);
+        iostorm[i].flags = PGWT_EVENT_FLAG_IO_WORKER;
+    }
+    for (int t = 0; t < 5; t++) {
+        double aas = -1, frac = -1;
+        pgwt_anomaly_metrics_from_batch(iostorm, 8, &aas, &frac);
+        CHECK(aas == 0.0, "io_worker-only batch aas=%.1f expected 0", aas);
+        struct pgwt_anomaly_decision d = pgwt_anomaly_eval(&b, aas, frac, clk);
+        clk += TICK_NS;
+        CHECK(d.action != PGWT_ANOMALY_FIRE,
+              "io_worker load must never fire the AAS rule");
+    }
 }
 
 /* ── Test 9: AAS + lock can fire together (combined fired_mask) ────────── */
@@ -317,6 +383,7 @@ int main(void)
     test_baseline_protected();
     test_budget_boundary();
     test_metrics_from_batch();
+    test_cpu_storm_fires();
     test_combined_fire();
 
     printf("\n%d/%d checks passed\n", tests_passed, tests_run);

--- a/tests/test_capture_smoke.py
+++ b/tests/test_capture_smoke.py
@@ -685,12 +685,14 @@ def phase_cpu_storm_escalation(pm_pid):
           + ("" if fires >= 1 else f" (tracer stderr tail: {err[-300:]!r})"))
 
     # No step artifact: every interior 1s bucket across the tier switch
-    # must show the storm. Pre-T2, sampled buckets read ~0.0 while exact
+    # must show the storm. The anomaly fires ~0.3-1 s into the storm, so
+    # starting the window at +0.7 s puts the sampled->exact switch INSIDE
+    # the asserted range. Pre-T2, sampled buckets read ~0.0 while exact
     # (escalated) buckets read ~3 — a hard step.
     resp = server_query(trace_dir, "aas",
-                        extra={"from": storm_from + 1_500_000_000,
-                               "to": storm_to - 1_500_000_000,
-                               "buckets": 6})
+                        extra={"from": storm_from + 700_000_000,
+                               "to": storm_to - 1_000_000_000,
+                               "buckets": 7})
     buckets = resp.get("buckets", [])
     check(len(buckets) >= 3, f"aas buckets across the tier switch "
           f"(got {len(buckets)}, fidelity={resp.get('fidelity')!r})")

--- a/tests/test_capture_smoke.py
+++ b/tests/test_capture_smoke.py
@@ -498,6 +498,214 @@ def phase_fork_after_attach(pm_pid, mode):
           f"(saw: {names})")
 
 
+class CpuStorm:
+    """N psql sessions each executing a long run of SHORT CPU-bound
+    statements (~30-100 ms each, fully cached): pg_stat_activity shows
+    them state='active' nearly continuously, and the real command
+    boundaries exercise the T2 command-open gate exactly like production
+    OLTP (one long DO block would hide the gate)."""
+
+    def __init__(self, n):
+        self.sessions = [subprocess.Popen(
+            ["psql", "-U", "postgres", "-d", "postgres"],
+            stdin=subprocess.PIPE, stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL, text=True) for _ in range(n)]
+        time.sleep(1.5)   # connected (and, pre-attach, scanned)
+
+    def fire(self, reps=400):
+        stmt = "SELECT count(*) FROM generate_series(1,300000);\n"
+        for s in self.sessions:
+            s.stdin.write(stmt * reps)
+            s.stdin.flush()
+
+    def stop(self):
+        for s in self.sessions:
+            s.terminate()
+            try:
+                s.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                s.kill()
+        cleanup_stale_backends()
+
+
+def sample_active_sessions(duration_s, interval=0.5):
+    """pg_stat_activity 1-per-interval ground truth: count of client
+    backends with state='active', excluding the sampling connection."""
+    counts = []
+    end = time.time() + duration_s
+    while time.time() < end:
+        out = psql("SELECT count(*) FROM pg_stat_activity "
+                   "WHERE state = 'active' "
+                   "AND backend_type = 'client backend' "
+                   "AND pid != pg_backend_pid()", timeout=10)
+        if re.fullmatch(r'\d+', out or ''):
+            counts.append(int(out))
+        time.sleep(interval)
+    return counts
+
+
+def aas_bucket_total(bucket):
+    return sum(v for k, v in bucket.items()
+               if k not in ("t", "total", "cat") and isinstance(v, (int, float)))
+
+
+def ctl_query(trace_dir, cmd):
+    """One JSON request over the daemon control socket."""
+    import socket
+    path = os.path.join(trace_dir, "pgwt.sock")
+    s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    s.settimeout(5)
+    try:
+        s.connect(path)
+        s.sendall((json.dumps({"cmd": cmd}) + "\n").encode())
+        buf = b""
+        while b"\n" not in buf:
+            c = s.recv(4096)
+            if not c:
+                break
+            buf += c
+        return json.loads(buf.decode().split("\n")[0])
+    finally:
+        s.close()
+
+
+def phase_sampled_aas_truth(pm_pid):
+    """T2 (AAS-1) definition-of-done: sampled AAS — now CPU-inclusive —
+    must match pg_stat_activity 1s-sampling ground truth. A CPU-bound
+    storm (3 hogs) + a pg_sleep session; pre-T2 the sampler skipped all
+    we==0 and reported AAS ~ 0.0x for exactly this shape (study Q4:
+    -98%%). Anomaly escalation is disabled (huge factor) so the window is
+    PURE sampled tier."""
+    print("--- Phase 5: sampled CPU-inclusive AAS vs pg_stat_activity ---")
+    trace_dir = tempfile.mkdtemp(prefix="pgwt_smoke_aas_")
+    os.chmod(trace_dir, 0o755)
+
+    storm = CpuStorm(3)
+    sleeper = subprocess.Popen(
+        ["psql", "-U", "postgres", "-d", "postgres"],
+        stdin=subprocess.PIPE, stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL, text=True)
+    time.sleep(1.0)
+
+    tracer = subprocess.Popen(
+        [TRACER, "--mode", "tiered", "--pid", str(pm_pid),
+         "-T", trace_dir, "--duration", "17", "--quiet",
+         "--interval", "5", "--anomaly-aas-factor", "1000000"],
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    time.sleep(3.0)   # BPF load + scan + first ticks
+    try:
+        win_from = time.time_ns()
+        storm.fire()
+        sleeper.stdin.write("SELECT pg_sleep(10);\n")
+        sleeper.stdin.flush()
+        time.sleep(0.5)
+        psa = sample_active_sessions(9.0, interval=0.5)
+        win_to = time.time_ns()
+        _, stderr = tracer.communicate(timeout=40)
+        err = stderr.decode('utf-8', errors='replace')
+    except subprocess.TimeoutExpired:
+        tracer.kill()
+        _, stderr = tracer.communicate()
+        err = stderr.decode('utf-8', errors='replace')
+    finally:
+        storm.stop()
+        sleeper.terminate()
+
+    psa_mean = sum(psa) / len(psa) if psa else 0.0
+    check(psa_mean >= 2.0,
+          f"ground truth: pg_stat_activity mean active = {psa_mean:.2f} "
+          f"(storm running; n={len(psa)})")
+
+    resp = server_query(trace_dir, "aas",
+                        extra={"from": win_from, "to": win_to, "buckets": 9})
+    buckets = resp.get("buckets", [])
+    check(len(buckets) > 0,
+          "aas view has buckets over the storm window" if buckets else
+          f"aas view has buckets (stderr tail: {err[-300:]!r})")
+    if buckets:
+        totals = [aas_bucket_total(b) for b in buckets]
+        tracer_mean = sum(totals) / len(totals)
+        cpu_mean = sum(b.get("cpu", 0.0) for b in buckets) / len(buckets)
+        tol = max(0.9, 0.35 * psa_mean)
+        check(abs(tracer_mean - psa_mean) <= tol,
+              f"sampled AAS matches pg_stat_activity ground truth: "
+              f"tracer={tracer_mean:.2f} vs psa={psa_mean:.2f} (tol ±{tol:.2f}) "
+              f"[AAS-1 definition of done]")
+        check(cpu_mean >= 1.0,
+              f"CPU class carries the storm: cpu AAS = {cpu_mean:.2f} "
+              f"(pre-T2 sampler reported ~0 here)")
+        check(resp.get("fidelity") == "sampled",
+              f"window is pure sampled tier (fidelity={resp.get('fidelity')!r})")
+
+    subprocess.run(["rm", "-rf", trace_dir])
+
+
+def phase_cpu_storm_escalation(pm_pid):
+    """T2 definition-of-done: a SELECT-storm CPU incident raises sampled
+    AAS enough to trigger anomaly escalation (the engine was blind to CPU
+    before — AAS-1), and the AAS chart shows no step artifact across the
+    sampled->exact tier switch."""
+    print("--- Phase 6: CPU storm triggers escalation; no AAS step ---")
+    trace_dir = tempfile.mkdtemp(prefix="pgwt_smoke_esc_")
+    os.chmod(trace_dir, 0o755)
+
+    storm = CpuStorm(3)
+    tracer = subprocess.Popen(
+        [TRACER, "--mode", "tiered", "--pid", str(pm_pid),
+         "-T", trace_dir, "--duration", "20", "--quiet",
+         "--interval", "5"],
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    time.sleep(7.0)   # BPF load + scan + anomaly baseline warmup (~5 s idle)
+    try:
+        storm_from = time.time_ns()
+        storm.fire()
+        time.sleep(5.0)
+        metrics = {}
+        try:
+            metrics = ctl_query(trace_dir, "metrics")
+        except OSError as e:
+            print(f"  (control socket: {e})")
+        storm_active = sample_active_sessions(3.0, interval=0.5)
+        storm_to = time.time_ns()
+        _, stderr = tracer.communicate(timeout=40)
+        err = stderr.decode('utf-8', errors='replace')
+    except subprocess.TimeoutExpired:
+        tracer.kill()
+        _, stderr = tracer.communicate()
+        err = stderr.decode('utf-8', errors='replace')
+    finally:
+        storm.stop()
+
+    fires = metrics.get("anomaly_fires_total", 0)
+    windows = metrics.get("escalation_windows_total", 0)
+    check(fires >= 1 and windows >= 1,
+          f"CPU storm triggered anomaly escalation "
+          f"(anomaly_fires_total={fires}, escalation_windows_total={windows}, "
+          f"tier={metrics.get('tier')!r}) [AAS-1: engine no longer CPU-blind]"
+          + ("" if fires >= 1 else f" (tracer stderr tail: {err[-300:]!r})"))
+
+    # No step artifact: every interior 1s bucket across the tier switch
+    # must show the storm. Pre-T2, sampled buckets read ~0.0 while exact
+    # (escalated) buckets read ~3 — a hard step.
+    resp = server_query(trace_dir, "aas",
+                        extra={"from": storm_from + 1_500_000_000,
+                               "to": storm_to - 1_500_000_000,
+                               "buckets": 6})
+    buckets = resp.get("buckets", [])
+    check(len(buckets) >= 3, f"aas buckets across the tier switch "
+          f"(got {len(buckets)}, fidelity={resp.get('fidelity')!r})")
+    if buckets:
+        totals = [aas_bucket_total(b) for b in buckets]
+        lo = min(totals)
+        truth = (sum(storm_active) / len(storm_active)) if storm_active else 3.0
+        check(lo >= 1.2,
+              f"no AAS step artifact at the tier switch: min bucket = "
+              f"{lo:.2f}, buckets = {[f'{t:.1f}' for t in totals]}, "
+              f"psa during storm = {truth:.1f}")
+
+    subprocess.run(["rm", "-rf", trace_dir])
+
+
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('--pid', type=int, help='Postmaster PID')
@@ -538,6 +746,12 @@ def main():
     phase_live_query_event(pm_pid, args.mode)
     phase_trace_file(pm_pid, args.mode)
     phase_fork_after_attach(pm_pid, args.mode)
+    if args.mode == 'tiered':
+        # T2 (AAS semantics): CPU-inclusive sampled AAS vs pg_stat_activity
+        # ground truth, and the CPU-storm escalation + tier-switch
+        # continuity checks (docs/AAS_SEMANTICS_DECISION.md).
+        phase_sampled_aas_truth(pm_pid)
+        phase_cpu_storm_escalation(pm_pid)
 
     print(f"\n{tests_passed}/{tests_run} checks passed")
     sys.exit(0 if tests_failed == 0 else 1)

--- a/tests/test_data_aas.py
+++ b/tests/test_data_aas.py
@@ -72,11 +72,23 @@ def main():
 
             if buckets:
                 b = buckets[0]
-                # Sum all class values
+                # Sum all class values (skip the T2 "cat" decomposition —
+                # it is a parallel breakdown of the same time, not a class)
                 total_aas = sum(v for k, v in b.items()
-                                if k not in ("t", "total"))
+                                if k not in ("t", "total", "cat"))
                 t.check_approx(total_aas, 4.0, 0.05,
                                "Total AAS = 4.0 (4 active sessions)")
+
+                # T2: the category decomposition covers the same total
+                # (all backends here are foreground clients; no io_workers)
+                cat = b.get("cat", {})
+                t.check(isinstance(cat, dict) and "execution" in cat,
+                        "bucket carries the T2 category decomposition")
+                cat_total = sum(cat.values())
+                t.check_approx(cat_total, 4.0, 0.05,
+                               "category AAS total = class AAS total")
+                t.check_approx(cat.get("io_worker", -1), 0.0, 0.001,
+                               "no io_worker AAS in a client-only scenario")
 
             # Also check time_model for AAS (use same 5s window)
             resp_tm = srv.query("time_model",

--- a/tests/test_data_categories.py
+++ b/tests/test_data_categories.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python3
+"""test_data_categories.py — T2 decomposed-AAS model over synthetic traces
+(docs/AAS_SEMANTICS_DECISION.md).
+
+Covers, end-to-end through pgwt-server:
+  1. io_worker exclusion: an io_worker's waits enter neither the class AAS
+     nor DB Time in any view; they appear ONLY in the "io_worker" category
+     slot and drive io_worker_busy_pct.
+  2. Category decomposition from backends.jsonl types
+     (maintenance = autovac_worker, background = checkpointer, ...).
+  3. CPU SAMPLES (event id 0 in a SAMPLES block — new in T2) are
+     first-class active time: they raise sampled AAS and the CPU class.
+  4. CMD_START/CMD_END markers classify exact we==0 intervals: the
+     in-command portion is CPU, the out-of-command portion is idle
+     (excluded from DB Time) — the AAS-1 "one definition, all paths" rule.
+  5. Exit-record phantom backstop: an EXIT transition closing a huge
+     "CPU" interval OUTSIDE exact coverage in a sampled trace (what
+     pre-T2 daemons recorded at every disconnect — study defect 2) must
+     not contribute to AAS/DB Time.
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(__file__))
+from server_harness import (
+    ServerHarness, generate_traces, cleanup_traces, TestRunner,
+    CPU, IO_DATA_FILE_READ,
+)
+
+BASE_TS = 10_000_000_000_000
+SEC = 1_000_000_000
+
+# Markers (src/pg_wait_tracer.h)
+MARKER_CMD_START = 0xFFFFFFF6
+MARKER_CMD_END = 0xFFFFFFF7
+EVENT_EXIT = 0xFFFFFFFF
+
+
+def scenario_io_worker():
+    """4 pids x 5 s of IO:DataFileRead: client, io_worker, autovac_worker,
+    checkpointer. Expected: class io AAS = 3.0 (io_worker excluded);
+    categories command/maintenance/background = 1.0 each, io_worker = 1.0
+    in its own slot; db_time = 15 s; io_worker_busy_pct = 100 (1 worker,
+    busy the whole window)."""
+    events = []
+    for pid in (100, 200, 300, 400):
+        events.append({"pid": pid, "ts": BASE_TS + 5 * SEC,
+                       "dur": 5 * SEC, "old": IO_DATA_FILE_READ,
+                       "new": CPU, "qid": 0})
+    return {
+        "backends": [
+            {"pid": 100, "type": "client", "user": "t", "db": "d"},
+            {"pid": 200, "type": "io_worker"},
+            {"pid": 300, "type": "autovac_worker"},
+            {"pid": 400, "type": "checkpointer"},
+        ],
+        "events": events,
+    }
+
+
+def scenario_cpu_samples():
+    """2 client pids sampled on-CPU (event 0) for 5 s at 10 Hz + 1
+    io_worker sampled in IO. Sampled AAS must be ~2.0 CPU (the io_worker
+    excluded), proving CPU samples are first-class active time."""
+    samples = []
+    for i in range(50):  # 5 s at 10 Hz
+        ts = BASE_TS + i * 100_000_000
+        samples.append({"pid": 500, "ts": ts, "event": CPU, "qid": 7})
+        samples.append({"pid": 501, "ts": ts, "event": CPU, "qid": 0})
+        samples.append({"pid": 502, "ts": ts, "event": IO_DATA_FILE_READ,
+                        "qid": 0})
+    return {
+        "backends": [
+            {"pid": 500, "type": "client", "user": "t", "db": "d"},
+            {"pid": 501, "type": "client", "user": "t", "db": "d"},
+            {"pid": 502, "type": "io_worker"},
+        ],
+        "queries": [{"id": 7, "text": "SELECT cpu"}],
+        "sample_period_ns": 100_000_000,
+        "samples": samples,
+    }
+
+
+def scenario_cmd_gate():
+    """One client pid, exact tier, with CMD markers:
+      0s   CMD_START
+      0-2s we==0 interval (fully in-command)      -> CPU, counted
+      2s   CMD_END
+      2-5s we==0 interval (fully out-of-command)  -> idle, NOT counted
+    Expected: CPU AAS over the 5 s window = 2/5 = 0.4; db_time = 2 s."""
+    events = [
+        {"pid": 600, "ts": BASE_TS, "dur": 0,
+         "old": MARKER_CMD_START, "new": MARKER_CMD_START, "qid": 9},
+        {"pid": 600, "ts": BASE_TS + 2 * SEC, "dur": 2 * SEC,
+         "old": CPU, "new": IO_DATA_FILE_READ, "qid": 9},
+        {"pid": 600, "ts": BASE_TS + 2 * SEC, "dur": 0,
+         "old": MARKER_CMD_END, "new": MARKER_CMD_END, "qid": 9},
+        {"pid": 600, "ts": BASE_TS + 5 * SEC, "dur": 3 * SEC,
+         "old": CPU, "new": IO_DATA_FILE_READ, "qid": 0},
+    ]
+    return {
+        "backends": [{"pid": 600, "type": "client", "user": "t", "db": "d"}],
+        "queries": [{"id": 9, "text": "SELECT gated"}],
+        "events": events,
+    }
+
+
+def scenario_exit_phantom():
+    """The study defect-2 shape: a sampled trace (10 Hz samples of one
+    genuinely active pid) plus an EXIT transition closing a phantom 5 s
+    "CPU" interval for a pid the sampler barely saw. The phantom lies
+    outside any exact coverage; the SAMPLES stream already covers the
+    window. Expected: AAS ~ 1.0 (the sampled pid), NOT ~2.0."""
+    samples = []
+    for i in range(50):
+        ts = BASE_TS + i * 100_000_000
+        samples.append({"pid": 700, "ts": ts, "event": IO_DATA_FILE_READ,
+                        "qid": 0})
+    events = [
+        # phantom: old=0 (CPU), new=EXIT, closing the whole 5 s window
+        {"pid": 701, "ts": BASE_TS + 5 * SEC, "dur": 5 * SEC,
+         "old": CPU, "new": EVENT_EXIT, "qid": 0},
+    ]
+    return {
+        "backends": [
+            {"pid": 700, "type": "client", "user": "t", "db": "d"},
+            {"pid": 701, "type": "client", "user": "t", "db": "d"},
+        ],
+        "sample_period_ns": 100_000_000,
+        "samples": samples,
+        "events": events,
+        "interleave": 1,
+    }
+
+
+def total_class_aas(bucket):
+    return sum(v for k, v in bucket.items() if k not in ("t", "total", "cat"))
+
+
+def run_io_worker(t):
+    print("--- 1+2: io_worker exclusion + categories ---")
+    trace_dir = generate_traces(scenario_io_worker())
+    try:
+        with ServerHarness(trace_dir) as srv:
+            resp = srv.query("aas", buckets=1,
+                             from_=BASE_TS, to_=BASE_TS + 5 * SEC)
+            b = resp["buckets"][0]
+            t.check_approx(total_class_aas(b), 3.0, 0.02,
+                           "class AAS = 3.0 (io_worker excluded)")
+            t.check_approx(resp.get("max_aas", -1), 3.0, 0.02,
+                           "max_aas excludes io_worker")
+            cat = b["cat"]
+            t.check_approx(cat["io_worker"], 1.0, 0.02,
+                           "io_worker category slot = 1.0")
+            t.check_approx(cat["maintenance"], 1.0, 0.02,
+                           "autovac_worker -> maintenance = 1.0")
+            t.check_approx(cat["background"], 1.0, 0.02,
+                           "checkpointer -> background = 1.0")
+            t.check_approx(cat["command"] + cat["execution"] + cat["planning"],
+                           1.0, 0.02, "client wait -> foreground = 1.0")
+
+            tm = srv.query("time_model",
+                           from_=BASE_TS, to_=BASE_TS + 5 * SEC)
+            t.check_approx(tm["db_time_ms"], 15000, 0.02,
+                           "DB Time = 15 s (io_worker excluded)")
+            t.check_approx(tm.get("io_worker_busy_pct", -1), 100.0, 0.02,
+                           "io_worker_busy_pct = 100 (1 worker, 5s/5s busy)")
+            cats = {r["name"]: r for r in tm.get("categories", [])}
+            t.check_approx(cats["io_worker"]["ms"], 5000, 0.02,
+                           "io_worker category ms outside DB Time")
+            t.check_approx(cats["maintenance"]["ms"], 5000, 0.02,
+                           "maintenance category ms")
+
+            te = srv.query("top_events",
+                           from_=BASE_TS, to_=BASE_TS + 5 * SEC)
+            io_rows = [r for r in te["rows"]
+                       if r["name"] == "IO:DataFileRead"]
+            t.check(len(io_rows) == 1, "one IO:DataFileRead row")
+            t.check_approx(io_rows[0]["total_ms"], 15000, 0.02,
+                           "top_events excludes the io_worker's 5 s")
+
+            ts_rows = srv.query("top_sessions",
+                                from_=BASE_TS, to_=BASE_TS + 5 * SEC)["rows"]
+            t.check(all(r["pid"] != 200 for r in ts_rows),
+                    "io_worker pid not listed as a session")
+    finally:
+        cleanup_traces(trace_dir)
+
+
+def run_cpu_samples(t):
+    print("--- 3: CPU samples are first-class active time ---")
+    trace_dir = generate_traces(scenario_cpu_samples())
+    try:
+        with ServerHarness(trace_dir) as srv:
+            resp = srv.query("aas", buckets=1,
+                             from_=BASE_TS, to_=BASE_TS + 5 * SEC)
+            t.check(resp.get("fidelity") == "sampled",
+                    "window is sampled fidelity")
+            b = resp["buckets"][0]
+            t.check_approx(b.get("cpu", -1), 2.0, 0.05,
+                           "sampled CPU AAS = 2.0 (two on-CPU clients)")
+            t.check_approx(b["cat"]["io_worker"], 1.0, 0.05,
+                           "sampled io_worker slot = 1.0")
+            t.check_approx(b["cat"]["execution"], 1.0, 0.05,
+                           "CPU sample with query_id -> execution")
+            t.check_approx(b["cat"]["command"], 1.0, 0.05,
+                           "CPU sample without query_id -> command")
+
+            tm = srv.query("time_model",
+                           from_=BASE_TS, to_=BASE_TS + 5 * SEC)
+            t.check_approx(tm["db_time_ms"], 10000, 0.06,
+                           "sampled DB Time = 10 s (2 pids x 5 s CPU)")
+
+            tq = srv.query("top_queries",
+                           from_=BASE_TS, to_=BASE_TS + 5 * SEC)["rows"]
+            q7 = [r for r in tq if r["query_id"] == "7"]
+            t.check(len(q7) == 1 and abs(q7[0]["total_ms"] - 5000) < 500,
+                    "CPU samples attribute to their query")
+    finally:
+        cleanup_traces(trace_dir)
+
+
+def run_cmd_gate(t):
+    print("--- 4: CMD markers classify exact we==0 ---")
+    trace_dir = generate_traces(scenario_cmd_gate())
+    try:
+        with ServerHarness(trace_dir) as srv:
+            resp = srv.query("aas", buckets=1,
+                             from_=BASE_TS, to_=BASE_TS + 5 * SEC)
+            b = resp["buckets"][0]
+            t.check_approx(b.get("cpu", -1), 0.4, 0.02,
+                           "in-command CPU only: AAS = 2s/5s = 0.4")
+            tm = srv.query("time_model",
+                           from_=BASE_TS, to_=BASE_TS + 5 * SEC)
+            t.check_approx(tm["db_time_ms"], 2000, 0.02,
+                           "DB Time = 2 s (post-command CPU is idle)")
+            t.check_approx(tm["idle_time_ms"], 3000, 0.02,
+                           "idle = 3 s (the out-of-command interval)")
+    finally:
+        cleanup_traces(trace_dir)
+
+
+def run_exit_phantom(t):
+    print("--- 5: exit-record phantom CPU backstop (study defect 2) ---")
+    trace_dir = generate_traces(scenario_exit_phantom())
+    try:
+        with ServerHarness(trace_dir) as srv:
+            resp = srv.query("aas", buckets=1,
+                             from_=BASE_TS, to_=BASE_TS + 5 * SEC)
+            b = resp["buckets"][0]
+            total = total_class_aas(b)
+            t.check_approx(total, 1.0, 0.05,
+                           "AAS = 1.0: the phantom 5 s exit-CPU interval "
+                           "is dropped, the sampled pid remains")
+            t.check_approx(b.get("cpu", 0), 0.0, 0.02,
+                           "no phantom CPU class AAS")
+            tm = srv.query("time_model",
+                           from_=BASE_TS, to_=BASE_TS + 5 * SEC)
+            t.check_approx(tm["db_time_ms"], 5000, 0.06,
+                           "DB Time = 5 s (samples only, no phantom)")
+    finally:
+        cleanup_traces(trace_dir)
+
+
+def main():
+    t = TestRunner("test_data_categories")
+    print(f"=== {t.name} ===")
+    run_io_worker(t)
+    run_cpu_samples(t)
+    run_cmd_gate(t)
+    run_exit_phantom(t)
+    sys.exit(0 if t.summary() else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_discovery.c
+++ b/tests/test_discovery.c
@@ -179,6 +179,77 @@ int main(void)
         CHECK((uint32_t)readback == 0xC0FFEE42u,
               "read-through-/proc/mem at resolved VA gave 0x%llx, not the magic",
               (unsigned long long)readback);
+
+        /* ── 3. vaddr -> uprobe FILE offset (the T2-study defect-1 class) ──
+         * The daemon computes uprobe file offsets from a symbol's st_value.
+         * The old `va - 0x400000` heuristic was a non-PIE assumption: on PIE
+         * builds the uprobe attached to a dead byte and NEVER fired,
+         * silently. pgwt_vaddr_to_file_offset must translate through the
+         * PT_LOAD program headers for BOTH ELF types (this test runs in the
+         * -pie and -no-pie builds).
+         *
+         * Proof "the offset lands on the symbol": the bytes in the FILE at
+         * the computed offset must equal the bytes in MEMORY at the symbol's
+         * runtime address — for a data object (the magic value) and for a
+         * function (the daemon probes functions). x86_64 text/data are not
+         * relocated in place, so file bytes == memory bytes. */
+        uint64_t data_off = pgwt_vaddr_to_file_offset(exe, sym_val);
+        CHECK(data_off != 0, "vaddr_to_file_offset(data symbol) returned 0");
+
+        FILE *ef = fopen(exe, "rb");
+        CHECK(ef != NULL, "cannot open own binary");
+        if (ef) {
+            /* Offset must land inside the file. */
+            fseek(ef, 0, SEEK_END);
+            long fsz = ftell(ef);
+            CHECK(data_off + 4 <= (uint64_t)fsz,
+                  "data offset 0x%llx beyond file size %ld",
+                  (unsigned long long)data_off, fsz);
+
+            uint32_t file_val = 0;
+            fseek(ef, (long)data_off, SEEK_SET);
+            CHECK(fread(&file_val, 1, 4, ef) == 4 && file_val == 0xC0FFEE42u,
+                  "file bytes at translated offset 0x%llx are 0x%x, not the "
+                  "magic — offset does not land on the symbol",
+                  (unsigned long long)data_off, file_val);
+
+            /* Function symbol — the actual uprobe use case. */
+            uint64_t fn_val = pgwt_find_symbol_offset(exe, "main");
+            CHECK(fn_val != 0, "cannot resolve 'main' in own binary");
+            uint64_t fn_off = pgwt_vaddr_to_file_offset(exe, fn_val);
+            CHECK(fn_off != 0, "vaddr_to_file_offset(function) returned 0");
+            CHECK(fn_off + 16 <= (uint64_t)fsz,
+                  "function offset 0x%llx beyond file size %ld",
+                  (unsigned long long)fn_off, fsz);
+
+            uint8_t file_bytes[16] = {0};
+            fseek(ef, (long)fn_off, SEEK_SET);
+            CHECK(fread(file_bytes, 1, 16, ef) == 16 &&
+                  memcmp(file_bytes, (const void *)(uintptr_t)main, 16) == 0,
+                  "file bytes at fn offset 0x%llx != memory bytes of main() — "
+                  "a uprobe at this offset would land on a dead/wrong byte "
+                  "(the PIE defect class)",
+                  (unsigned long long)fn_off);
+
+            /* The old heuristic must be provably wrong on at least one of
+             * the two builds: on PIE, st_value - 0x400000 (when applicable)
+             * must NOT equal the correct translation. On non-PIE, where
+             * p_offset == p_vaddr - image_base for the classic layout, the
+             * two may coincide — that coincidence is exactly why the bug
+             * shipped. Only assert the divergence where it must exist. */
+#if PGWT_TEST_EXPECT_PIE
+            uint64_t heuristic = fn_val > 0x400000 ? fn_val - 0x400000 : fn_val;
+            CHECK(heuristic != fn_off || fn_val <= 0x400000,
+                  "PIE: heuristic accidentally equals the real offset — "
+                  "fixture no longer covers the defect");
+#endif
+
+            /* A vaddr in no PT_LOAD (way past the image) must return 0. */
+            CHECK(pgwt_vaddr_to_file_offset(exe, 0x7FFFFFFFFFFFULL) == 0,
+                  "unmapped vaddr must translate to 0");
+
+            fclose(ef);
+        }
     }
 
     printf("\n%d/%d tests passed\n", ok, run);

--- a/tests/test_sampler.c
+++ b/tests/test_sampler.c
@@ -70,29 +70,37 @@ static void test_self_read(void)
           (unsigned long long)faults);
 }
 
-/* ── Test 2: build_batch skips on-CPU and encodes fields ──────────────── */
+/* ── Test 2: build_batch encodes fields; gated on-CPU skip is counted ──── */
 
 static void test_build_batch(void)
 {
-    printf("--- build_batch encoding + on-CPU skip ---\n");
+    printf("--- build_batch encoding + gated on-CPU skip ---\n");
 
     struct pgwt_sample_target targets[3] = {
-        { .pid = 1001, .wait_event_addr = 0x1000, .query_id = 111 },
-        { .pid = 1002, .wait_event_addr = 0x2000, .query_id = 222 },
-        { .pid = 1003, .wait_event_addr = 0x3000, .query_id = 333 },
+        { .pid = 1001, .wait_event_addr = 0x1000, .query_id = 111,
+          .backend_type = PGWT_BT_CLIENT },
+        /* client, command NOT open: its we==0 reading is between-command
+         * churn — not recorded, but counted (T2 decision). */
+        { .pid = 1002, .wait_event_addr = 0x2000, .query_id = 222,
+          .backend_type = PGWT_BT_CLIENT, .cmd_open = 0 },
+        { .pid = 1003, .wait_event_addr = 0x3000, .query_id = 333,
+          .backend_type = PGWT_BT_CLIENT },
     };
     uint32_t vals[3] = {
         WEI(PG_WAIT_IO, 0x01),  /* recorded */
-        0,                       /* on CPU — skipped */
+        0,                       /* on CPU, no command — skipped + counted */
         WEI(PG_WAIT_LWLOCK, 0x07),
     };
 
     struct pgwt_trace_event out[3];
     memset(out, 0xAA, sizeof(out));
     uint64_t ts = 0x123456789ABCULL;
-    int n = pgwt_sampler_build_batch(targets, vals, 3, ts, out, NULL);
+    uint64_t noncmd = 0;
+    int n = pgwt_sampler_build_batch(targets, vals, 3, ts, out, NULL, &noncmd);
 
-    CHECK(n == 2, "expected 2 records (1 on-CPU skipped), got %d", n);
+    CHECK(n == 2, "expected 2 records (1 non-command on-CPU skipped), got %d", n);
+    CHECK(noncmd == 1, "expected 1 non-command CPU skip counted, got %llu",
+          (unsigned long long)noncmd);
 
     /* Record 0 = target 0 */
     CHECK(out[0].timestamp_ns == ts, "ts mismatch");
@@ -103,13 +111,82 @@ static void test_build_batch(void)
     CHECK(out[0].duration_ns == 0, "duration must be 0 for samples");
     CHECK(out[0].query_id == 111, "query_id=%llu expected 111",
           (unsigned long long)out[0].query_id);
+    CHECK(out[0].flags == 0, "client sample carries no category flag");
 
-    /* Record 1 = target 2 (target 1 was on-CPU) */
+    /* Record 1 = target 2 (target 1 was gated on-CPU) */
     CHECK(out[1].pid == 1003, "pid=%u expected 1003", out[1].pid);
     CHECK(out[1].new_event == vals[2], "new_event=0x%x expected 0x%x",
           out[1].new_event, vals[2]);
     CHECK(out[1].query_id == 333, "query_id=%llu expected 333",
           (unsigned long long)out[1].query_id);
+}
+
+/* ── Test 2c: the T2 on-CPU policy (docs/AAS_SEMANTICS_DECISION.md) ────── */
+
+static void test_build_batch_cpu_policy(void)
+{
+    printf("--- build_batch on-CPU policy (T2 decomposed AAS) ---\n");
+
+    struct pgwt_sample_target targets[6] = {
+        /* client INSIDE a command: we==0 is a first-class CPU sample */
+        { .pid = 1, .query_id = 42, .backend_type = PGWT_BT_CLIENT,
+          .cmd_open = 1 },
+        /* client outside a command: skipped (counted) */
+        { .pid = 2, .backend_type = PGWT_BT_CLIENT, .cmd_open = 0 },
+        /* background types: we==0 always records (their idle states are
+         * instrumented Activity waits), each with its category flag */
+        { .pid = 3, .backend_type = PGWT_BT_CHECKPOINTER },
+        { .pid = 4, .backend_type = PGWT_BT_AUTOVAC_WORKER },
+        { .pid = 5, .backend_type = PGWT_BT_IO_WORKER },
+        /* parallel workers exist only inside a query: always CPU-recordable,
+         * foreground (no flag) */
+        { .pid = 6, .backend_type = PGWT_BT_PARALLEL_WORKER },
+    };
+    uint32_t vals[6] = { 0, 0, 0, 0, 0, 0 };
+
+    struct pgwt_trace_event out[6];
+    uint64_t noncmd = 0;
+    int n = pgwt_sampler_build_batch(targets, vals, 6, 7, out, NULL, &noncmd);
+
+    CHECK(n == 5, "expected 5 CPU records (1 gated out), got %d", n);
+    CHECK(noncmd == 1, "expected 1 gated skip, got %llu",
+          (unsigned long long)noncmd);
+
+    CHECK(out[0].pid == 1 && out[0].new_event == 0,
+          "in-command client CPU sample recorded as event 0");
+    CHECK(out[0].flags == 0, "client CPU sample is foreground (no flag)");
+    CHECK(out[0].query_id == 42, "CPU sample keeps its query_id");
+
+    CHECK(out[1].pid == 3 && out[1].flags == PGWT_EVENT_FLAG_BACKGROUND,
+          "checkpointer CPU sample flagged BACKGROUND");
+    CHECK(out[2].pid == 4 && out[2].flags == PGWT_EVENT_FLAG_MAINT,
+          "autovacuum worker CPU sample flagged MAINT");
+    CHECK(out[3].pid == 5 && out[3].flags == PGWT_EVENT_FLAG_IO_WORKER,
+          "io_worker CPU sample flagged IO_WORKER");
+    CHECK(out[4].pid == 6 && out[4].flags == 0,
+          "parallel worker CPU sample is foreground (no flag)");
+
+    /* Waits carry the category flag too (an io_worker's DataFileRead must
+     * be excludable from AAS by every consumer). */
+    uint32_t wvals[6] = { WEI(PG_WAIT_IO, 1), WEI(PG_WAIT_IO, 1),
+                          WEI(PG_WAIT_IO, 1), WEI(PG_WAIT_IO, 1),
+                          WEI(PG_WAIT_IO, 1), WEI(PG_WAIT_IO, 1) };
+    n = pgwt_sampler_build_batch(targets, wvals, 6, 8, out, NULL, NULL);
+    CHECK(n == 6, "all wait readings recorded, got %d", n);
+    CHECK(out[4].flags == PGWT_EVENT_FLAG_IO_WORKER,
+          "io_worker WAIT sample flagged IO_WORKER");
+    CHECK(out[1].flags == 0,
+          "client WAIT sample recorded even with command closed");
+
+    /* UNKNOWN type is conservative: gated like a client. */
+    struct pgwt_sample_target unk = { .pid = 9,
+                                      .backend_type = PGWT_BT_UNKNOWN };
+    uint32_t zero = 0;
+    n = pgwt_sampler_build_batch(&unk, &zero, 1, 9, out, NULL, NULL);
+    CHECK(n == 0, "UNKNOWN type we==0 is gated (command closed)");
+    unk.cmd_open = 1;
+    n = pgwt_sampler_build_batch(&unk, &zero, 1, 9, out, NULL, NULL);
+    CHECK(n == 1, "UNKNOWN type we==0 records when command open");
 }
 
 /* ── Test 2b: build_batch drops + counts garbage readings (CAP-2/5) ───── */
@@ -131,7 +208,7 @@ static void test_build_batch_garbage(void)
 
     struct pgwt_trace_event out[3];
     uint64_t invalid = 0;
-    int n = pgwt_sampler_build_batch(targets, vals, 3, 1, out, &invalid);
+    int n = pgwt_sampler_build_batch(targets, vals, 3, 1, out, &invalid, NULL);
 
     CHECK(n == 1, "expected 1 record (2 garbage dropped), got %d", n);
     CHECK(out[0].pid == 2001, "the valid record survived");
@@ -139,7 +216,7 @@ static void test_build_batch_garbage(void)
           (unsigned long long)invalid);
 
     /* NULL counter must not crash and must still drop garbage. */
-    n = pgwt_sampler_build_batch(targets, vals, 3, 1, out, NULL);
+    n = pgwt_sampler_build_batch(targets, vals, 3, 1, out, NULL, NULL);
     CHECK(n == 1, "NULL invalid counter: still 1 record, got %d", n);
 }
 
@@ -409,6 +486,7 @@ int main(void)
     test_self_read();
     test_build_batch();
     test_build_batch_garbage();
+    test_build_batch_cpu_policy();
     test_fallback();
     test_child_read();
     test_local_addr_not_batched();

--- a/tests/test_trace_v2.c
+++ b/tests/test_trace_v2.c
@@ -63,7 +63,11 @@ static void test_mixed_roundtrip(void)
         /* Samples come after the transitions, sorted ascending. */
         samp[i].timestamp_ns = 2000000ULL + (uint64_t)i * SAMPLE_PERIOD;
         samp[i].pid = 2000 + (i % 5);
-        samp[i].new_event = 0x01000000U + (uint32_t)i;  /* sampled event */
+        /* Every 7th sample is a first-class CPU sample (event id 0 — T2):
+         * id 0 must round-trip like any other id, distinguishable from a
+         * transition only by FLAG_SAMPLE. */
+        samp[i].new_event = (i % 7 == 0) ? 0
+                          : 0x01000000U + (uint32_t)i;  /* sampled event */
         /* old_event/duration deliberately set to nonzero garbage to prove
          * the writer ignores them and the reader returns them zeroed. */
         samp[i].old_event = 0xDEADBEEFU;

--- a/tests/test_uprobe_fired.py
+++ b/tests/test_uprobe_fired.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""test_uprobe_fired.py — T2 item 0: the uprobes must actually FIRE.
+
+The defect class this guards (T2 io_worker study, defect 1): uprobe file
+offsets were computed as `va - 0x400000` (a non-PIE assumption). On PIE
+builds (PGDG Ubuntu/EL9) the attach SUCCEEDED but the probe sat on a dead
+byte and never fired — bpftool showed run_cnt = 0 for on_report_query_id
+while USDT probes ran 61,869x in the same trace. Attribution was silently
+zero; nothing went red. This test makes that class un-shippable:
+
+  - kernel.bpf_stats_enabled=1 so the kernel counts per-program runs;
+  - the tracer runs in --mode tiered (de-escalated: USDT probes are NOT
+    attached, so the uprobes are the ONLY query/activity path);
+  - a handful of psql statements execute (each one calls
+    pgstat_report_activity and, on PG14+, pgstat_report_query_id);
+  - `bpftool prog show` must report run_cnt > 0 for:
+      * the query-id uprobe (on_report_query_id, or on_executor_start on
+        PG13's pg_stat_statements route), and
+      * the T2 command-open gate uprobe (on_report_activity).
+
+Usage: sudo python3 tests/test_uprobe_fired.py [--pid PM_PID]
+           [--pg-version N] [--bpftool PATH]
+"""
+import argparse
+import os
+import re
+import subprocess
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from testutil import find_postmaster
+
+PROJECT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+TRACER = os.path.join(PROJECT_DIR, "pg_wait_tracer")
+
+tests_run = 0
+tests_failed = 0
+
+
+def check(cond, msg):
+    global tests_run, tests_failed
+    tests_run += 1
+    if cond:
+        print(f"  PASS: {msg}")
+    else:
+        tests_failed += 1
+        print(f"  FAIL: {msg}")
+
+
+def psql(sql):
+    return subprocess.run(
+        ["psql", "-U", "postgres", "-d", "postgres", "-tAc", sql],
+        capture_output=True, text=True, timeout=15).stdout.strip()
+
+
+def prog_run_counts(bpftool):
+    """Parse `bpftool prog show`: BPF object names are truncated to 15
+    chars by the kernel, so match on prefixes. Returns {name: run_cnt}."""
+    out = subprocess.run([bpftool, "prog", "show"],
+                         capture_output=True, text=True, timeout=15).stdout
+    counts = {}
+    for block in out.split("\n\n"):
+        m = re.search(r'\bname\s+(\S+)', block)
+        if not m:
+            continue
+        r = re.search(r'\brun_cnt\s+(\d+)', block)
+        counts[m.group(1)] = int(r.group(1)) if r else 0
+    return counts
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--pid', type=int)
+    parser.add_argument('--pg-version', type=int, default=0)
+    parser.add_argument('--bpftool', default=os.environ.get('BPFTOOL',
+                                                            'bpftool'))
+    args = parser.parse_args()
+
+    if os.geteuid() != 0:
+        print("ERROR: must run as root (sudo)")
+        sys.exit(1)
+    bpf_ok = subprocess.run([args.bpftool, "version"],
+                            capture_output=True).returncode == 0
+    if not bpf_ok:
+        print(f"ERROR: bpftool not usable ({args.bpftool}) — pass --bpftool "
+              "or set BPFTOOL; this assertion must not silently skip")
+        sys.exit(1)
+
+    pm_pid = args.pid or find_postmaster()
+    if not pm_pid:
+        print("ERROR: cannot find postmaster")
+        sys.exit(1)
+
+    print(f"=== test_uprobe_fired (postmaster {pm_pid}, "
+          f"pg-version {args.pg_version or 'auto'}) ===")
+
+    stats_path = "/proc/sys/kernel/bpf_stats_enabled"
+    with open(stats_path) as f:
+        prev_stats = f.read().strip()
+    with open(stats_path, "w") as f:
+        f.write("1\n")
+
+    tracer = subprocess.Popen(
+        [TRACER, "--mode", "tiered", "--pid", str(pm_pid),
+         "--duration", "10", "--quiet", "--interval", "5"],
+        stdout=subprocess.DEVNULL, stderr=subprocess.PIPE)
+    try:
+        time.sleep(3.0)   # BPF load + attach + initial scan
+        # Each statement drives pgstat_report_activity (RUNNING then IDLE)
+        # and the per-version query-id path.
+        for i in range(10):
+            psql(f"SELECT {i} + count(*) FROM generate_series(1, 1000)")
+        time.sleep(1.0)
+
+        # Read run counts WHILE the tracer still holds the programs.
+        counts = prog_run_counts(args.bpftool)
+    finally:
+        try:
+            tracer.wait(timeout=15)
+        except subprocess.TimeoutExpired:
+            tracer.kill()
+        with open(stats_path, "w") as f:
+            f.write(prev_stats + "\n")
+
+    err = tracer.stderr.read().decode('utf-8', errors='replace')
+
+    def cnt(prefix):
+        return sum(v for k, v in counts.items() if k.startswith(prefix))
+
+    # Command-open gate uprobe (T2 item 1) — every PG version.
+    activity = cnt("on_report_activ")
+    check(activity > 0,
+          f"on_report_activity uprobe FIRED (run_cnt={activity}) "
+          f"[T2 gate probe; dead-offset class]"
+          + ("" if activity else
+             f" (progs seen: {sorted(counts)}; stderr tail: {err[-300:]!r})"))
+
+    # Query-id uprobe — version-dependent symbol (PG13: pgss route).
+    if args.pg_version == 13:
+        qid = cnt("on_executor_sta")
+        check(qid > 0,
+              f"on_executor_start uprobe FIRED on PG13 (run_cnt={qid}) "
+              f"[study defect 1: run_cnt was 0 on PIE builds]")
+    else:
+        qid = cnt("on_report_query")
+        check(qid > 0,
+              f"on_report_query_id uprobe FIRED (run_cnt={qid}) "
+              f"[study defect 1: run_cnt was 0 on PIE builds]")
+
+    print(f"\n{tests_run - tests_failed}/{tests_run} checks passed")
+    sys.exit(0 if tests_failed == 0 else 1)
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/test_uprobe_fired.py
+++ b/tests/test_uprobe_fired.py
@@ -55,17 +55,27 @@ def psql(sql):
 
 
 def prog_run_counts(bpftool):
-    """Parse `bpftool prog show`: BPF object names are truncated to 15
-    chars by the kernel, so match on prefixes. Returns {name: run_cnt}."""
+    """Parse `bpftool prog show`: entries are contiguous lines (no blank
+    separators) — a header line `<id>: <type>  name <name>  tag ...` with
+    `run_time_ns X run_cnt Y` appended when bpf_stats is enabled, followed
+    by indented detail lines. Parse statefully per line. BPF object names
+    are truncated to 15 chars by the kernel, so callers match prefixes.
+    Returns {name: run_cnt}."""
     out = subprocess.run([bpftool, "prog", "show"],
                          capture_output=True, text=True, timeout=15).stdout
     counts = {}
-    for block in out.split("\n\n"):
-        m = re.search(r'\bname\s+(\S+)', block)
-        if not m:
+    current = None
+    for line in out.splitlines():
+        if re.match(r'^\d+:', line):
+            m = re.search(r'\bname\s+(\S+)', line)
+            current = m.group(1) if m else None
+            if current is not None:
+                counts.setdefault(current, 0)
+        if current is None:
             continue
-        r = re.search(r'\brun_cnt\s+(\d+)', block)
-        counts[m.group(1)] = int(r.group(1)) if r else 0
+        r = re.search(r'\brun_cnt\s+(\d+)', line)
+        if r:
+            counts[current] = max(counts[current], int(r.group(1)))
     return counts
 
 
@@ -103,7 +113,7 @@ def main():
 
     tracer = subprocess.Popen(
         [TRACER, "--mode", "tiered", "--pid", str(pm_pid),
-         "--duration", "10", "--quiet", "--interval", "5"],
+         "--duration", "15", "--quiet", "--interval", "5"],
         stdout=subprocess.DEVNULL, stderr=subprocess.PIPE)
     try:
         time.sleep(3.0)   # BPF load + attach + initial scan
@@ -114,7 +124,12 @@ def main():
         time.sleep(1.0)
 
         # Read run counts WHILE the tracer still holds the programs.
+        check(tracer.poll() is None,
+              "tracer still running when run counts are read")
         counts = prog_run_counts(args.bpftool)
+        check(any(k.startswith("on_") for k in counts),
+              f"tracer's BPF programs visible to bpftool "
+              f"(saw {sorted(counts)[:12]})")
     finally:
         try:
             tracer.wait(timeout=15)


### PR DESCRIPTION
## Phase T2 — AAS semantics: one definition, all paths (Trust Milestone)

Implements `docs/AAS_SEMANTICS_DECISION.md` (gate decision, PR #40) end to end. Owns findings **AAS-1** and **SMP-5**; fixes the two registered defects from the study and verifies the third.

**The headline (AAS-1):** the sampler skipped every `we==0` reading and no coverage-derived CPU existed anywhere — sampled AAS measured *waiting sessions*, not active sessions. A pure CPU storm produced AAS ≈ 0.017 for a machine-saturating workload (study Q4: −29% I/O-bound → −71% convoy → −≥98% CPU storm) and the anomaly engine was blind to exactly the CPU-incident class. Now: **active = non-idle wait OR on-CPU**, decomposed into visible categories, identical across tiers.

### 0. Prerequisite fix — PIE uprobe attach offsets (study defect 1)

`daemon.c` computed uprobe file offsets as `va − 0x400000`. On PIE builds (PGDG Ubuntu/EL9) the attach "succeeded" and the probe never fired — `on_report_query_id` run_cnt = 0 while USDT probes ran 61,869× in the same trace; query attribution was silently ~zero, and the breakpoint byte sat at an arbitrary spot in hot text.

- `pgwt_vaddr_to_file_offset()`: PT_LOAD program-header translation (`offset = vaddr − p_vaddr + p_offset`), correct for ET_EXEC and ET_DYN; `p_filesz`-bounded so a `.bss` vaddr can never become a probe offset. Both uprobe attach sites use it; translation failure WARNs loudly.
- Unit tests in the T0 `-pie`/`-no-pie` builds of `test_discovery`: the translated offset of a data symbol and of a function must land inside the file AND the file bytes there must equal the memory bytes at the symbol's runtime address.
- CI: new `test_uprobe_fired.py` smoke section (every cell) — with `kernel.bpf_stats_enabled=1`, `bpftool` run_cnt must be > 0 for the query-id uprobe (PG13: `on_executor_start`) and the new gate uprobe, while a tiered tracer (no USDT attached) runs. This class can no longer ship silently.

### 1. Command-open gate (client backends)

New `on_report_activity` uprobe on `pgstat_report_activity(state, …)` — the function PostgreSQL itself uses to drive `pg_stat_activity.state` — maintains a per-pid `cmd_open` flag in the BPF state_map. Open = `STATE_RUNNING`/`STATE_FASTPATH` (query message received → command complete: parse, plan, bind, execute, commit/abort). Enum values are per-version rodata: **PG13–17 = 2/4; PG18 = 3/5** (`STATE_STARTING` was inserted in PG18 — verified against `REL_13/16/17/18_STABLE` headers, and empirically by the smoke matrix). The symbol is exported (postgres links `--export-dynamic`), so stripped PGDG builds resolve it from `.dynsym`.

Failure mode is honest and loud: gate unavailable → client CPU is **not** recorded (under-count + WARN), never the ungated ~3× over-count the study measured on chatty OLTP. While a watchpoint is live, gate flips are recorded as `CMD_START`/`CMD_END` markers (0xFFFFFFF6/F7) so the exact tier carries the same command window. Documented cold-start edge: a command already in flight at attach contributes CPU only from its next statement (waits are unaffected).

### 2. Sampler records CPU samples

`we==0` readings become first-class CPU samples — **event id 0 in SAMPLES blocks** (never written before; zero format change, old traces read back identically, documented in the block-format comments):

- client (and UNKNOWN) backends: only while `cmd_open` — gated skips are counted (`noncmd_cpu_samples_total`), never recorded;
- background types (checkpointer, bgwriter, walwriter, autovacuum/parallel/io workers…): always — their parked states are instrumented Activity-class waits.

The sampled-tier fork path now lazily classifies backends via `/proc` cmdline once init completes and writes `backends.jsonl` — previously forked backends in sampled mode were **never classified nor recorded in metadata at all** (everything read as type 0 = client). In-memory category flags (never persisted) stamp each sample for the anomaly engine and live accumulator.

### 3. Categories (the decomposed model)

One tagging pass (`pgwt_tag_events`) annotates every merged window: pid categories from `backends.jsonl`, PLAN/EXEC marker sub-windows, and the command gate. Exact `we==0` intervals majority-outside a CMD window are reclassified to a synthetic Activity-class id (`NonCommandCpu`) — idle, excluded-but-recorded — the same definition the sampled tier captured with, so **AAS shows no step at tier switches**. Pids without CMD markers (legacy traces, background processes) keep all `we==0` as CPU.

Views (additive, raw path; summaries carry no category data — documented scope cut):
- `aas` buckets gain a nested `cat` object: `planning / execution / command / maintenance / background / io_worker`;
- `time_model` gains `categories` rows + `io_worker_busy_pct`;
- mirrored in `mock_server.py` — protocol-drift green.

Parallel workers: the cheap documented version — counted foreground/execution under their own query_id (`leader_pid` is parsed but not yet written to `backends.jsonl`; leader roll-up is a documented gap). Sampled-tier phase attribution is the cheap version too: foreground samples with a query_id = execution, without = command overhead.

### 4. io_workers: excluded from AAS/DB Time, surfaced as utilization

Per the measured decision (double-counts the same I/O 2.0×, +60% AAS inflation, structurally query-less): io_worker records never enter class AAS, `max_aas`, DB Time, `top_events`, `top_sessions`, `top_queries` — in either tier. Exact traces still record them (nothing dropped; exclusion is a compute-time category tag; they remain in raw views and their own `cat` slot). `io_worker_busy_pct` (busy = non-`IoWorkerMain` time / workers × wall) is on the control-socket `metrics` and in `time_model`.

### 5. Anomaly engine sees CPU

`pgwt_anomaly_metrics_from_batch`: CPU samples count as active; io_worker records don't. Unit tests: a sustained CPU-storm batch FIRES the AAS rule; an identical io_worker-only storm never does. CI phase 6: a real SELECT storm must fire anomaly escalation (`anomaly_fires_total ≥ 1` via the control socket) — the trigger *rules* themselves are untouched (T3).

### 6. Exit-record phantom CPU (study defect 2) — root cause + backstop

Root cause: BPF `on_exit` "closed the last interval" from state_map entries that were only sampled-tier **seeds** (query-id carriers) — `last_ts` was the seed time, so every disconnect back-filled the backend's whole sampled lifetime as one interval labeled CPU (rC2: 4 clients × 120 s of phantom CPU in a trace whose sampler saw 0.017 AAS).

Fix: `pgwt_pid_state.wp_live` — set only while a live watchpoint maintains the interval state (preseed/first fire), cleared on sampled seeds and de-escalation resets. `on_exit` closes an interval only when `wp_live`; `on_watchpoint` defensively promotes a seed entry without fabricating an interval. Consumer backstop for already-recorded traces: the exact-wins merge drops EXIT intervals whose midpoint lies outside exact coverage in a generation with sampled coverage. Regression-tested with a synthetic defect-2-shaped trace.

### 7. Third registered defect — verdict: already fixed by T1

In-trace samples/exact overlap (observed pre-T1): T1's marker-authoritative exact-wins merge covers exactly this shape. `test_data_fidelity` §3 (mixed-window merge, no double counting) and `test_data_esc_coverage` (FID-1: long wait spanning an escalation window) reproduce it and stay green on this branch. **No further fix needed.**

### 8. Cross-validation

`cross_validate` now compares CPU-inclusive AAS: samples with `we==0` count as CPU; exact `we==0` intervals are gated by the same per-pid CMD-marker sweep — without this the two sides would diverge by construction on chatty workloads. The pg_stat_io cross-check (`test_accuracy` Test 3) already compared **counts** (0.1–3.0 with timing slack), never a 0.80-style time ratio; the study-Q3 rationale is now documented in place so a time ratio can't be reintroduced.

### SMP-5 (owned by T2)

Sampler timer is now armed one-shot with ±10% phase jitter per tick (anti-aliasing against periodic workloads); total sample weight is unaffected (SMP-3 measured-elapsed weighting).

### Definition of done (plan) — how each is enforced in CI

- *SELECT-storm CPU incident raises sampled AAS and can trigger escalation*: smoke phase 6 (fires + escalates) + anomaly unit tests.
- *AAS shows no step artifact at tier switches*: phase 6 asserts every interior bucket across the sampled→exact switch carries the storm; synthetic `test_data_categories` asserts the CMD-gate classification that makes the definitions converge.
- *Sampled AAS matches pg_stat_activity ground truth in CI*: phase 5 — trace-derived CPU-inclusive AAS vs 0.5 s `pg_stat_activity` sampling of a 3-hog storm + pg_sleep, pure sampled tier.

### Tests

New: `test_data_categories.py` (26 checks: io_worker exclusion end-to-end, categories, CPU samples raise sampled AAS/DB Time and attribute to queries, CMD-gate classification, exit-phantom drop); `test_uprobe_fired.py`; sampler CPU-policy matrix; anomaly CPU-storm/io_worker tests; SAMPLES id-0 round-trip; PIE/non-PIE offset-translation tests. Updated: `test_data_aas` (category dimension), `mock_server.py`, `cross_validate`, `run_all.sh`. All existing suites green: C units, synthetic data, protocol-drift, web-ui (198/198 + 13/13 snapshots).

### Explicit scope cuts (documented)

- Category fields are raw-path only; the ≥120 s exact-window summary fast path returns responses without them (summary format is T5 territory).
- CLI `--replay` keeps pre-T2 CPU semantics (no category tagging offline in the daemon binary); pgwt-server is the analysis path.
- Parallel-worker leader attribution: counted in foreground/execution under their own query_id; leader roll-up needs `leader_pid` in `backends.jsonl` (future).
- Escalation/budget/trigger rules untouched (T3); the ESC-3 live double-count tolerance in the smoke stays as T0 left it.
