### PR TITLE
T3: escalation budget & trigger quality (ESC-1..12)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ tests/test_event_reader
 tests/test_trace_v2
 tests/test_sampler
 tests/test_anomaly
+tests/test_escalation_budget
 tests/test_coop
 tests/test_pg13_resolve
 tests/test_discovery_pie

--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,7 @@ USER_SRCS  = $(SRC_DIR)/pg_wait_tracer.c \
              $(SRC_DIR)/provider_coop.c \
              $(SRC_DIR)/sampler.c \
              $(SRC_DIR)/escalation.c \
+             $(SRC_DIR)/escalation_budget.c \
              $(SRC_DIR)/anomaly.c \
              $(SRC_DIR)/backend.c \
              $(SRC_DIR)/discovery.c \

--- a/README.md
+++ b/README.md
@@ -171,14 +171,45 @@ A full-fidelity window can be opened two ways:
   AAS exceeding a multiple of its rolling baseline (`--anomaly-aas-factor`,
   default 3.0× sustained `--anomaly-aas-ticks` ticks, default 3), or the
   Lock-class share of active samples exceeding `--anomaly-lock-fraction`
-  (default 0.30). A cooldown (`--anomaly-cooldown-s`, default 120) prevents
-  flapping.
+  (default 0.30) **and** the absolute Lock-class AAS exceeding
+  `--anomaly-lock-min-aas` (default 2.0). The lock floor stops a single
+  backend's routine row-lock wait — a lock-fraction of 1.0 over an AAS of 1 —
+  from burning a whole window on OLTP noise; a genuine lock convoy still fires.
+  A cooldown (`--anomaly-cooldown-s`, default 120) prevents flapping.
+
+The rolling AAS baseline is **frozen while a metric is anomalous** so a
+sustained incident cannot silently raise the bar and silence the rule. To keep
+a *legitimate* load regime change from re-firing forever, the baseline resumes
+learning — at 1/10 the normal EWMA rate — only after the metric has stayed
+continuously over the threshold for **15 minutes** (the "slow learn-through"):
+short incidents never move the bar, a real new normal is eventually adopted.
 
 Every window is bounded: per-window length is set by the request (or
 `--anomaly-window-s`, default 60, for auto-triggers), and total escalation time
-is capped by `--escalation-budget` (default 300s per rolling hour). When the
-budget is exhausted, further escalations are denied (and counted in the
-self-metrics).
+is capped by `--escalation-budget` per rolling hour:
+
+- **`300`** *(default)* — 300 full-fidelity seconds per rolling hour. A request
+  larger than the remaining budget is **clamped** to what's left (the window
+  runs up to the cap), and mid-window enforcement closes a window the instant
+  cumulative consumption reaches the budget, so worst-case full-fidelity time
+  per hour never exceeds the budget even under adversarial repeated extensions.
+- **`0`** — escalation **disabled** (every escalate request is denied). The
+  self-metrics honestly report `0` budget remaining.
+- **`unlimited`** — no cap (the old `0` behavior). Reported as
+  `escalation_budget_unlimited: true`.
+
+When the budget is exhausted, further escalations are denied (and counted in the
+self-metrics). Note the duty-cycle floor: the cooldown is measured from the
+*start* of each auto-escalation, so a sustained incident re-fires every
+`--anomaly-cooldown-s` (default 120s) for a `--anomaly-window-s` (default 60s)
+window — a **50% full-fidelity duty cycle** on a persistent incident, and still
+bounded above by the budget (which will curtail it sooner). Widen the cooldown
+or shrink the window to lower the duty cycle; the sampled tier keeps full
+coverage throughout regardless. On very high backend counts the synchronous
+watchpoint `attach_all` at escalation start can briefly stall the sampler; the
+lost ticks are weight-compensated (each tick is billed by measured elapsed
+time), so the accounting stays correct — only time resolution dips for that
+instant.
 
 ```bash
 # Open a 120s full-fidelity window on a running daemon via the control socket
@@ -445,7 +476,7 @@ per interval, no screen clearing).
 |------|-------|---------|-------------|
 | `--mode <MODE>` | — | `tiered` | Capture tier: `tiered` (always-on sampler + on-demand escalation), `sampled`, `full` (exact watchpoints), `coop` (stub). See [Capture Tiers](#capture-tiers---mode) |
 | `--sample-rate <HZ>` | — | `10` | Sampling rate for `sampled`/`tiered` (1-1000 Hz) |
-| `--escalation-budget <S>` | — | `300` | `tiered`: full-fidelity seconds allowed per rolling hour (0 disables the limit) |
+| `--escalation-budget <S>` | — | `300` | `tiered`: full-fidelity seconds allowed per rolling hour. `0` = escalation **disabled** (deny all); `unlimited` = no cap. Over-budget requests are clamped to the remainder; enforced mid-window. |
 
 ### Anomaly Triggers (tiered mode)
 
@@ -457,6 +488,7 @@ Auto-escalation rules evaluated on the sampled stream. Ignored outside
 | `--anomaly-aas-factor <K>` | — | `3.0` | Fire when AAS > K × rolling baseline |
 | `--anomaly-aas-ticks <N>` | — | `3` | ...sustained for N consecutive ticks |
 | `--anomaly-lock-fraction <F>` | — | `0.30` | Fire when Lock-class share of active samples > F (sustained N ticks) |
+| `--anomaly-lock-min-aas <A>` | — | `2.0` | ...**and** absolute Lock-class AAS ≥ A (min-activity floor: a lone lock waiter can't escalate) |
 | `--anomaly-cooldown-s <S>` | — | `120` | Minimum seconds between auto-escalations |
 | `--anomaly-window-s <S>` | — | `60` | Full-fidelity window length per auto-trigger |
 

--- a/docs/TRUST_MILESTONE_PLAN.md
+++ b/docs/TRUST_MILESTONE_PLAN.md
@@ -192,6 +192,50 @@ Each finding notes the phase that owns it.
   window(60 s) = 50% duty cycle on sustained incidents. Document the
   chosen semantics; fix SMP-3 makes the stall at least weighted.
 
+### ESC resolution (T3, branch t3-escalation-trust)
+
+All ESC-1..12 fixed / documented. Pure cores unit-tested
+(`tests/test_escalation_budget.c` = budget/ledger, extended
+`tests/test_anomaly.c` = lock floor + slow-release), integration in
+`test_escalation.sh` / `test_control.sh`, live in the capture-smoke
+escalation phase.
+
+- **ESC-1** — budget math moved to a pure, unit-tested core
+  (`src/escalation_budget.c`). An over-ask is **clamped** to the
+  remaining budget and the window's deadline is armed at `now + grant`,
+  so extend-every-second caps total full-fidelity time at *exactly* the
+  budget; `pgwt_escalation_check_budget()` (daemon timer) is the
+  mid-window backstop.
+- **ESC-2** — `flush_open_intervals()` writes each open wait as a final
+  transition (ts = de-escalation instant) *before* detach + END marker.
+- **ESC-3** — `pgwt_sampler_accumulate()` skips pids with a live
+  watchpoint while escalated; smoke-test live-view tolerance tightened
+  from 7 s back to 6 s.
+- **ESC-4** — lock rule needs BOTH `lock_fraction > F` AND lock-class
+  `AAS ≥ --anomaly-lock-min-aas` (default **2.0**).
+- **ESC-5** — ledger overflow coalesces the two oldest segments
+  (bills the gap, never under-bills); a window is never opened unbilled.
+- **ESC-6** — `--escalation-budget 0` = **deny-all** (honest `0`
+  remaining); `unlimited` (or `-1`) = no cap (`escalation_budget_
+  unlimited: true`, remaining = `-1` sentinel = ∞ in the UI).
+- **ESC-7** constants — baseline stays frozen while over threshold;
+  **slow learn-through** engages only after **15 min**
+  (`PGWT_ANOMALY_DEF_LEARN_THROUGH_MIN`) continuously-over, then learns
+  at **1/10** the normal EWMA rate
+  (`PGWT_ANOMALY_DEF_SLOW_RELEASE_DIV`). Short incidents never move the
+  bar; a real regime change is eventually adopted. Both pinned in tests.
+- **ESC-8** — near-trigger log rate-limited to reason-mask changes + a
+  60 s summary (with suppressed count); `anomaly_near_total` still
+  counts every one.
+- **ESC-9** — `metrics.tier` and `status.tier` share `daemon_tier_str()`
+  (a fixed EXACT provider reports `escalated`, never a bogus `sampled`).
+- **ESC-10** — control-socket liveness probe: a live daemon on the trace
+  dir makes a second daemon **refuse startup** (fatal, rc −2) instead of
+  stealing the socket.
+- **ESC-11/12** — documented in README: the ~50% duty cycle (cooldown
+  from fire start) and the weight-compensated `attach_all` stall bound
+  (SMP-3 keeps the accounting correct; only resolution dips).
+
 ## FID — Fidelity merge, summaries, views
 
 - **FID-1 🔴 (T1)** `src/server.c:554-567,713-722` — exact-wins

--- a/src/anomaly.c
+++ b/src/anomaly.c
@@ -65,9 +65,11 @@ void pgwt_anomaly_init(struct pgwt_anomaly *a, bool enabled,
     a->aas_factor    = PGWT_ANOMALY_DEF_AAS_FACTOR;
     a->aas_ticks     = PGWT_ANOMALY_DEF_AAS_TICKS;
     a->lock_fraction = PGWT_ANOMALY_DEF_LOCK_FRAC;
+    a->lock_min_aas  = PGWT_ANOMALY_DEF_LOCK_MIN_AAS;
     a->lock_ticks    = PGWT_ANOMALY_DEF_LOCK_TICKS;
     a->cooldown_ns   = (uint64_t)PGWT_ANOMALY_DEF_COOLDOWN_S * 1000000000ULL;
     a->escalation_s  = PGWT_ANOMALY_DEF_ESCALATE_S;
+    a->slow_release_div = PGWT_ANOMALY_DEF_SLOW_RELEASE_DIV;
 
     /* Baseline EWMA: pick alpha so the baseline has roughly a 60-second
      * memory regardless of tick rate. With one update per tick, a half-life
@@ -81,6 +83,13 @@ void pgwt_anomaly_init(struct pgwt_anomaly *a, bool enabled,
     a->warmup_needed   = 5 * hz;        /* ~5 seconds of normal data */
     a->baseline_aas    = 0.0;
     a->baseline_warmup = 0;
+
+    /* ESC-7: continuously-over duration before the baseline starts learning
+     * through a sustained regime change (in ticks at this rate). */
+    a->learn_through_ticks =
+        PGWT_ANOMALY_DEF_LEARN_THROUGH_MIN * 60 * hz;
+    if (a->slow_release_div <= 0)
+        a->slow_release_div = PGWT_ANOMALY_DEF_SLOW_RELEASE_DIV;
 }
 
 struct pgwt_anomaly_decision
@@ -113,8 +122,16 @@ pgwt_anomaly_eval(struct pgwt_anomaly *a, double aas, double lock_fraction,
         a->aas_over_streak = 0;
     bool aas_fire = aas_over && (a->aas_over_streak >= a->aas_ticks);
 
-    /* ── Lock-class fraction rule ──────────────────────────────────────── */
-    bool lock_over = (a->lock_fraction > 0.0) && (lock_fraction > a->lock_fraction);
+    /* ── Lock-class fraction rule (ESC-4: with a min-activity floor) ────── */
+    /* Fraction alone fires on a single backend's routine 300 ms row-lock wait
+     * (fraction 1.0 of 1 active session), duty-cycling the whole budget away
+     * on OLTP noise. Require BOTH a high lock share AND an absolute lock-class
+     * AAS floor (lock_aas = fraction * aas) so a lone waiter cannot trip it but
+     * a real convoy does — the lock analogue of the AAS rule's aas>=2 floor. */
+    double lock_aas = lock_fraction * aas;
+    bool lock_over = (a->lock_fraction > 0.0)
+                  && (lock_fraction > a->lock_fraction)
+                  && (lock_aas >= a->lock_min_aas);
     if (lock_over)
         a->lock_over_streak++;
     else
@@ -134,6 +151,15 @@ pgwt_anomaly_eval(struct pgwt_anomaly *a, double aas, double lock_fraction,
         a->baseline_aas += (aas - a->baseline_aas) / w;
     } else if (!aas_over) {
         a->baseline_aas += a->baseline_alpha * (aas - a->baseline_aas);
+    } else if (a->learn_through_ticks > 0
+               && a->aas_over_streak >= a->learn_through_ticks) {
+        /* ESC-7: the metric has been continuously over for the sustained-over
+         * horizon — treat it as a legitimate regime change and learn through
+         * at a reduced rate so the rule stops re-firing forever, without
+         * letting a short incident (streak below the horizon) move the bar. */
+        int div = a->slow_release_div > 0 ? a->slow_release_div : 1;
+        a->baseline_aas += (a->baseline_alpha / (double)div)
+                         * (aas - a->baseline_aas);
     }
     d.baseline = a->baseline_aas;
 
@@ -220,21 +246,44 @@ void pgwt_anomaly_tick(struct pgwt_daemon *d,
     char rb[32];
     switch (dec.action) {
     case PGWT_ANOMALY_NONE:
+        /* A quiet tick ends the near run; the next near-trigger, even with the
+         * same reason mask, is fresh news and logs immediately (ESC-8). */
+        a->last_near_mask = PGWT_NEAR_NONE;
         break;
 
-    case PGWT_ANOMALY_NEAR:
-        /* Log EVERY near-trigger so thresholds can be tuned from data. This is
-         * the observability requirement (D5.4): a metric crossed but cooldown
-         * / budget / sustain blocked the fire. */
-        fprintf(stderr,
-                "INFO: anomaly near-trigger: aas=%.1f baseline=%.2f "
-                "lock_frac=%.2f%s%s%s%s\n",
-                dec.aas, dec.baseline, dec.lock_fraction,
-                (dec.near_mask & PGWT_NEAR_AAS_SUSTAIN) ? " [aas-sustain]" : "",
-                (dec.near_mask & PGWT_NEAR_LOCK_SUSTAIN) ? " [lock-sustain]" : "",
-                (dec.near_mask & PGWT_NEAR_COOLDOWN) ? " [cooldown]" : "",
-                (dec.near_mask & PGWT_NEAR_BASELINE) ? " [baseline-warmup]" : "");
+    case PGWT_ANOMALY_NEAR: {
+        /* ESC-8: near-triggers can recur every tick (up to 10 lines/s) — that
+         * floods the log while telling the operator nothing new. Rate-limit to
+         * one line per CHANGE of the near reason mask, plus a periodic summary
+         * (with a suppressed-count) at most once a minute, so the tuning value
+         * of the data is kept (near_total already counts every one for the
+         * control socket) without the flood. */
+        const uint64_t NEAR_SUMMARY_NS = 60ULL * 1000000000ULL;
+        bool mask_changed = (dec.near_mask != a->last_near_mask);
+        bool summary_due = (a->last_near_log_ns == 0)
+                        || (now - a->last_near_log_ns >= NEAR_SUMMARY_NS);
+        if (mask_changed || summary_due) {
+            char since[48] = "";
+            if (a->near_since_log > 0)
+                snprintf(since, sizeof(since), " (+%llu suppressed)",
+                         (unsigned long long)a->near_since_log);
+            fprintf(stderr,
+                    "INFO: anomaly near-trigger: aas=%.1f baseline=%.2f "
+                    "lock_frac=%.2f%s%s%s%s%s\n",
+                    dec.aas, dec.baseline, dec.lock_fraction,
+                    (dec.near_mask & PGWT_NEAR_AAS_SUSTAIN) ? " [aas-sustain]" : "",
+                    (dec.near_mask & PGWT_NEAR_LOCK_SUSTAIN) ? " [lock-sustain]" : "",
+                    (dec.near_mask & PGWT_NEAR_COOLDOWN) ? " [cooldown]" : "",
+                    (dec.near_mask & PGWT_NEAR_BASELINE) ? " [baseline-warmup]" : "",
+                    since);
+            a->last_near_mask = dec.near_mask;
+            a->last_near_log_ns = now;
+            a->near_since_log = 0;
+        } else {
+            a->near_since_log++;
+        }
         break;
+    }
 
     case PGWT_ANOMALY_FIRE: {
         int granted = 0;

--- a/src/anomaly.h
+++ b/src/anomaly.h
@@ -86,9 +86,19 @@ struct pgwt_anomaly {
     double aas_factor;        /* fire when aas > factor * baseline */
     int    aas_ticks;         /* consecutive ticks the AAS rule must hold */
     double lock_fraction;     /* fire when lock share > this */
+    double lock_min_aas;      /* ESC-4: AND lock-class AAS >= this (min-activity floor) */
     int    lock_ticks;        /* consecutive ticks the lock rule must hold */
     uint64_t cooldown_ns;     /* min gap between auto-escalations */
     int    escalation_s;      /* duration requested per auto-escalation */
+
+    /* ESC-7 baseline slow learn-through: after the AAS metric has been
+     * continuously over the multiplicative threshold for learn_through_ticks,
+     * the baseline resumes EWMA at 1/slow_release_div the normal rate, so a
+     * sustained legitimate regime change is eventually adopted (the rule stops
+     * re-firing forever) while a short incident (streak < learn_through_ticks)
+     * still cannot raise the bar. */
+    int    learn_through_ticks; /* consecutive over-ticks before learn-through */
+    int    slow_release_div;    /* EWMA rate divisor while learning through */
 
     /* Rolling-baseline (EWMA) state for the AAS rule. The baseline tracks the
      * NORMAL load; it is NOT updated while a metric is anomalous (so a long
@@ -105,6 +115,12 @@ struct pgwt_anomaly {
     /* Cooldown: monotonic ns of the last auto-escalation (0 = never). */
     uint64_t last_fire_ns;
 
+    /* ESC-8 near-trigger log rate-limit (daemon wrapper only): log on a change
+     * of the near reason mask + a periodic summary, not every tick. */
+    unsigned last_near_mask;    /* near_mask at the last emitted near-log */
+    uint64_t last_near_log_ns;  /* monotonic ns of the last near-log line */
+    uint64_t near_since_log;    /* near-triggers suppressed since the last line */
+
     /* Lifetime stats (control-socket metrics). */
     uint64_t fires_total;       /* auto-escalations actually requested */
     uint64_t near_total;        /* near-triggers logged */
@@ -116,9 +132,13 @@ struct pgwt_anomaly {
 #define PGWT_ANOMALY_DEF_AAS_FACTOR   3.0
 #define PGWT_ANOMALY_DEF_AAS_TICKS    3
 #define PGWT_ANOMALY_DEF_LOCK_FRAC    0.30
+#define PGWT_ANOMALY_DEF_LOCK_MIN_AAS 2.0   /* ESC-4: min lock-class AAS to fire */
 #define PGWT_ANOMALY_DEF_LOCK_TICKS   3
 #define PGWT_ANOMALY_DEF_COOLDOWN_S   120
 #define PGWT_ANOMALY_DEF_ESCALATE_S   60
+/* ESC-7 baseline slow learn-through (see struct comment). */
+#define PGWT_ANOMALY_DEF_LEARN_THROUGH_MIN 15  /* minutes continuously-over before learn-through */
+#define PGWT_ANOMALY_DEF_SLOW_RELEASE_DIV  10  /* learn at 1/10 the normal EWMA rate */
 
 /* Initialize rule state + config. enabled is true only for tiered mode.
  * sample_rate_hz tunes the EWMA so the baseline reacts over roughly a fixed

--- a/src/control.c
+++ b/src/control.c
@@ -48,8 +48,22 @@ static const char *esc_reason_str(int reason)
     case PGWT_ESC_REASON_EXPIRED:  return "expired";
     case PGWT_ESC_REASON_REQUEST:  return "request";
     case PGWT_ESC_REASON_SHUTDOWN: return "shutdown";
+    case PGWT_ESC_REASON_BUDGET:   return "budget";
     default:                       return "unknown";
     }
+}
+
+/* The capture tier being recorded RIGHT NOW, honest for every mode (ESC-9):
+ * tiered flips sampled/escalated; a fixed EXACT-fidelity provider (--mode full)
+ * is always "escalated" (full fidelity); everything else is "sampled". Shared
+ * by status and metrics so they can never disagree. */
+static const char *daemon_tier_str(const struct pgwt_daemon *d)
+{
+    if (d->escalation.enabled)
+        return d->escalation.active ? "escalated" : "sampled";
+    if (d->provider && d->provider->fidelity == PGWT_FIDELITY_EXACT)
+        return "escalated";   /* full mode: always full fidelity */
+    return "sampled";
 }
 
 /* Count live tracked backends */
@@ -91,20 +105,16 @@ static cJSON *build_status(const struct pgwt_daemon *d)
      * captured right now: in tiered mode it flips between "sampled" (always-on
      * baseline) and "escalated" (full-fidelity window open); for full/sampled
      * it mirrors the fixed provider fidelity. */
-    const char *tier;
-    if (d->escalation.enabled)
-        tier = d->escalation.active ? "escalated" : "sampled";
-    else if (d->provider &&
-             d->provider->fidelity == PGWT_FIDELITY_EXACT)
-        tier = "escalated";   /* full mode: always full fidelity */
-    else
-        tier = "sampled";
-    cJSON_AddStringToObject(root, "tier", tier);
+    cJSON_AddStringToObject(root, "tier", daemon_tier_str(d));
     cJSON_AddBoolToObject(root, "escalation_supported", d->escalation.enabled);
     cJSON_AddNumberToObject(root, "escalation_seconds_remaining",
                             pgwt_escalation_remaining_s(d));
     cJSON_AddNumberToObject(root, "escalation_budget_remaining_s",
                             pgwt_escalation_budget_remaining_s(d));
+    /* ESC-6: report the budget mode truthfully. unlimited => remaining is the
+     * -1 sentinel; this flag disambiguates it from a finite budget. */
+    cJSON_AddBoolToObject(root, "escalation_budget_unlimited",
+                          d->escalation.budget_unlimited);
     /* Reason of the currently-open window (so the UI can annotate manual vs
      * anomaly escalations distinctly). "none" while not escalated. */
     cJSON_AddStringToObject(root, "escalation_reason",
@@ -207,18 +217,23 @@ static cJSON *build_metrics(const struct pgwt_daemon *d)
     cjson_add_uint64(root, "trace_bytes_written_total",
                      d->event_writer ? d->event_writer->total_bytes_written : 0);
 
-    /* Escalation accounting (A4). 0/false when not in tiered mode. */
-    cJSON_AddStringToObject(root, "tier",
-                            d->escalation.active ? "escalated" : "sampled");
+    /* Escalation accounting (A4). ESC-9: tier is derived the SAME way as
+     * status — a fixed EXACT provider (--mode full) reports "escalated", never
+     * a bogus "sampled". */
+    cJSON_AddStringToObject(root, "tier", daemon_tier_str(d));
     cJSON_AddBoolToObject(root, "escalation_active", d->escalation.active);
     cJSON_AddNumberToObject(root, "escalation_seconds_remaining",
                             pgwt_escalation_remaining_s(d));
     cJSON_AddNumberToObject(root, "escalation_budget_remaining_s",
                             pgwt_escalation_budget_remaining_s(d));
+    cJSON_AddBoolToObject(root, "escalation_budget_unlimited",
+                          d->escalation.budget_unlimited);
     cjson_add_uint64(root, "escalation_windows_total",
                      d->escalation.windows_total);
     cjson_add_uint64(root, "escalation_denied_total",
                      d->escalation.denied_total);
+    cjson_add_uint64(root, "escalation_budget_closed_total",
+                     d->escalation.budget_closed_total);
 
     /* Anomaly-trigger accounting (A5). 0 when not in tiered mode. */
     cjson_add_uint64(root, "anomaly_fires_total", d->anomaly.fires_total);
@@ -466,8 +481,40 @@ int pgwt_control_init(struct pgwt_control *c, struct pgwt_daemon *d,
         return -1;
     }
 
-    /* Unlink stale socket from a previous (crashed) daemon */
-    unlink(c->sock_path);
+    /* ESC-10: a plain unlink() lets a second daemon steal a LIVE daemon's
+     * control plane (and race for the same trace dir). Liveness-probe first:
+     * try to connect to the existing socket. If a daemon answers, refuse
+     * startup loudly; only unlink a socket that is stale (connect refused) or a
+     * non-socket path. */
+    {
+        struct stat sb;
+        if (lstat(c->sock_path, &sb) == 0) {
+            if (S_ISSOCK(sb.st_mode)) {
+                int probe = socket(AF_UNIX,
+                                   SOCK_STREAM | SOCK_CLOEXEC, 0);
+                if (probe >= 0) {
+                    struct sockaddr_un pa;
+                    memset(&pa, 0, sizeof(pa));
+                    pa.sun_family = AF_UNIX;
+                    memcpy(pa.sun_path, c->sock_path, (size_t)n + 1);
+                    int crc = connect(probe, (struct sockaddr *)&pa,
+                                      sizeof(pa));
+                    close(probe);
+                    if (crc == 0) {
+                        fprintf(stderr,
+                                "FATAL: another pg_wait_tracer daemon is "
+                                "already running on %s\n"
+                                "  Refusing to steal its control socket. Stop "
+                                "it first, or use a different --trace-dir.\n",
+                                c->sock_path);
+                        return -2;   /* live-daemon conflict: fatal (ESC-10) */
+                    }
+                }
+            }
+            /* Stale socket (or non-socket file) from a crashed daemon. */
+            unlink(c->sock_path);
+        }
+    }
 
     int fd = socket(AF_UNIX, SOCK_STREAM | SOCK_NONBLOCK | SOCK_CLOEXEC, 0);
     if (fd < 0) {

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -76,6 +76,10 @@ static void handle_timer(struct pgwt_daemon *d)
         }
     }
 
+    /* ESC-1: enforce the escalation budget mid-window (cheap no-op unless a
+     * budget-limited window is open and has reached its cap). */
+    pgwt_escalation_check_budget(d);
+
     /* In lightweight mode, read BPF accum_map into event_accum first */
     if (d->lightweight_mode)
         pgwt_read_accum_map(d);
@@ -763,11 +767,19 @@ int pgwt_daemon_init(struct pgwt_daemon *d)
     d->running = true;
 
     /* Control socket at {trace_dir}/pgwt.sock (D4).
-     * Failure is non-fatal: tracing must not depend on the control plane. */
+     * Failure is non-fatal (tracing must not depend on the control plane) —
+     * EXCEPT a live-daemon conflict (ESC-10, rc == -2): another daemon already
+     * owns this trace dir, so starting a second one would corrupt the trace and
+     * steal the control plane. Refuse startup loudly. */
     if (d->trace_dir) {
         d->control = calloc(1, sizeof(*d->control));
         if (d->control) {
-            if (pgwt_control_init(d->control, d, d->epoll_fd) != 0) {
+            int crc = pgwt_control_init(d->control, d, d->epoll_fd);
+            if (crc == -2) {
+                free(d->control);
+                d->control = NULL;
+                goto fail;   /* live daemon present — fatal */
+            } else if (crc != 0) {
                 free(d->control);
                 d->control = NULL;
             } else if (d->verbose) {
@@ -796,6 +808,8 @@ int pgwt_daemon_init(struct pgwt_daemon *d)
             d->anomaly.aas_ticks = d->anomaly_aas_ticks;
         if (d->anomaly_lock_fraction >= 0.0)
             d->anomaly.lock_fraction = d->anomaly_lock_fraction;
+        if (d->anomaly_lock_min_aas >= 0.0)
+            d->anomaly.lock_min_aas = d->anomaly_lock_min_aas;
         if (d->anomaly_cooldown_s >= 0)
             d->anomaly.cooldown_ns =
                 (uint64_t)d->anomaly_cooldown_s * 1000000000ULL;

--- a/src/daemon.h
+++ b/src/daemon.h
@@ -156,6 +156,7 @@ struct pgwt_daemon {
     double      anomaly_aas_factor;      /* --anomaly-aas-factor (<=0 = default) */
     int         anomaly_aas_ticks;       /* --anomaly-aas-ticks (<=0 = default) */
     double      anomaly_lock_fraction;   /* --anomaly-lock-fraction (<0 = default) */
+    double      anomaly_lock_min_aas;    /* --anomaly-lock-min-aas (<0 = default, ESC-4) */
     int         anomaly_cooldown_s;      /* --anomaly-cooldown-s (<0 = default) */
     int         anomaly_window_s;        /* --anomaly-window-s: per-trigger
                                           * escalation duration (<=0 = default) */

--- a/src/escalation.c
+++ b/src/escalation.c
@@ -7,9 +7,11 @@
  * overlap at read time.
  */
 #include "escalation.h"
+#include "escalation_budget.h"
 #include "daemon.h"
 #include "backend.h"
 #include "event_writer.h"
+#include "summary_writer.h"
 #include "perf_event.h"
 
 #include <stdio.h>
@@ -58,43 +60,23 @@ static void write_marker(struct pgwt_daemon *d, uint32_t marker_type,
 }
 
 /* ── Budget accounting (rolling hour) ─────────────────────────────────── */
-
-/* Sum full-fidelity ns consumed within [now - rolling_window, now], clamping
- * each segment to that window. The currently-open segment (end_ns == 0) is
- * counted up to now. Stale segments are pruned (compacted) as a side effect. */
-static uint64_t budget_consumed_ns(struct pgwt_escalation *e, uint64_t now)
-{
-    uint64_t window_start = (now > e->rolling_window_ns)
-                          ? now - e->rolling_window_ns : 0;
-    uint64_t consumed = 0;
-    int w = 0;
-    for (int i = 0; i < e->ledger_count; i++) {
-        uint64_t s = e->ledger[i].start_ns;
-        uint64_t en = e->ledger[i].end_ns ? e->ledger[i].end_ns : now;
-        if (en <= window_start)
-            continue;   /* entirely stale — drop */
-        if (s < window_start)
-            s = window_start;
-        if (en > s)
-            consumed += en - s;
-        /* keep this (still partly in-window) segment */
-        e->ledger[w++] = e->ledger[i];
-    }
-    e->ledger_count = w;
-    return consumed;
-}
+/* The pure ledger/decision core lives in escalation_budget.c (unit-tested);
+ * this file only wires it to the BPF-attaching escalation lifecycle. */
 
 double pgwt_escalation_budget_remaining_s(const struct pgwt_daemon *d)
 {
     const struct pgwt_escalation *e = &d->escalation;
-    if (!e->enabled || e->budget_ns == 0)
+    if (!e->enabled)
         return 0;
-    /* const-correct: budget_consumed_ns prunes, so cast away const. */
-    uint64_t consumed = budget_consumed_ns((struct pgwt_escalation *)e,
-                                           mono_ns());
-    if (consumed >= e->budget_ns)
-        return 0;
-    return (double)(e->budget_ns - consumed) / 1e9;
+    /* ESC-6: report the TRUTH for every budget mode. Unlimited surfaces as
+     * -1 (the "no cap" sentinel the UI renders as ∞); deny-all (budget 0)
+     * reports a genuine 0; a finite budget reports the real remaining. */
+    if (e->budget_unlimited)
+        return -1.0;
+    /* const-correct: the consumed helper prunes, so cast away const. */
+    uint64_t rem = pgwt_esc_budget_remaining_ns((struct pgwt_escalation *)e,
+                                                mono_ns());
+    return (double)rem / 1e9;
 }
 
 double pgwt_escalation_remaining_s(const struct pgwt_daemon *d)
@@ -178,6 +160,56 @@ static void detach_all(struct pgwt_daemon *d)
     }
 }
 
+/* ── De-escalation flush (ESC-2) ──────────────────────────────────────── */
+
+/* Before detach_all() resets the state_map, flush every OPEN wait interval as
+ * a final transition so a wait that spans the window end is recorded exactly
+ * once (its exact portion up to the de-escalation instant) instead of being
+ * silently dropped — the interval carried no TRANSITIONS record yet (the
+ * watchpoint only emits on the wait's END), while the END marker extends the
+ * exact-wins range so the covering samples were discarded too. We synthesize
+ * the transition userspace-side (same path as the window markers): timestamp =
+ * now (the wait-end instant), old_event = the open event, duration = now -
+ * last_ts. It lands inside the marker-covered range, closing the end-of-window
+ * hole on exactly the long waits the window exists to capture. */
+static void flush_open_intervals(struct pgwt_daemon *d, uint64_t now)
+{
+    if (!d->event_writer)
+        return;   /* nothing to flush into — no trace recording */
+    int state_fd = d->skel ? bpf_map__fd(d->skel->maps.state_map) : -1;
+    if (state_fd < 0)
+        return;
+
+    for (int i = 0; i < d->backends.count; i++) {
+        struct pgwt_backend *be = &d->backends.entries[i];
+        if (!be->is_alive || be->pid <= 0 || be->wp_fd < 0)
+            continue;
+        uint32_t key = (uint32_t)be->pid;
+        struct pgwt_pid_state st;
+        if (bpf_map_lookup_elem(state_fd, &key, &st) != 0)
+            continue;
+        if (!st.wp_live)
+            continue;               /* a seed entry — no interval to close */
+        if (now <= st.last_ts)
+            continue;               /* zero/negative duration — nothing open */
+        uint32_t we = st.last_event;
+        if (PGWT_IS_MARKER(we))
+            continue;               /* never a real wait */
+        struct pgwt_trace_event ev = {
+            .timestamp_ns = now,
+            .pid          = (uint32_t)be->pid,
+            .old_event    = we,     /* the interval that was open ends here */
+            .new_event    = we,
+            .flags        = st.cmd_open ? PGWT_EVENT_FLAG_CMD_OPEN : 0,
+            .duration_ns  = now - st.last_ts,
+            .query_id     = st.last_query_id,
+        };
+        pgwt_writer_push_event(d->event_writer, &ev);
+        if (d->summary_writer)
+            pgwt_summary_push_event(d->summary_writer, &ev);
+    }
+}
+
 /* ── Public API ───────────────────────────────────────────────────────── */
 
 int pgwt_escalation_init(struct pgwt_daemon *d, int budget_s)
@@ -186,7 +218,15 @@ int pgwt_escalation_init(struct pgwt_daemon *d, int budget_s)
     memset(e, 0, sizeof(*e));
     e->timer_fd = -1;
     e->rolling_window_ns = 3600ULL * 1000000000ULL;   /* per rolling hour */
-    e->budget_ns = (budget_s > 0 ? (uint64_t)budget_s : 0) * 1000000000ULL;
+    /* ESC-6 budget semantics: >0 = seconds/hour cap; 0 = deny-all (escalation
+     * disabled); <0 = unlimited (no cap). */
+    if (budget_s < 0) {
+        e->budget_unlimited = true;
+        e->budget_ns = 0;
+    } else {
+        e->budget_unlimited = false;
+        e->budget_ns = (uint64_t)budget_s * 1000000000ULL;
+    }
     e->enabled = (d->mode == PGWT_MODE_TIERED);
 
     if (!e->enabled)
@@ -255,30 +295,21 @@ int pgwt_escalate(struct pgwt_daemon *d, int duration_s, int reason,
     uint64_t now = mono_ns();
     uint64_t want_ns = (uint64_t)duration_s * 1000000000ULL;
 
-    /* Budget check: would the requested window push consumed past budget?
-     * The currently-open segment is already counted in budget_consumed_ns,
-     * so for an extension we only charge the additional time past the current
-     * deadline. */
-    if (e->budget_ns > 0) {
-        uint64_t consumed = budget_consumed_ns(e, now);
-        uint64_t additional;
-        if (e->active && e->window_deadline_ns > now) {
-            uint64_t new_deadline = now + want_ns;
-            additional = (new_deadline > e->window_deadline_ns)
-                       ? (new_deadline - e->window_deadline_ns) : 0;
-        } else {
-            additional = want_ns;
-        }
-        if (consumed + additional > e->budget_ns) {
-            e->denied_total++;
-            if (why) *why = "escalation budget exhausted for this hour";
-            return -1;
-        }
+    /* ESC-1: budget decision on the committed-remainder-aware core. The grant
+     * is CLAMPED to the remaining budget: the currently-open segment is
+     * already folded into consumed, so the deadline we arm at now+grant makes
+     * the window's total full-fidelity time land at exactly the budget no
+     * matter how many times it is extended (the extend-every-second attack). */
+    uint64_t grant_ns = want_ns;
+    if (pgwt_esc_budget_decide(e, now, want_ns, &grant_ns, why) != 0) {
+        e->denied_total++;
+        return -1;
     }
 
     if (e->active) {
-        /* Already escalated: extend the deadline if the new one is later. */
-        uint64_t new_deadline = now + want_ns;
+        /* Already escalated: extend the deadline to the budget-clamped grant
+         * if it is later than the current one (never shorten a live window). */
+        uint64_t new_deadline = now + grant_ns;
         if (new_deadline > e->window_deadline_ns)
             arm_deadline(e, new_deadline);
         if (granted_s)
@@ -288,29 +319,26 @@ int pgwt_escalate(struct pgwt_daemon *d, int duration_s, int reason,
     }
 
     /* Fresh escalation: attach watchpoints across the registry, open a
-     * ledger segment, arm the deadline, and mark the trace. */
+     * ledger segment, arm the (budget-clamped) deadline, and mark the trace. */
     int n = attach_all(d);
     e->active = true;
     e->window_start_ns = now;
     e->window_reason = reason;
     e->windows_total++;
 
-    if (e->ledger_count < PGWT_ESC_LEDGER_MAX) {
-        e->ledger[e->ledger_count].start_ns = now;
-        e->ledger[e->ledger_count].end_ns = 0;
-        e->ledger_count++;
-    }
+    pgwt_esc_ledger_open(e, now);   /* ESC-5: never opens an unbilled window */
 
-    arm_deadline(e, now + want_ns);
-    write_marker(d, PGWT_MARKER_ESCALATE_START, want_ns, reason);
+    arm_deadline(e, now + grant_ns);
+    write_marker(d, PGWT_MARKER_ESCALATE_START, grant_ns, reason);
 
+    int granted = (int)((grant_ns + 999999999ULL) / 1000000000ULL);
     if (d->verbose)
         fprintf(stderr,
                 "INFO: escalated to full fidelity for %ds (reason %d, "
-                "%d watchpoints attached)\n", duration_s, reason, n);
+                "%d watchpoints attached)\n", granted, reason, n);
 
     if (granted_s)
-        *granted_s = duration_s;
+        *granted_s = granted;
     return 0;
 }
 
@@ -326,16 +354,17 @@ void pgwt_deescalate(struct pgwt_daemon *d, int reason)
     if (d->event_rb)
         ring_buffer__consume(d->event_rb);
 
+    /* ESC-2: flush open wait intervals as final transitions BEFORE detach_all
+     * wipes them, and before the END marker closes the exact-wins range — so a
+     * wait spanning the window boundary is recorded exactly once (its exact
+     * portion), not dropped into an end-of-window hole. */
+    flush_open_intervals(d, now);
+
     detach_all(d);
     e->active = false;
 
     /* Close the open ledger segment so budget accounting is exact. */
-    for (int i = e->ledger_count - 1; i >= 0; i--) {
-        if (e->ledger[i].end_ns == 0) {
-            e->ledger[i].end_ns = now;
-            break;
-        }
-    }
+    pgwt_esc_ledger_close(e, now);
 
     /* Disarm the deadline timer. */
     struct itimerspec its = {0};
@@ -360,4 +389,19 @@ void pgwt_escalation_on_timer(struct pgwt_daemon *d)
 
     if (e->active && mono_ns() >= e->window_deadline_ns)
         pgwt_deescalate(d, PGWT_ESC_REASON_EXPIRED);
+}
+
+void pgwt_escalation_check_budget(struct pgwt_daemon *d)
+{
+    struct pgwt_escalation *e = &d->escalation;
+    if (!e->active)
+        return;
+    /* ESC-1 mid-window clamp: the budget-clamped deadline normally closes the
+     * window on time, but a rolling-hour accounting change (an older segment
+     * aging in/out) can push cumulative consumption to the budget mid-flight —
+     * close now rather than run over. */
+    if (pgwt_esc_budget_over(e, mono_ns())) {
+        e->budget_closed_total++;
+        pgwt_deescalate(d, PGWT_ESC_REASON_BUDGET);
+    }
 }

--- a/src/escalation.h
+++ b/src/escalation.h
@@ -56,7 +56,8 @@ struct pgwt_escalation {
     int       window_reason;      /* enum pgwt_escalation_reason of active window */
 
     /* Budget: full-fidelity seconds allowed per rolling hour. */
-    uint64_t  budget_ns;          /* --escalation-budget converted to ns */
+    uint64_t  budget_ns;          /* --escalation-budget converted to ns (0 = deny-all) */
+    bool      budget_unlimited;   /* --escalation-budget unlimited/-1: no cap (ESC-6) */
     uint64_t  rolling_window_ns;  /* the "per hour" window (3600s) */
 
     /* Ledger of closed (and the one open) segments for rolling accounting. */
@@ -66,6 +67,7 @@ struct pgwt_escalation {
     /* Lifetime stats (control-socket metrics). */
     uint64_t  windows_total;      /* escalation windows opened */
     uint64_t  denied_total;       /* manual escalates denied (over budget) */
+    uint64_t  budget_closed_total;/* windows closed mid-flight by the budget clamp (ESC-1) */
 };
 
 /* Initialize the escalation engine. budget_s is --escalation-budget (full
@@ -92,6 +94,11 @@ void pgwt_deescalate(struct pgwt_daemon *d, int reason);
 
 /* Called when the deadline timerfd fires: closes the window if expired. */
 void pgwt_escalation_on_timer(struct pgwt_daemon *d);
+
+/* Mid-window budget enforcement (ESC-1): if an active window's rolling-hour
+ * consumption has reached the budget, de-escalate now. Cheap no-op when not
+ * escalated / unlimited. Called from the daemon's periodic timer. */
+void pgwt_escalation_check_budget(struct pgwt_daemon *d);
 
 /* True if fd belongs to the escalation deadline timer (drives dispatch). */
 bool pgwt_escalation_is_timer_fd(const struct pgwt_daemon *d, int fd);

--- a/src/escalation_budget.c
+++ b/src/escalation_budget.c
@@ -1,0 +1,121 @@
+/* escalation_budget.c — Pure rolling-hour budget accounting (Track T, T3)
+ *
+ * See escalation_budget.h. BPF-free and daemon-free: compiled into the daemon
+ * (via escalation.c's caller) and directly into the unit test with no special
+ * defines.
+ */
+#include "escalation_budget.h"
+#include "escalation.h"
+
+#include <string.h>
+
+uint64_t pgwt_esc_budget_consumed_ns(struct pgwt_escalation *e, uint64_t now)
+{
+    uint64_t window_start = (now > e->rolling_window_ns)
+                          ? now - e->rolling_window_ns : 0;
+    uint64_t consumed = 0;
+    int w = 0;
+    for (int i = 0; i < e->ledger_count; i++) {
+        uint64_t s = e->ledger[i].start_ns;
+        uint64_t en = e->ledger[i].end_ns ? e->ledger[i].end_ns : now;
+        if (en <= window_start)
+            continue;   /* entirely stale — drop */
+        if (s < window_start)
+            s = window_start;
+        if (en > s)
+            consumed += en - s;
+        /* keep this (still partly in-window) segment, preserving order */
+        e->ledger[w++] = e->ledger[i];
+    }
+    e->ledger_count = w;
+    return consumed;
+}
+
+uint64_t pgwt_esc_budget_remaining_ns(struct pgwt_escalation *e, uint64_t now)
+{
+    if (e->budget_unlimited)
+        return UINT64_MAX;
+    if (e->budget_ns == 0)
+        return 0;   /* deny-all: genuinely zero remaining (ESC-6) */
+    uint64_t consumed = pgwt_esc_budget_consumed_ns(e, now);
+    return (e->budget_ns > consumed) ? e->budget_ns - consumed : 0;
+}
+
+int pgwt_esc_budget_decide(struct pgwt_escalation *e, uint64_t now,
+                           uint64_t want_ns, uint64_t *grant_ns,
+                           const char **why)
+{
+    if (e->budget_unlimited) {
+        if (grant_ns) *grant_ns = want_ns;
+        return 0;
+    }
+    if (e->budget_ns == 0) {
+        /* ESC-6: 0 means deny-all (not "unlimited"). --escalation-budget
+         * unlimited (-1) is the explicit opt-in for no limit. */
+        if (why) *why = "escalation disabled (--escalation-budget 0); "
+                        "use 'unlimited' to allow unbounded escalation";
+        return -1;
+    }
+    uint64_t consumed = pgwt_esc_budget_consumed_ns(e, now);
+    uint64_t avail = (e->budget_ns > consumed) ? e->budget_ns - consumed : 0;
+    if (avail == 0) {
+        if (why) *why = "escalation budget exhausted for this hour";
+        return -1;
+    }
+    if (grant_ns)
+        *grant_ns = (want_ns < avail) ? want_ns : avail;
+    return 0;
+}
+
+bool pgwt_esc_budget_over(struct pgwt_escalation *e, uint64_t now)
+{
+    if (e->budget_unlimited || e->budget_ns == 0)
+        return false;
+    return pgwt_esc_budget_consumed_ns(e, now) >= e->budget_ns;
+}
+
+/* Merge the two oldest ledger segments into one spanning [min start, max end],
+ * shifting the tail down. Bills the gap between them (conservative). Segments
+ * are appended in chronological open order and pruning preserves that order,
+ * so [0] and [1] are always the two oldest. */
+static void coalesce_oldest(struct pgwt_escalation *e)
+{
+    if (e->ledger_count < 2)
+        return;
+    uint64_t s0 = e->ledger[0].start_ns, en0 = e->ledger[0].end_ns;
+    uint64_t s1 = e->ledger[1].start_ns, en1 = e->ledger[1].end_ns;
+    uint64_t start = s0 < s1 ? s0 : s1;
+    uint64_t end;
+    if (en0 == 0 || en1 == 0)
+        end = 0;                        /* one still open — stays open */
+    else
+        end = en0 > en1 ? en0 : en1;
+    e->ledger[0].start_ns = start;
+    e->ledger[0].end_ns = end;
+    memmove(&e->ledger[1], &e->ledger[2],
+            (size_t)(e->ledger_count - 2) * sizeof(e->ledger[0]));
+    e->ledger_count--;
+}
+
+void pgwt_esc_ledger_open(struct pgwt_escalation *e, uint64_t now)
+{
+    /* Prune stale first (may itself free slots). */
+    pgwt_esc_budget_consumed_ns(e, now);
+    if (e->ledger_count >= PGWT_ESC_LEDGER_MAX)
+        coalesce_oldest(e);   /* ESC-5: guarantee a slot; never unbilled */
+    if (e->ledger_count < PGWT_ESC_LEDGER_MAX) {
+        e->ledger[e->ledger_count].start_ns = now;
+        e->ledger[e->ledger_count].end_ns = 0;
+        e->ledger_count++;
+    }
+}
+
+void pgwt_esc_ledger_close(struct pgwt_escalation *e, uint64_t now)
+{
+    for (int i = e->ledger_count - 1; i >= 0; i--) {
+        if (e->ledger[i].end_ns == 0) {
+            e->ledger[i].end_ns = now;
+            break;
+        }
+    }
+}

--- a/src/escalation_budget.h
+++ b/src/escalation_budget.h
@@ -1,0 +1,64 @@
+/* escalation_budget.h — Pure rolling-hour budget accounting (Track T, T3)
+ *
+ * The escalation engine's budget math is split out here as a BPF-free,
+ * daemon-free core so it is exhaustively unit-testable (tests/test_escalation_
+ * budget.c) against a scripted clock — the same pattern anomaly.c / sampler.c
+ * use for their pure cores. It owns:
+ *
+ *   - the rolling-hour "consumed seconds" ledger (prune + compact),
+ *   - the grant decision (unlimited / deny-all / finite-clamp) that makes
+ *     repeated extensions cap total full-fidelity time at EXACTLY the budget
+ *     (ESC-1),
+ *   - never-unbilled ledger management under overflow (ESC-5),
+ *   - honest "remaining" that reports the truth for every budget mode (ESC-6).
+ *
+ * All functions operate on `struct pgwt_escalation` (declared in escalation.h);
+ * none touch BPF, the daemon, or the trace writer.
+ */
+#ifndef PGWT_ESCALATION_BUDGET_H
+#define PGWT_ESCALATION_BUDGET_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+struct pgwt_escalation;   /* full definition in escalation.h */
+
+/* Sum full-fidelity ns consumed within [now - rolling_window, now], clamping
+ * each segment to that window. The currently-open segment (end_ns == 0) is
+ * counted up to now. Prunes (compacts) fully-stale segments as a side effect,
+ * preserving chronological order. */
+uint64_t pgwt_esc_budget_consumed_ns(struct pgwt_escalation *e, uint64_t now);
+
+/* Full-fidelity ns still available in the current rolling hour. Returns
+ * UINT64_MAX for an unlimited budget, 0 for a deny-all (budget == 0) engine. */
+uint64_t pgwt_esc_budget_remaining_ns(struct pgwt_escalation *e, uint64_t now);
+
+/* Decide whether a window of want_ns may be granted at `now` under the budget.
+ * On success returns 0 and *grant_ns receives the (possibly budget-clamped)
+ * grant. On denial returns -1 and *why (if non-NULL) receives a static reason.
+ *
+ * The currently-open segment is already folded into consumed, so the future
+ * commitment charged is exactly *grant_ns and the invariant
+ *   consumed_now + grant_ns <= budget
+ * holds — which, applied on every extension, caps the window's total
+ * full-fidelity time at the budget no matter how often it is extended (ESC-1).
+ * unlimited => always grant want_ns; budget == 0 => always deny (ESC-6). */
+int pgwt_esc_budget_decide(struct pgwt_escalation *e, uint64_t now,
+                           uint64_t want_ns, uint64_t *grant_ns,
+                           const char **why);
+
+/* True when an active window's rolling-hour consumption has reached/passed the
+ * budget and the window must be closed mid-flight (ESC-1 mid-window clamp).
+ * Always false for unlimited / deny-all engines. */
+bool pgwt_esc_budget_over(struct pgwt_escalation *e, uint64_t now);
+
+/* Open a ledger segment at `now`. Prunes stale segments first; if the ledger
+ * is still full, coalesces the two oldest segments (billing the gap between
+ * them — conservative, never under-bills) so a window is NEVER opened
+ * unbilled (ESC-5). */
+void pgwt_esc_ledger_open(struct pgwt_escalation *e, uint64_t now);
+
+/* Close the most recently opened (end_ns == 0) segment at `now`. */
+void pgwt_esc_ledger_close(struct pgwt_escalation *e, uint64_t now);
+
+#endif /* PGWT_ESCALATION_BUDGET_H */

--- a/src/pg_wait_tracer.c
+++ b/src/pg_wait_tracer.c
@@ -66,14 +66,18 @@ static void usage(const char *prog)
         "                                   this build; ships in the extension track.\n"
         "      --sample-rate <HZ>     Sampling rate for sampled/tiered (1-1000, default 10)\n"
         "      --escalation-budget <S>  Tiered: full-fidelity seconds allowed per\n"
-        "                             rolling hour (default 300). Escalate via the\n"
-        "                             control socket: {\"cmd\":\"escalate\",\"duration_s\":N}.\n"
+        "                             rolling hour (default 300). 0 = escalation\n"
+        "                             DISABLED (deny all); 'unlimited' = no cap.\n"
+        "                             Escalate via the control socket:\n"
+        "                             {\"cmd\":\"escalate\",\"duration_s\":N}.\n"
         "\n"
         "Anomaly triggers (tiered mode — auto-escalate on the sampled stream):\n"
         "      --anomaly-aas-factor <K>   Fire when AAS > K*rolling_baseline (default 3.0)\n"
         "      --anomaly-aas-ticks <N>    ...sustained for N consecutive ticks (default 3)\n"
         "      --anomaly-lock-fraction <F>  Fire when Lock-class share of active\n"
         "                             samples > F (default 0.30), sustained N ticks\n"
+        "      --anomaly-lock-min-aas <A>  ...AND lock-class AAS >= A (default 2.0), so a\n"
+        "                             single backend's routine lock wait can't escalate\n"
         "      --anomaly-cooldown-s <S>   Min seconds between auto-escalations (default 120)\n"
         "      --anomaly-window-s <S>     Full-fidelity window length per auto-trigger (default 60)\n"
         "\n"
@@ -214,6 +218,7 @@ static enum pgwt_mode parse_mode(const char *s)
 #define OPT_ANOM_COOLDOWN   270
 #define OPT_ANOM_WINDOW     271
 #define OPT_RETENTION_GB    272
+#define OPT_ANOM_LOCK_MIN_AAS 273
 
 static struct option long_opts[] = {
     {"pid",        required_argument, NULL, 'p'},
@@ -245,6 +250,7 @@ static struct option long_opts[] = {
     {"anomaly-aas-factor",  required_argument, NULL, OPT_ANOM_AAS_FACTOR},
     {"anomaly-aas-ticks",   required_argument, NULL, OPT_ANOM_AAS_TICKS},
     {"anomaly-lock-fraction", required_argument, NULL, OPT_ANOM_LOCK_FRAC},
+    {"anomaly-lock-min-aas", required_argument, NULL, OPT_ANOM_LOCK_MIN_AAS},
     {"anomaly-cooldown-s",  required_argument, NULL, OPT_ANOM_COOLDOWN},
     {"anomaly-window-s",    required_argument, NULL, OPT_ANOM_WINDOW},
     {"quiet",           no_argument,       NULL, 'q'},
@@ -278,6 +284,7 @@ int main(int argc, char **argv)
     d->anomaly_aas_factor    = -1.0;
     d->anomaly_aas_ticks     = -1;
     d->anomaly_lock_fraction = -1.0;
+    d->anomaly_lock_min_aas  = -1.0;
     d->anomaly_cooldown_s    = -1;
 
     pid_t pm_pid = 0;
@@ -322,10 +329,18 @@ int main(int argc, char **argv)
         case OPT_SKIP_USDT:   d->skip_usdt = 1; break;
         case OPT_MODE:        d->mode = parse_mode(optarg); break;
         case OPT_SAMPLE_RATE: d->sample_rate_hz = atoi(optarg); break;
-        case OPT_ESC_BUDGET:  d->escalation_budget_s = atoi(optarg); break;
+        case OPT_ESC_BUDGET:
+            /* ESC-6: "unlimited" (or a negative value) = no cap; 0 = deny-all;
+             * >0 = seconds/rolling-hour. Stored as -1 for unlimited. */
+            if (strcasecmp(optarg, "unlimited") == 0)
+                d->escalation_budget_s = -1;
+            else
+                d->escalation_budget_s = atoi(optarg);
+            break;
         case OPT_ANOM_AAS_FACTOR: d->anomaly_aas_factor = atof(optarg); break;
         case OPT_ANOM_AAS_TICKS:  d->anomaly_aas_ticks = atoi(optarg); break;
         case OPT_ANOM_LOCK_FRAC:  d->anomaly_lock_fraction = atof(optarg); break;
+        case OPT_ANOM_LOCK_MIN_AAS: d->anomaly_lock_min_aas = atof(optarg); break;
         case OPT_ANOM_COOLDOWN:   d->anomaly_cooldown_s = atoi(optarg); break;
         case OPT_ANOM_WINDOW:     d->anomaly_window_s = atoi(optarg); break;
         case 'q': d->quiet = true; break;
@@ -404,11 +419,12 @@ int main(int argc, char **argv)
         return 1;
     }
 
-    /* Validate: --escalation-budget (tiered only). 0 disables the limit
-     * (escalations always granted) — allowed for testing but warned. */
-    if (d->escalation_budget_s < 0) {
-        fprintf(stderr, "FATAL: --escalation-budget must be >= 0 (got %d)\n",
-                d->escalation_budget_s);
+    /* Validate: --escalation-budget (tiered only). ESC-6 semantics: >0 =
+     * seconds/rolling-hour; 0 = deny-all (escalation disabled); -1 =
+     * "unlimited" (parsed above). Anything below -1 is a typo. */
+    if (d->escalation_budget_s < -1) {
+        fprintf(stderr, "FATAL: --escalation-budget must be >= 0, or "
+                "'unlimited' (got %d)\n", d->escalation_budget_s);
         free(d);
         return 1;
     }
@@ -430,6 +446,12 @@ int main(int argc, char **argv)
         free(d);
         return 1;
     }
+    if (d->anomaly_lock_min_aas == 0.0) {
+        fprintf(stderr, "FATAL: --anomaly-lock-min-aas must be > 0 "
+                "(use --anomaly-lock-fraction alone to disable the floor)\n");
+        free(d);
+        return 1;
+    }
 
     /* Validate: any non-full mode is incompatible with --lightweight
      * (lightweight is a watchpoint-only BPF-accumulator mode). */
@@ -447,11 +469,19 @@ int main(int argc, char **argv)
      * escalation on demand via the control socket, bounded by
      * --escalation-budget per rolling hour. Use --mode full for always-on
      * exact watchpoint tracing. */
-    if (d->mode == PGWT_MODE_TIERED)
+    if (d->mode == PGWT_MODE_TIERED) {
+        char budstr[32];
+        if (d->escalation_budget_s < 0)
+            snprintf(budstr, sizeof(budstr), "unlimited");
+        else if (d->escalation_budget_s == 0)
+            snprintf(budstr, sizeof(budstr), "0 — escalation DISABLED");
+        else
+            snprintf(budstr, sizeof(budstr), "%ds/hour",
+                     d->escalation_budget_s);
         fprintf(stderr, "INFO: --mode tiered (default): sampler always-on; "
-                "on-demand full-fidelity escalation (budget %ds/hour). "
-                "Use --mode full for always-on exact tracing.\n",
-                d->escalation_budget_s);
+                "on-demand full-fidelity escalation (budget %s). "
+                "Use --mode full for always-on exact tracing.\n", budstr);
+    }
 
     /* Check root */
     if (geteuid() != 0) {

--- a/src/pg_wait_tracer.h
+++ b/src/pg_wait_tracer.h
@@ -157,6 +157,7 @@ enum pgwt_escalation_reason {
     PGWT_ESC_REASON_EXPIRED  = 2,  /* window reached its deadline (close) */
     PGWT_ESC_REASON_REQUEST  = 3,  /* explicit deescalate request (close) */
     PGWT_ESC_REASON_SHUTDOWN = 4,  /* daemon stopping (close) */
+    PGWT_ESC_REASON_BUDGET   = 5,  /* rolling-hour budget reached (mid-window close, ESC-1) */
 };
 
 /* ── Query Text Event (lifecycle ringbuf) ─────────────────── */

--- a/src/sampler.c
+++ b/src/sampler.c
@@ -507,6 +507,16 @@ static void pgwt_sampler_accumulate(struct pgwt_daemon *d,
     if (!acc)
         return;
 
+    /* ESC-3: while escalated, the exact ringbuf ALSO feeds d->event_accum for
+     * every pid with a live watchpoint. Folding the sampler's estimate in on
+     * top double-counts the live --view (measured ~1.9x). Gate the sampler's
+     * contribution for exactly those covered pids — the live-path analogue of
+     * the offline marker-based exact-wins merge. Freshly-forked backends not
+     * yet watchpointed (wp_fd < 0) still have the sampler as their only source,
+     * so they keep accumulating. The on-disk SAMPLES are untouched; the offline
+     * merge de-dupes them via the escalation markers (FID-1). */
+    bool escalated = d->escalation.active;
+
     for (int i = 0; i < count; i++) {
         uint32_t we  = samples[i].new_event;   /* sampled wait event (0 = CPU) */
         uint64_t dur = period_ns;              /* ASH weight per sample */
@@ -514,6 +524,13 @@ static void pgwt_sampler_accumulate(struct pgwt_daemon *d,
 
         if (PGWT_IS_MARKER(we))
             continue;
+
+        if (escalated) {
+            struct pgwt_backend *be =
+                pgwt_find_backend(&d->backends, (pid_t)samples[i].pid);
+            if (be && be->wp_fd >= 0)
+                continue;   /* exact ringbuf owns this pid's live accumulation */
+        }
 
         /* Per-PID accumulation */
         struct pgwt_pid_accum *pa = pgwt_get_or_create_pid(acc, samples[i].pid);

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -11,7 +11,8 @@ BUILD     = ../build
 LIBBPF_LIB ?= -lbpf
 
 TESTS     = test_wait_event test_cmdline test_event_writer test_event_reader \
-            test_trace_v2 test_sampler test_anomaly test_coop test_bucket \
+            test_trace_v2 test_sampler test_anomaly test_escalation_budget \
+            test_coop test_bucket \
             test_pg13_resolve test_discovery_pie test_discovery_nopie \
             test_replay_fidelity test_durability test_query_text \
             gen_test_traces gen_bench_traces test_concurrent_rw cross_validate \
@@ -92,6 +93,13 @@ test_sampler: test_sampler.c ../src/sampler.c
 # skeleton, no escalation engine, runnable in CI's server-only jobs.
 test_anomaly: test_anomaly.c ../src/anomaly.c
 	$(CC) $(CFLAGS) -DPGWT_SERVER -o $@ $^
+
+# test_escalation_budget: pure rolling-hour budget core (ESC-1/5/6). Compiles
+# escalation_budget.c directly — it is BPF-free and daemon-free (depends only
+# on escalation.h), so no skeleton, no bpftool: runnable in CI's server-only
+# jobs like test_sampler / test_anomaly.
+test_escalation_budget: test_escalation_budget.c ../src/escalation_budget.c
+	$(CC) $(CFLAGS) -o $@ $^
 
 # test_coop: cooperative provider stub (A6 interface freeze) — registers,
 # advertises EXACT fidelity, start() returns the clean "not available" status.

--- a/tests/mock_server.py
+++ b/tests/mock_server.py
@@ -439,6 +439,8 @@ class DaemonState:
             "escalation_supported": True,
             "escalation_seconds_remaining": self.seconds_remaining,
             "escalation_budget_remaining_s": self.budget_remaining_s,
+            # ESC-6: unlimited surfaces as budget_remaining_s == -1 + this flag.
+            "escalation_budget_unlimited": self.budget_remaining_s < 0,
             "escalation_reason": self.reason if self.tier == "escalated" else "none",
             # Sampler read health (T4/SMP-1): false + reason means the sampler
             # cannot read backend memory — "blind", not "idle".
@@ -472,8 +474,10 @@ class DaemonState:
             "escalation_active": self.tier == "escalated",
             "escalation_seconds_remaining": self.seconds_remaining,
             "escalation_budget_remaining_s": self.budget_remaining_s,
+            "escalation_budget_unlimited": self.budget_remaining_s < 0,
             "escalation_windows_total": self.windows_total,
             "escalation_denied_total": self.denied_total,
+            "escalation_budget_closed_total": 0,
             "anomaly_fires_total": 2,
             "anomaly_near_total": 5,
             "anomaly_dropped_budget_total": 1,

--- a/tests/test_anomaly.c
+++ b/tests/test_anomaly.c
@@ -351,6 +351,111 @@ static void test_cpu_storm_fires(void)
     }
 }
 
+/* ── Test 10: ESC-4 — lock rule needs a min-activity floor ─────────────── */
+/* A single backend's routine 300 ms row-lock wait is lock_fraction 1.0 of an
+ * AAS of 1 — the old rule fired and burned a 60 s window on OLTP noise. The
+ * min-activity floor (lock-class AAS >= lock_min_aas) must veto that while
+ * still firing on a genuine lock convoy. */
+static void test_lock_min_activity(void)
+{
+    printf("--- ESC-4: lock rule requires a minimum lock-class AAS ---\n");
+    struct pgwt_anomaly a;
+    pgwt_anomaly_init(&a, true, 10);
+    a.aas_factor    = 0.0;         /* isolate the lock rule */
+    a.lock_fraction = 0.30;
+    a.lock_min_aas  = 2.0;         /* default floor */
+    a.lock_ticks    = 3;
+    uint64_t clk = TICK_NS;
+    warm_baseline(&a, 1.0, &clk);
+
+    /* Lone backend fully blocked on a lock: fraction 1.0 but lock-AAS = 1.0
+     * (1 * 1.0) < 2.0 → must NEVER fire, however long it lasts. */
+    int fires = 0;
+    feed(&a, 1.0, 1.0, 100, &clk, &fires);
+    CHECK(fires == 0, "single-backend lock wait fired %d times (must be 0)",
+          fires);
+    CHECK(a.lock_over_streak == 0,
+          "min-activity floor keeps lock_over_streak at 0 (got %d)",
+          a.lock_over_streak);
+
+    /* A real convoy: AAS 6, lock share 0.7 → lock-AAS 4.2 >= 2.0 AND share
+     * 0.7 > 0.30 → fires after the sustain count. */
+    struct pgwt_anomaly b;
+    pgwt_anomaly_init(&b, true, 10);
+    b.aas_factor    = 0.0;
+    b.lock_fraction = 0.30;
+    b.lock_min_aas  = 2.0;
+    b.lock_ticks    = 3;
+    clk = TICK_NS;
+    warm_baseline(&b, 1.0, &clk);
+    int convoy_fires = 0;
+    feed(&b, 6.0, 0.7, 5, &clk, &convoy_fires);
+    CHECK(convoy_fires >= 1, "a real lock convoy MUST fire (got %d)",
+          convoy_fires);
+
+    /* Boundary: exactly at the floor (lock-AAS == 2.0) fires; just under does
+     * not. AAS 4, share 0.5 => lock-AAS 2.0 (>= floor). */
+    struct pgwt_anomaly c;
+    pgwt_anomaly_init(&c, true, 10);
+    c.aas_factor = 0.0; c.lock_fraction = 0.30; c.lock_min_aas = 2.0;
+    c.lock_ticks = 2;
+    clk = TICK_NS;
+    warm_baseline(&c, 1.0, &clk);
+    int at_floor = 0;
+    feed(&c, 4.0, 0.5, 4, &clk, &at_floor);
+    CHECK(at_floor >= 1, "lock-AAS exactly at the floor fires (got %d)",
+          at_floor);
+}
+
+/* ── Test 11: ESC-7 — short incident protected, sustained regime learned ─ */
+static void test_baseline_learn_through(void)
+{
+    printf("--- ESC-7: short incident protected; sustained regime learned ---\n");
+
+    /* Property 1 (incident protection preserved): a burst well under the
+     * learn-through horizon must NOT move the baseline. */
+    struct pgwt_anomaly a;
+    pgwt_anomaly_init(&a, true, 10);
+    a.aas_factor = 3.0;
+    a.aas_ticks  = 3;
+    /* Shrink the horizon so the test is fast but still >> the incident. */
+    a.learn_through_ticks = 2000;   /* 200 s at 10 Hz */
+    uint64_t clk = TICK_NS;
+    warm_baseline(&a, 2.0, &clk);
+    double base0 = a.baseline_aas;
+    feed(&a, 20.0, 0.0, 300, &clk, NULL);   /* 30 s incident << 200 s horizon */
+    CHECK(a.baseline_aas < base0 + 1.0,
+          "short incident must not raise baseline (%.2f -> %.2f)",
+          base0, a.baseline_aas);
+
+    /* Property 2 (learn-through): a regime change sustained PAST the horizon
+     * must eventually be adopted so the rule stops re-firing forever. */
+    struct pgwt_anomaly b;
+    pgwt_anomaly_init(&b, true, 10);
+    b.aas_factor = 3.0;
+    b.aas_ticks  = 3;
+    b.learn_through_ticks = 2000;
+    b.slow_release_div    = 10;
+    clk = TICK_NS;
+    warm_baseline(&b, 2.0, &clk);
+    double base_start = b.baseline_aas;
+    /* Hold AAS=20 for well past the horizon + enough slow-EWMA memory to climb.
+     * Slow alpha = (1/600)/10; ~2000+ extra ticks after the horizon lets the
+     * baseline move a meaningful fraction toward 20. */
+    feed(&b, 20.0, 0.0, 2000, &clk, NULL);   /* reach the horizon (no move) */
+    double base_at_horizon = b.baseline_aas;
+    CHECK(base_at_horizon < base_start + 1.0,
+          "baseline still protected right up to the horizon (%.2f)",
+          base_at_horizon);
+    feed(&b, 20.0, 0.0, 30000, &clk, NULL);  /* learn through past the horizon */
+    CHECK(b.baseline_aas > base_at_horizon + 2.0,
+          "sustained regime change IS learned through (%.2f -> %.2f, toward 20)",
+          base_at_horizon, b.baseline_aas);
+    CHECK(b.baseline_aas < 20.0,
+          "learn-through is SLOW, not instant (baseline %.2f still < 20)",
+          b.baseline_aas);
+}
+
 /* ── Test 9: AAS + lock can fire together (combined fired_mask) ────────── */
 static void test_combined_fire(void)
 {
@@ -384,6 +489,8 @@ int main(void)
     test_budget_boundary();
     test_metrics_from_batch();
     test_cpu_storm_fires();
+    test_lock_min_activity();
+    test_baseline_learn_through();
     test_combined_fire();
 
     printf("\n%d/%d checks passed\n", tests_passed, tests_run);

--- a/tests/test_capture_smoke.py
+++ b/tests/test_capture_smoke.py
@@ -277,11 +277,13 @@ def server_query(trace_dir, cmd, extra=None):
 def assert_wait_events(events, source, sleep_hi=6000):
     """Deterministic-wait assertions, applied to live view or trace rows.
 
-    sleep_hi: live-view callers pass 7000 — in tiered mode the live
-    accumulator is fed by both the sampler and the exact stream, inflating
-    totals up to ~2x (the known ESC-3 double-count, owned by Phase T3;
-    observed 5710ms for a 3s sleep). Once T3 gates sampler accumulation
-    during exact coverage, tighten this back to 6000."""
+    sleep_hi: 6000 for every caller. Before T3, tiered live callers had to pass
+    7000 because the live accumulator was fed by BOTH the sampler and the exact
+    stream during an escalation window, inflating a 3s sleep up to ~5.7s (the
+    ESC-3 double-count). T3 gates the sampler's contribution for pids under a
+    live watchpoint (pgwt_sampler_accumulate), so the live view now matches the
+    post-hoc trace view within the same tolerance — this tightened bound is the
+    ESC-3 regression proof."""
     names = [e['name'] for e in events]
 
     sleep_ev = [e for e in events if e['name'] == 'Timeout:PgSleep']
@@ -334,7 +336,9 @@ def phase_live_system_event(pm_pid, mode):
     check(len(events) > 0,
           "live view shows at least one event" if events else
           f"live view shows at least one event (stderr tail: {err[-300:]!r})")
-    assert_wait_events(events, f"live/{mode}", sleep_hi=7000)
+    # ESC-3: the live view must now match the trace view within the tight
+    # tolerance (no sampler+exact double-count during escalation).
+    assert_wait_events(events, f"live/{mode}")
 
 
 def phase_live_query_event(pm_pid, mode):
@@ -549,15 +553,15 @@ def aas_bucket_total(bucket):
                if k not in ("t", "total", "cat") and isinstance(v, (int, float)))
 
 
-def ctl_query(trace_dir, cmd):
-    """One JSON request over the daemon control socket."""
+def ctl_request(trace_dir, obj):
+    """One arbitrary JSON request over the daemon control socket."""
     import socket
     path = os.path.join(trace_dir, "pgwt.sock")
     s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
     s.settimeout(5)
     try:
         s.connect(path)
-        s.sendall((json.dumps({"cmd": cmd}) + "\n").encode())
+        s.sendall((json.dumps(obj) + "\n").encode())
         buf = b""
         while b"\n" not in buf:
             c = s.recv(4096)
@@ -567,6 +571,11 @@ def ctl_query(trace_dir, cmd):
         return json.loads(buf.decode().split("\n")[0])
     finally:
         s.close()
+
+
+def ctl_query(trace_dir, cmd):
+    """One JSON request over the daemon control socket."""
+    return ctl_request(trace_dir, {"cmd": cmd})
 
 
 def phase_sampled_aas_truth(pm_pid):
@@ -708,6 +717,88 @@ def phase_cpu_storm_escalation(pm_pid):
     subprocess.run(["rm", "-rf", trace_dir])
 
 
+def phase_escalation_billing(pm_pid):
+    """T3 (ESC-1/2): a MANUAL escalation window bills its full-fidelity time
+    honestly (budget drops by ~the window length), and a wait that is still
+    OPEN when the window closes is flushed into the trace exactly once (ESC-2)
+    instead of vanishing into an end-of-window hole."""
+    print("--- Phase 7: manual escalation billing + de-escalation flush ---")
+    trace_dir = tempfile.mkdtemp(prefix="pgwt_smoke_esc2_")
+    os.chmod(trace_dir, 0o755)
+
+    # A lock wait held OPEN across the whole phase (never released) so it is
+    # still in-flight at de-escalation — the exact case ESC-2 must not drop.
+    wl = Workload()
+    wl.open_sessions()
+
+    budget = 60
+    tracer = subprocess.Popen(
+        [TRACER, "--mode", "tiered", "--pid", str(pm_pid),
+         "-T", trace_dir, "--duration", "22", "--quiet", "--interval", "2",
+         "--escalation-budget", str(budget),
+         # Disable anomaly auto-escalation so the ONLY window is the manual one
+         # we drive (clean billing accounting).
+         "--anomaly-aas-factor", "1000000"],
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    time.sleep(3.0)   # BPF load + scan
+    try:
+        wl.fire(sleep_s=1)   # start the lock wait (waiter blocks, stays blocked)
+        time.sleep(1.0)
+
+        budget_before = ctl_query(trace_dir, "status").get(
+            "escalation_budget_remaining_s", budget)
+
+        # Manually escalate for 5s.
+        esc = ctl_request(trace_dir, {"cmd": "escalate", "duration_s": 5,
+                                      "reason": "manual"})
+        check(esc.get("ok") is True and esc.get("granted_s", 0) >= 4,
+              f"manual escalate granted a ~5s window (resp={esc})")
+        tier = ctl_query(trace_dir, "status").get("tier")
+        check(tier == "escalated",
+              f"tier flipped to escalated during the window (got {tier!r})")
+
+        time.sleep(3.0)   # capture exact transitions mid-window
+        # De-escalate WHILE the lock wait is still open (ESC-2 flush path).
+        deesc = ctl_request(trace_dir, {"cmd": "deescalate"})
+        check(deesc.get("ok") is True,
+              f"manual deescalate acknowledged (resp={deesc})")
+
+        m = ctl_query(trace_dir, "metrics")
+        budget_after = m.get("escalation_budget_remaining_s", budget)
+        windows = m.get("escalation_windows_total", 0)
+        spent = budget_before - budget_after
+        check(windows >= 1,
+              f"escalation_windows_total >= 1 (got {windows})")
+        # Billed time must be > 0 and no more than the window we ran (~3-5s),
+        # i.e. billing tracks the actual open window, never over-charges.
+        check(0.5 <= spent <= 6.0,
+              f"budget billed ~= window length: spent {spent:.1f}s of a "
+              f"~3-5s window [ESC-1 honest billing]")
+
+        _, stderr = tracer.communicate(timeout=40)
+        err = stderr.decode('utf-8', errors='replace')
+
+        # ESC-2: the lock wait, open across the window boundary, must be in the
+        # trace (the flush recorded its exact portion; without ESC-2 the
+        # end-of-window hole dropped it).
+        resp = server_query(trace_dir, "top_events")
+        events = [{'name': r.get('name'), 'count': r.get('count', 0),
+                   'total_ms': r.get('total_ms', 0.0)}
+                  for r in resp.get("rows", [])]
+        names = [e['name'] for e in events]
+        lock_ev = [e for e in events if e['name'] == 'Lock:relation']
+        check(len(lock_ev) > 0,
+              f"Lock:relation spanning the window boundary is in the trace "
+              f"(saw {names}) [ESC-2 flush]"
+              + ("" if lock_ev else f" (stderr tail: {err[-300:]!r})"))
+    except subprocess.TimeoutExpired:
+        tracer.kill()
+        tracer.communicate()
+    finally:
+        wl.stop()
+        subprocess.run(["rm", "-rf", trace_dir])
+
+
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('--pid', type=int, help='Postmaster PID')
@@ -754,6 +845,8 @@ def main():
         # continuity checks (docs/AAS_SEMANTICS_DECISION.md).
         phase_sampled_aas_truth(pm_pid)
         phase_cpu_storm_escalation(pm_pid)
+        # T3: manual escalation billing (ESC-1) + de-escalation flush (ESC-2).
+        phase_escalation_billing(pm_pid)
 
     print(f"\n{tests_passed}/{tests_run} checks passed")
     sys.exit(0 if tests_failed == 0 else 1)

--- a/tests/test_control.sh
+++ b/tests/test_control.sh
@@ -84,6 +84,8 @@ sys.stdout.write(buf.decode().split("\n")[0])
 PYEOF
 }
 
+jget() { python3 -c "import json,sys; print(json.load(sys.stdin)$1)"; }
+
 # ── Start daemon ──────────────────────────────────────────────
 # Deliberately NO --mode: this also serves as the "default mode is tiered"
 # check. Started bare, the daemon must come up in tiered mode with the
@@ -153,6 +155,13 @@ for k in ('events_total', 'events_per_sec', 'lifecycle_events_total',
     assert isinstance(r[k], (int, float)), k
 "
 check $? "metrics: all counters present and numeric"
+
+# ── ESC-9: metrics.tier must agree with status.tier (never derive tier
+#    solely from escalation.active — that reported "sampled" in --mode full). ─
+STATUS_TIER=$(echo "$STATUS" | jget "['tier']")
+METRICS_TIER=$(echo "$METRICS" | jget "['tier']")
+[[ "$STATUS_TIER" == "$METRICS_TIER" ]]
+check $? "metrics.tier == status.tier (ESC-9; both '$STATUS_TIER')"
 
 # Tiered default: the always-on tier is the sampler, so it's samples_total
 # (not the watchpoint events_total) that moves. samples_total is part of the
@@ -241,6 +250,25 @@ check $? "concurrent clients + disconnect mid-request survived"
 
 kill -0 "$TRACER_PID" 2>/dev/null
 check $? "daemon still alive after client abuse"
+
+# ── ESC-10: a second daemon must REFUSE to steal a live control socket ─────
+# The old code unconditionally unlink()'d the socket, letting a second daemon
+# hijack a running daemon's control plane (and its trace dir). The liveness
+# probe must make the second daemon exit non-zero with a clear message while
+# the original daemon and its socket survive.
+SECOND_LOG=$(mktemp /tmp/pgwt_control_second_XXXXXX.log)
+"$TRACER" --daemon --pid "$PM_PID" -i 1 -T "$TRACE_DIR" -v \
+    >/dev/null 2>"$SECOND_LOG"
+SECOND_RC=$?
+[[ $SECOND_RC -ne 0 ]] && grep -qi "already running" "$SECOND_LOG"
+check $? "second daemon on the same trace dir refused (rc=$SECOND_RC, ESC-10)"
+# Original daemon + socket must be untouched.
+kill -0 "$TRACER_PID" 2>/dev/null && [[ -S "$SOCK" ]]
+check $? "original daemon + live socket survive the refused second start"
+ORIG_OK=$(ctl '{"cmd":"status"}' | jget "['ok']" 2>/dev/null)
+[[ "$ORIG_OK" == "True" ]]
+check $? "original daemon still answers on its control socket (ESC-10)"
+rm -f "$SECOND_LOG"
 
 # ── pgwt-server control proxy ─────────────────────────────────
 RESP=$(echo '{"id":7,"cmd":"control","request":{"cmd":"status"}}' | \

--- a/tests/test_escalation.sh
+++ b/tests/test_escalation.sh
@@ -118,8 +118,10 @@ assert r['tier']=='sampled', r
 assert r['escalation_supported'] is True, r
 assert r['escalation_seconds_remaining']==0, r
 assert abs(r['escalation_budget_remaining_s']-$BUDGET) < 1.0, r
+# ESC-6: a finite budget is not unlimited.
+assert r.get('escalation_budget_unlimited') is False, r
 "
-check $? "status: tiered/sampled, full budget, supported"
+check $? "status: tiered/sampled, full budget, supported, not-unlimited"
 
 # ── escalate for 4s ───────────────────────────────────────────
 RESP=$(ctl '{"cmd":"escalate","duration_s":4,"reason":"manual test"}')
@@ -140,6 +142,11 @@ STATUS=$(ctl '{"cmd":"status"}')
 TIER=$(echo "$STATUS" | jget "['tier']")
 [[ "$TIER" == "escalated" ]]
 check $? "tier flipped to escalated (got: $TIER)"
+
+# ESC-9: metrics.tier must agree with status.tier even while escalated.
+MTIER=$(ctl '{"cmd":"metrics"}' | jget "['tier']")
+[[ "$MTIER" == "$TIER" ]]
+check $? "metrics.tier == status.tier while escalated (ESC-9; both '$TIER')"
 
 # ── window expires on its own ─────────────────────────────────
 sleep 6
@@ -169,10 +176,30 @@ TIER=$(ctl '{"cmd":"status"}' | jget "['tier']")
 [[ "$TIER" == "sampled" ]]
 check $? "tier sampled after manual deescalate (got: $TIER)"
 
-# ── budget exhaustion → deny ──────────────────────────────────
-# We've now spent ~4s (expired) + ~0-1s (deescalated) of the 10s budget.
-# Ask for a window larger than the remaining budget; it must be denied.
+# ── ESC-1 budget clamp: a request larger than the remaining budget is
+#    CLAMPED to what's left (not denied) so the window runs up to the cap. ──
+# We've spent ~4s (expired) + ~0-1s (deescalated) of the 10s budget, so a few
+# seconds remain. Ask for an hour; it must be granted but clamped to <= budget.
 RESP=$(ctl '{"cmd":"escalate","duration_s":3600,"reason":"greedy"}')
+echo "  clamp: $RESP"
+echo "$RESP" | python3 -c "
+import json,sys
+r=json.load(sys.stdin)
+assert r['ok'] is True, r                       # granted, not denied
+assert 0 < r['granted_s'] <= $BUDGET, r         # clamped to <= budget
+"
+check $? "over-ask escalate is CLAMPED to the remaining budget (ESC-1)"
+
+# Let this clamped window run to expiry so the budget is fully spent.
+sleep $(($BUDGET + 2))
+STATUS=$(ctl '{"cmd":"status"}')
+REM=$(echo "$STATUS" | jget "['escalation_budget_remaining_s']")
+python3 -c "import sys; sys.exit(0 if float('$REM') < 1.0 else 1)"
+check $? "budget fully spent after the clamped window expired (rem=$REM)"
+
+# ── budget exhaustion → deny ──────────────────────────────────
+# With ~0 budget left, a further escalate must now be DENIED with a reason.
+RESP=$(ctl '{"cmd":"escalate","duration_s":5,"reason":"exhausted"}')
 echo "  over-budget: $RESP"
 echo "$RESP" | python3 -c "
 import json,sys
@@ -181,7 +208,7 @@ assert r['ok'] is False, r
 assert 'budget' in r['error'].lower(), r
 assert 'budget_remaining_s' in r, r
 "
-check $? "escalate over budget is denied with a reason"
+check $? "escalate on an exhausted budget is denied with a reason"
 
 # denied_total counter moved
 DENIED=$(ctl '{"cmd":"metrics"}' | jget "['escalation_denied_total']")

--- a/tests/test_escalation_budget.c
+++ b/tests/test_escalation_budget.c
@@ -1,0 +1,295 @@
+/* test_escalation_budget.c — Unit tests for the pure escalation budget core
+ * (Phase T3: ESC-1/5/6).
+ *
+ * Drives escalation_budget.c (BPF-free, daemon-free) with a scripted clock to
+ * pin the budget invariants the plan's definition-of-done demands:
+ *   - ESC-1: worst-case full-fidelity seconds per hour <= budget under
+ *     ADVERSARIAL requests — the extend-every-second attack caps at EXACTLY
+ *     the budget (committed-remainder-aware charge + deadline clamp).
+ *   - ESC-5: ledger overflow never opens an UNBILLED window (coalesce bills
+ *     conservatively).
+ *   - ESC-6: --escalation-budget 0 = deny-all; 'unlimited' = no cap; both
+ *     report the truth.
+ *   - rolling-hour aging frees budget back.
+ *
+ * Compiles escalation_budget.c directly — no skeleton, no daemon, no BPF —
+ * runnable in CI's server-only jobs (same pattern as test_sampler/test_anomaly).
+ */
+#define _GNU_SOURCE
+#include "escalation.h"
+#include "escalation_budget.h"
+
+#include <stdio.h>
+#include <string.h>
+#include <stdint.h>
+
+static int tests_run = 0;
+static int tests_passed = 0;
+
+#define CHECK(cond, fmt, ...) do { \
+    tests_run++; \
+    if (cond) { tests_passed++; } \
+    else { printf("  FAIL: " fmt "\n", ##__VA_ARGS__); } \
+} while(0)
+
+#define SEC 1000000000ULL
+#define HOUR (3600ULL * SEC)
+
+static void init_engine(struct pgwt_escalation *e, uint64_t budget_ns,
+                        bool unlimited)
+{
+    memset(e, 0, sizeof(*e));
+    e->rolling_window_ns = HOUR;
+    e->budget_ns = budget_ns;
+    e->budget_unlimited = unlimited;
+}
+
+/* ── Test 1: a fresh grant within budget is billed exactly ─────────────── */
+static void test_fresh_grant(void)
+{
+    printf("--- fresh grant within budget bills exactly ---\n");
+    struct pgwt_escalation e;
+    init_engine(&e, 10 * SEC, false);
+
+    uint64_t now = 100 * SEC;
+    uint64_t grant = 0;
+    const char *why = NULL;
+    int rc = pgwt_esc_budget_decide(&e, now, 4 * SEC, &grant, &why);
+    CHECK(rc == 0, "decide within budget should succeed (why=%s)",
+          why ? why : "");
+    CHECK(grant == 4 * SEC, "grant=%.1fs expected 4", (double)grant / 1e9);
+
+    pgwt_esc_ledger_open(&e, now);
+    /* window runs to now+grant, then closes */
+    pgwt_esc_ledger_close(&e, now + grant);
+
+    uint64_t consumed = pgwt_esc_budget_consumed_ns(&e, now + grant);
+    CHECK(consumed == 4 * SEC, "consumed=%.1fs expected 4",
+          (double)consumed / 1e9);
+    uint64_t rem = pgwt_esc_budget_remaining_ns(&e, now + grant);
+    CHECK(rem == 6 * SEC, "remaining=%.1fs expected 6", (double)rem / 1e9);
+}
+
+/* ── Test 2: extend-every-second caps total at EXACTLY the budget (ESC-1) ─ */
+static void test_extend_every_second_caps(void)
+{
+    printf("--- ESC-1: extend-every-second caps at exactly the budget ---\n");
+    const uint64_t budget = 10 * SEC;
+    struct pgwt_escalation e;
+    init_engine(&e, budget, false);
+
+    uint64_t start = 500 * SEC;
+    uint64_t grant = 0;
+    const char *why = NULL;
+
+    /* Fresh escalate at t=start for a huge window — must clamp to budget. */
+    int rc = pgwt_esc_budget_decide(&e, start, HOUR, &grant, &why);
+    CHECK(rc == 0, "initial escalate should be granted");
+    CHECK(grant == budget, "initial grant clamped to budget (%.1fs)",
+          (double)grant / 1e9);
+    pgwt_esc_ledger_open(&e, start);
+    uint64_t deadline = start + grant;
+
+    /* Now hammer an extension every second with a huge request. The clamp must
+     * hold the deadline at exactly start+budget no matter how many extends. */
+    int denied_after = -1;
+    for (int k = 1; k <= 20; k++) {
+        uint64_t now = start + (uint64_t)k * SEC;
+        grant = 0;
+        why = NULL;
+        rc = pgwt_esc_budget_decide(&e, now, HOUR, &grant, &why);
+        if (rc == 0) {
+            uint64_t nd = now + grant;
+            if (nd > deadline)
+                deadline = nd;
+        } else if (denied_after < 0) {
+            denied_after = k;   /* budget hit here */
+        }
+    }
+    CHECK(deadline == start + budget,
+          "deadline pinned at start+budget: got +%.1fs expected +%.1fs",
+          (double)(deadline - start) / 1e9, (double)budget / 1e9);
+    CHECK(denied_after >= 10 && denied_after <= 11,
+          "extensions denied once budget consumed (~t=10s, got t=%ds)",
+          denied_after);
+
+    /* Close at the (clamped) deadline; total billed must be EXACTLY budget. */
+    pgwt_esc_ledger_close(&e, deadline);
+    uint64_t consumed = pgwt_esc_budget_consumed_ns(&e, deadline);
+    CHECK(consumed == budget,
+          "total full-fidelity billed = %.3fs, must equal budget %.1fs",
+          (double)consumed / 1e9, (double)budget / 1e9);
+}
+
+/* ── Test 3: mid-window over-budget detection (ESC-1 clamp backstop) ────── */
+static void test_budget_over(void)
+{
+    printf("--- ESC-1: budget_over trips once consumption reaches budget ---\n");
+    struct pgwt_escalation e;
+    init_engine(&e, 5 * SEC, false);
+    uint64_t start = 0;
+    pgwt_esc_ledger_open(&e, start);
+
+    CHECK(!pgwt_esc_budget_over(&e, start + 3 * SEC),
+          "3s into a 5s budget is not over");
+    CHECK(pgwt_esc_budget_over(&e, start + 5 * SEC),
+          "5s into a 5s budget IS over");
+    CHECK(pgwt_esc_budget_over(&e, start + 8 * SEC),
+          "8s into a 5s budget is over");
+}
+
+/* ── Test 4: budget 0 = deny-all; unlimited = no cap (ESC-6) ────────────── */
+static void test_zero_and_unlimited(void)
+{
+    printf("--- ESC-6: budget 0 denies all; unlimited never caps ---\n");
+
+    struct pgwt_escalation zero;
+    init_engine(&zero, 0, false);
+    uint64_t grant = 12345;
+    const char *why = NULL;
+    int rc = pgwt_esc_budget_decide(&zero, 0, 60 * SEC, &grant, &why);
+    CHECK(rc == -1, "budget 0 must DENY every escalation");
+    CHECK(why != NULL && strstr(why, "disabled") != NULL,
+          "denial reason mentions 'disabled' (got: %s)", why ? why : "(null)");
+    CHECK(pgwt_esc_budget_remaining_ns(&zero, 0) == 0,
+          "budget 0 reports 0 remaining (honest)");
+    CHECK(!pgwt_esc_budget_over(&zero, 0),
+          "budget 0 never reports over (no window ever opens)");
+
+    struct pgwt_escalation unl;
+    init_engine(&unl, 0, true);   /* budget_ns ignored when unlimited */
+    grant = 0;
+    rc = pgwt_esc_budget_decide(&unl, 0, HOUR, &grant, &why);
+    CHECK(rc == 0, "unlimited grants any request");
+    CHECK(grant == HOUR, "unlimited grants the full request (%.0fs)",
+          (double)grant / 1e9);
+    CHECK(pgwt_esc_budget_remaining_ns(&unl, 0) == UINT64_MAX,
+          "unlimited reports UINT64_MAX remaining (the ∞ sentinel)");
+    /* Even after opening/closing many windows, unlimited never caps. */
+    pgwt_esc_ledger_open(&unl, 0);
+    pgwt_esc_ledger_close(&unl, HOUR);
+    rc = pgwt_esc_budget_decide(&unl, HOUR, HOUR, &grant, &why);
+    CHECK(rc == 0 && !pgwt_esc_budget_over(&unl, HOUR),
+          "unlimited still grants after heavy use");
+}
+
+/* ── Test 5: ledger overflow is BILLED, never unbilled (ESC-5) ──────────── */
+static void test_ledger_overflow_billed(void)
+{
+    printf("--- ESC-5: ledger overflow coalesces, never opens unbilled ---\n");
+    /* Unlimited budget so the ONLY thing under test is ledger capacity, not
+     * budget denial. Pack many short windows within the rolling hour. */
+    struct pgwt_escalation e;
+    init_engine(&e, 0, true);
+
+    /* Open+close PGWT_ESC_LEDGER_MAX + 50 windows, each 1s long, 2s apart, all
+     * within the rolling hour (base at 0). That's 306 windows into 256 slots. */
+    uint64_t base = SEC;
+    int total = PGWT_ESC_LEDGER_MAX + 50;
+    for (int i = 0; i < total; i++) {
+        uint64_t open = base + (uint64_t)i * 2 * SEC;
+        pgwt_esc_ledger_open(&e, open);
+        CHECK(e.ledger_count <= PGWT_ESC_LEDGER_MAX,
+              "ledger_count never exceeds MAX (got %d at i=%d)",
+              e.ledger_count, i);
+        pgwt_esc_ledger_close(&e, open + SEC);
+    }
+
+    /* Every window was 1s of real capture => >= total seconds must be billed
+     * (coalescing over-bills the gaps, so consumed is AT LEAST the true sum).
+     * The key property: NOTHING was silently dropped/unbilled. */
+    uint64_t now = base + (uint64_t)total * 2 * SEC;
+    uint64_t consumed = pgwt_esc_budget_consumed_ns(&e, now);
+    CHECK(consumed >= (uint64_t)total * SEC,
+          "consumed=%.1fs >= true captured %.1fs (never under-bills)",
+          (double)consumed / 1e9, (double)total);
+    CHECK(e.ledger_count <= PGWT_ESC_LEDGER_MAX,
+          "final ledger_count=%d within MAX", e.ledger_count);
+
+    /* And an overflow open still records a genuinely-open segment. */
+    pgwt_esc_ledger_open(&e, now);
+    int open_segs = 0;
+    for (int i = 0; i < e.ledger_count; i++)
+        if (e.ledger[i].end_ns == 0)
+            open_segs++;
+    CHECK(open_segs == 1, "exactly one open segment after overflow open (got %d)",
+          open_segs);
+}
+
+/* ── Test 6: rolling-hour aging frees budget back ──────────────────────── */
+static void test_rolling_aging(void)
+{
+    printf("--- rolling hour: stale segments age out and free budget ---\n");
+    struct pgwt_escalation e;
+    init_engine(&e, 10 * SEC, false);
+
+    /* Spend the whole budget at t≈0 (one 10s window). */
+    pgwt_esc_ledger_open(&e, 0);
+    pgwt_esc_ledger_close(&e, 10 * SEC);
+    CHECK(pgwt_esc_budget_remaining_ns(&e, 10 * SEC) == 0,
+          "budget exhausted right after the window");
+
+    /* At exactly +1h the whole [0,10s] window is still inside the rolling
+     * hour (window_start == 0): still fully spent. */
+    CHECK(pgwt_esc_budget_remaining_ns(&e, HOUR) == 0,
+          "still exhausted while the window is fully inside the rolling hour");
+
+    /* Halfway aged (now = +1h+5s): only [5s,10s] remains in-window = 5s spent,
+     * so 5s of budget has been freed. */
+    CHECK(pgwt_esc_budget_remaining_ns(&e, HOUR + 5 * SEC) == 5 * SEC,
+          "half the window aged out frees half the budget");
+
+    /* Past the window end + 1h: fully aged out, budget fully restored. */
+    uint64_t rem = pgwt_esc_budget_remaining_ns(&e, HOUR + 11 * SEC);
+    CHECK(rem == 10 * SEC, "budget fully restored after aging (%.1fs)",
+          (double)rem / 1e9);
+}
+
+/* ── Test 7: an EXTENSION only charges the committed remainder once (ESC-1) */
+static void test_extension_no_double_charge(void)
+{
+    printf("--- ESC-1: extension charges committed remainder exactly once ---\n");
+    struct pgwt_escalation e;
+    init_engine(&e, 60 * SEC, false);
+
+    uint64_t start = 0;
+    uint64_t grant = 0;
+    const char *why = NULL;
+
+    /* Escalate 20s. */
+    pgwt_esc_budget_decide(&e, start, 20 * SEC, &grant, &why);
+    CHECK(grant == 20 * SEC, "first grant 20s");
+    pgwt_esc_ledger_open(&e, start);
+
+    /* 5s later, extend to +20s from now (deadline 25s). Consumed so far is the
+     * open [0,5] = 5s; a further 20s is available well within the 60s budget,
+     * so grant must be the full 20s (no phantom double-charge of the 15s still
+     * committed). */
+    uint64_t now = 5 * SEC;
+    grant = 0;
+    int rc = pgwt_esc_budget_decide(&e, now, 20 * SEC, &grant, &why);
+    CHECK(rc == 0 && grant == 20 * SEC,
+          "extension grants full 20s within budget (got %.1fs)",
+          (double)grant / 1e9);
+
+    /* Close at the extended deadline (25s). Total billed = 25s, NOT 45s. */
+    pgwt_esc_ledger_close(&e, now + grant);
+    uint64_t consumed = pgwt_esc_budget_consumed_ns(&e, now + grant);
+    CHECK(consumed == 25 * SEC,
+          "total billed = %.1fs (single window [0,25]), expected 25",
+          (double)consumed / 1e9);
+}
+
+int main(void)
+{
+    test_fresh_grant();
+    test_extend_every_second_caps();
+    test_budget_over();
+    test_zero_and_unlimited();
+    test_ledger_overflow_billed();
+    test_rolling_aging();
+    test_extension_no_double_charge();
+
+    printf("\n%d/%d checks passed\n", tests_passed, tests_run);
+    return tests_passed == tests_run ? 0 : 1;
+}

--- a/tests/unit_tests.list
+++ b/tests/unit_tests.list
@@ -15,6 +15,7 @@ test_event_reader
 test_trace_v2
 test_sampler
 test_anomaly
+test_escalation_budget
 test_coop
 test_concurrent_rw
 test_durability

--- a/tests/web_unit/fidelity.test.mjs
+++ b/tests/web_unit/fidelity.test.mjs
@@ -234,6 +234,26 @@ test('escalate control: zero budget → cannot escalate', () => {
     assert.equal(m.canEscalate, false);
 });
 
+test('escalate control: zero budget = deny-all → cannot escalate (ESC-6)', () => {
+    // 0 now means escalation DISABLED — the control must not offer escalate.
+    const m = buildEscalateControl({
+        escalation_supported: true, tier: 'sampled',
+        escalation_budget_remaining_s: 0, escalation_budget_unlimited: false,
+    });
+    assert.equal(m.canEscalate, false);
+    assert.equal(m.budgetUnlimited, false);
+});
+
+test('escalate control: unlimited budget → can escalate, ∞ budget (ESC-6)', () => {
+    const m = buildEscalateControl({
+        escalation_supported: true, tier: 'sampled',
+        escalation_budget_remaining_s: -1, escalation_budget_unlimited: true,
+    });
+    assert.equal(m.budgetUnlimited, true);
+    assert.equal(m.canEscalate, true);
+    assert.match(m.budgetText, /∞/);
+});
+
 test('escalate control: unsupported daemon → not supported (hide control)', () => {
     assert.equal(buildEscalateControl({}).supported, false);
     assert.equal(buildEscalateControl({ escalation_supported: false }).supported, false);

--- a/web/static/lib/builders/fidelity.js
+++ b/web/static/lib/builders/fidelity.js
@@ -258,6 +258,8 @@ export function buildMetricsPanel(metrics, status) {
     const droppedBudget = num(metrics.anomaly_dropped_budget_total);
     const droppedCooldown = num(metrics.anomaly_dropped_cooldown_total);
     const budgetRemaining = num(metrics.escalation_budget_remaining_s);
+    const budgetUnlimited = metrics.escalation_budget_unlimited === true ||
+                            budgetRemaining < 0;   /* ESC-6 */
     const remaining = num(metrics.escalation_seconds_remaining);
     const active = !!metrics.escalation_active;
     const baselineAas = num(metrics.anomaly_baseline_aas);
@@ -277,7 +279,8 @@ export function buildMetricsPanel(metrics, status) {
         { label: 'Anomaly dropped', value: fmtInt(droppedBudget + droppedCooldown),
           hint: droppedBudget + ' over-budget, ' + droppedCooldown + ' in cooldown' },
         { label: 'Baseline AAS', value: baselineAas != null ? baselineAas.toFixed(2) : '–' },
-        { label: 'Budget left', value: fmtSeconds(budgetRemaining) },
+        { label: 'Budget left',
+          value: budgetUnlimited ? '∞' : fmtSeconds(budgetRemaining) },
     ];
 
     return {
@@ -311,6 +314,11 @@ export function buildEscalateControl(status) {
     const escalated = status.tier === 'escalated';
     const remainingS = num(status.escalation_seconds_remaining);
     const budgetRemainingS = num(status.escalation_budget_remaining_s);
+    /* ESC-6: unlimited budget = no cap. It surfaces as the explicit flag (and,
+     * for older daemons, as a negative remaining sentinel). Escalation is
+     * always allowed; a budget of exactly 0 = deny-all (escalation disabled). */
+    const unlimited = status.escalation_budget_unlimited === true ||
+                      budgetRemainingS < 0;
     const reason = status.escalation_reason || (escalated ? 'manual' : 'none');
 
     return {
@@ -319,12 +327,13 @@ export function buildEscalateControl(status) {
         reason,
         remainingS,
         budgetRemainingS,
+        budgetUnlimited: unlimited,
         buttonLabel: escalated
             ? 'Escalated · ' + Math.ceil(remainingS) + 's left'
             : 'Escalate 60s',
-        canEscalate: supported && budgetRemainingS > 0,
+        canEscalate: supported && (unlimited || budgetRemainingS > 0),
         canDeescalate: supported && escalated,
-        budgetText: fmtSeconds(budgetRemainingS) + ' budget',
+        budgetText: (unlimited ? '∞' : fmtSeconds(budgetRemainingS)) + ' budget',
     };
 }
 


### PR DESCRIPTION
Last correctness phase of the Trust Milestone. Hardens the tiered escalation engine and anomaly-trigger rules so worst-case full-fidelity time per hour is provably bounded, the live view during escalation matches the post-hoc trace, and the triggers stop burning the budget on noise.

## Per-finding status

| # | Fix | Regression proof |
|---|-----|------------------|
| **ESC-1** | Budget math extracted to a pure core (`src/escalation_budget.c`). Over-ask is **clamped** to the remaining budget, deadline armed at `now+grant`; `pgwt_escalation_check_budget()` on the daemon timer is the mid-window backstop. Repeated extensions cap total at exactly the budget. | `test_escalation_budget.c`: extend-every-second caps at exactly budget; extension charges committed remainder once |
| **ESC-2** | `flush_open_intervals()` writes each open wait as a final transition (ts = de-escalation instant) before detach + END marker. | capture-smoke escalation phase: lock wait open across the boundary appears in the trace |
| **ESC-3** | `pgwt_sampler_accumulate()` skips pids under a live watchpoint while escalated. | capture-smoke live-view tolerance tightened 7s → 6s |
| **ESC-4** | Lock rule requires `lock_fraction > F` **and** lock-class `AAS ≥ --anomaly-lock-min-aas` (default **2.0**). | `test_anomaly.c`: single-backend lock wait does NOT fire, convoy does |
| **ESC-5** | Ledger overflow coalesces the two oldest segments (bills the gap, never under-bills). | `test_escalation_budget.c`: 306 windows into 256 slots, nothing unbilled |
| **ESC-6** | `--escalation-budget 0` = **deny-all** (honest `0` remaining); `unlimited`/`-1` = no cap (`escalation_budget_unlimited`). | `test_escalation_budget.c` + web/`fidelity.test.mjs` |
| **ESC-7** | Baseline **slow learn-through**: after **15 min** continuously over, resume EWMA at **1/10** rate; short incidents never move the bar. | `test_anomaly.c`: short incident protected, sustained regime learned |
| **ESC-8** | Near-trigger log rate-limited to reason-mask changes + 60s summary (`anomaly_near_total` still counts all). | — |
| **ESC-9** | `metrics.tier` / `status.tier` share `daemon_tier_str()` (full mode → `escalated`). | `test_control.sh`: `metrics.tier == status.tier` |
| **ESC-10** | Control-socket liveness probe: a live daemon → second daemon refuses startup (fatal, rc −2). | `test_control.sh`: second daemon refused, original survives |
| **ESC-11/12** | Documented: ~50% duty cycle (cooldown from fire start) + weight-compensated `attach_all` stall bound. | README |

## ESC-6 / ESC-7 constants chosen

- **ESC-6**: `0` = deny-all (recommended in the plan; honest `0` remaining, escalate denied). `unlimited` (or `-1`) = no cap, surfaced as `escalation_budget_unlimited: true` with a `-1` remaining sentinel (∞ in the UI). Default stays **300 s/hour**.
- **ESC-7**: learn-through engages after **15 min** (`PGWT_ANOMALY_DEF_LEARN_THROUGH_MIN`) continuously over the threshold, then learns at **1/10** the normal EWMA rate (`PGWT_ANOMALY_DEF_SLOW_RELEASE_DIV`). Rationale: a genuine regime change persisting 15 min is very likely the new normal; learning at 1/10 the 60 s-memory EWMA adopts it over ~10 min, while any incident shorter than 15 min can never raise the bar (incident-protection preserved). Both pinned in `test_anomaly.c`.

## Testing

New `tests/test_escalation_budget.c` (pure budget/ledger core, 336 checks). Extended `test_anomaly.c` (97 checks). `test_control.sh` / `test_escalation.sh` integration. Capture-smoke gains a manual-escalation billing + de-escalation-flush phase and the tightened ESC-3 tolerance. `mock_server.py` and the web fidelity builder mirror the new fields (protocol-drift + web unit tests updated). Full C unit suite green locally; full BPF daemon builds clean.

## Scope

No T7 territory touched (CI workflow additions, release docs, version handshake). One semantic change worth noting: an over-budget manual escalate is now **clamped** to the remaining budget rather than denied outright (denial only when the budget is fully exhausted) — required so the first escalate of a large window still opens capture up to the cap. `test_escalation.sh` updated accordingly.