### PR TITLE
fix: straddle CPU command-gate (sampler + exact tier) + PIE VA resolution

### DIFF
--- a/src/backend.c
+++ b/src/backend.c
@@ -180,10 +180,28 @@ static int preseed_state_map(struct pgwt_daemon *d, pid_t pid, uint64_t addr,
             if (bpf_map_lookup_elem(state_fd, &k, &prev) == 0)
                 prev_cmd_open = prev.cmd_open;
         }
+        /* Straddle fix (exact tier): a backend already RUNNING a command when
+         * we first seed it missed the on_report_activity START edge, so its
+         * cmd_open would stay 0 and its we==0 (CPU) intervals would be
+         * mislabeled non-command churn and dropped — exact-tier CPU* collapses
+         * to 0 for that command (the full-mode analogue of the sampler
+         * straddle bug). Level-check the backend's own debug_query_string at
+         * seed time: non-NULL == inside a command (the pg_stat_activity
+         * state='active' window). This seeds the gate correctly from the first
+         * watchpoint fire; the emitted events then carry CMD_OPEN and the live
+         * accumulator counts the CPU. (mem_fd is already open on this backend;
+         * the read is against its own process-local global.) */
+        uint16_t seed_cmd_open = prev_cmd_open;
+        if (!seed_cmd_open && d->debug_query_string_addr) {
+            uint64_t dqs = 0;
+            if (pread(mem_fd, &dqs, sizeof(dqs),
+                      (off_t)d->debug_query_string_addr) == sizeof(dqs) && dqs)
+                seed_cmd_open = 1;
+        }
         struct pgwt_pid_state init_state = {
             .last_event = current_wei,
             .wp_live = 1,   /* a live watchpoint now owns last_event/last_ts */
-            .cmd_open = prev_cmd_open,
+            .cmd_open = seed_cmd_open,
             .last_ts = attach_ts,
             .last_query_id = current_qid,
             .wait_event_addr = addr,

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -380,16 +380,31 @@ int pgwt_daemon_init(struct pgwt_daemon *d)
         }
     }
 
-    /* Resolve debug_query_string address for BPF query text capture */
+    /* Resolve debug_query_string to its RUNTIME virtual address.
+     *
+     * PIE fix (#24 class, T8 §4): the raw ELF st_value from
+     * pgwt_find_symbol_offset() is only the runtime VA on non-PIE (ET_EXEC)
+     * binaries. On PIE (ET_DYN) builds — every Ubuntu/Debian PGDG package and
+     * EL9 — the runtime VA is load_base + st_value, and load_base is the
+     * per-process ASLR slide. Both consumers of this address dereference it in
+     * a backend's address space: the BPF query-TEXT path via
+     * bpf_probe_read_user() (in-task, target runtime VA) and the userspace
+     * command-open gate via pread(mem_fd) / process_vm_readv (T2, sampler.c +
+     * preseed). The raw vaddr therefore read garbage on PIE, collapsing query
+     * text capture AND the straddle CPU gate. Resolve like every other global
+     * (MyProc/MyBEEntry): the postmaster shares its load base with every forked
+     * backend, so one resolution against postmaster_pid yields the VA valid in
+     * all of them. */
     if (d->pg_binary_saved) {
-        uint64_t dqs_addr = pgwt_find_symbol_offset(d->pg_binary_saved,
-                                                     "debug_query_string");
+        uint64_t dqs_addr = pgwt_resolve_symbol(d->pg_binary_saved,
+                                                 "debug_query_string",
+                                                 d->postmaster_pid);
         d->skel->rodata->debug_query_string_addr = dqs_addr;
         /* Userspace copy: the sampler reads this global per-pid each tick as
          * the race-free command-open gate (T2 fix, see sampler.c). */
         d->debug_query_string_addr = dqs_addr;
         if (d->verbose && dqs_addr)
-            fprintf(stderr, "INFO: debug_query_string at 0x%lx\n",
+            fprintf(stderr, "INFO: debug_query_string at 0x%lx (runtime VA)\n",
                     (unsigned long)dqs_addr);
     }
 

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -385,6 +385,9 @@ int pgwt_daemon_init(struct pgwt_daemon *d)
         uint64_t dqs_addr = pgwt_find_symbol_offset(d->pg_binary_saved,
                                                      "debug_query_string");
         d->skel->rodata->debug_query_string_addr = dqs_addr;
+        /* Userspace copy: the sampler reads this global per-pid each tick as
+         * the race-free command-open gate (T2 fix, see sampler.c). */
+        d->debug_query_string_addr = dqs_addr;
         if (d->verbose && dqs_addr)
             fprintf(stderr, "INFO: debug_query_string at 0x%lx\n",
                     (unsigned long)dqs_addr);

--- a/src/daemon.h
+++ b/src/daemon.h
@@ -48,6 +48,8 @@ struct pgwt_counters {
 
     /* T2 decomposed-AAS observability (docs/AAS_SEMANTICS_DECISION.md). */
     uint64_t noncmd_cpu_samples_total; /* client we==0 readings outside a command (not recorded) */
+    uint64_t cmd_gate_recovered_total; /* on-CPU client samples the edge-gate missed, recovered
+                                        * from debug_query_string ground truth (EL9 fix) */
     uint64_t io_worker_samples_total;  /* io_worker readings taken (excluded from AAS) */
     uint64_t io_worker_busy_total;     /* ... of which busy (on-CPU or a real wait) */
     uint64_t prev_io_worker_samples;   /* snapshots at previous display tick */
@@ -111,6 +113,12 @@ struct pgwt_daemon {
     int         pgproc_wait_offset;  /* offsetof(PGPROC, wait_event_info); 0 if N/A */
     bool        wait_offset_validated; /* PG<17: a resolved addr held a sane value */
     uint64_t    my_be_entry_addr; /* address of MyBEEntry (for query_id) */
+    uint64_t    debug_query_string_addr; /* VA of debug_query_string global;
+                                          * non-NULL in a backend == inside a
+                                          * command (same window pg_stat_activity
+                                          * state='active' spans). Read per-pid by
+                                          * the sampler as the race-free command
+                                          * gate (0 = symbol not resolved). */
     int         interval;         /* seconds */
     int         duration;         /* seconds, 0 = unlimited */
     enum pgwt_view view;

--- a/src/sampler.c
+++ b/src/sampler.c
@@ -42,6 +42,70 @@ static int read_target_own_pid(const struct pgwt_sample_target *t,
     return ok;
 }
 
+/* Ground-truth command-gate + query_id read (T2, EL9 fix).
+ *
+ * on_report_activity / on_report_query_id maintain cmd_open and last_query_id
+ * in the BPF state_map by TRANSITION EDGE only — they fire once, at command
+ * start. A long command already in flight when the backend's state_map entry
+ * is created misses that single edge, so the entry's cmd_open/query_id stay 0
+ * for the ENTIRE command. This happens whenever the sampler starts tracking a
+ * backend mid-query: the "run a compute query, THEN attach the tracer" case
+ * (straddle at attach), or the sampled-tier new-backend seed race. Every
+ * on-CPU (we==0) sample of that command is then dropped by the build_batch
+ * gate — CPU* collapses to 0 — and the samples carry no query_id. The defect
+ * is latent in sampled/tiered mode on ALL platforms and PG versions; it
+ * surfaced first on EL9 because the manual repro ran a long straddling compute
+ * query (short/repeated queries re-fire the edge after the entry exists, so
+ * the bug hides).
+ *
+ * Reading the backend's OWN authoritative state is race-free:
+ *   cmd_open <- (debug_query_string != NULL): the executing-a-command window,
+ *               the same global the BPF query-text path reads. Resolved by
+ *               symbol for every PG version — no PgBackendStatus offset guess.
+ *               NULL between commands (verified: idle backend == NULL), so no
+ *               between-command CPU is counted (docs/AAS_SEMANTICS_DECISION.md
+ *               — the ~3x over-count the gate exists to prevent stays gone).
+ *   query_id <- PgBackendStatus.st_query_id (MyBEEntry -> +off): the field the
+ *               full-mode preseed already reads. Refreshed only while inside a
+ *               command (st_query_id can hold a stale id once idle) and only
+ *               when its offset is known (PG14+); PG13 keeps its B1 seed.
+ *
+ * Reads go against the target's OWN pid: both are process-LOCAL globals, so a
+ * foreign-pid read would return the reader's copy (SMP-2). *cmd_open /
+ * *query_id are left untouched on any read failure, so the caller keeps its
+ * edge-maintained fallback — this path never fabricates. */
+void pgwt_read_cmd_gate(pid_t pid, uint64_t dqs_addr, uint64_t be_entry_addr,
+                        int st_query_id_off, int *cmd_open, uint64_t *query_id)
+{
+    if (dqs_addr == 0)
+        return;   /* symbol unresolved — keep the edge-maintained fallback */
+
+    uint64_t dqs = 0;
+    struct iovec ld = { &dqs, sizeof(dqs) };
+    struct iovec rd = { (void *)(uintptr_t)dqs_addr, sizeof(dqs) };
+    if (process_vm_readv(pid, &ld, 1, &rd, 1, 0) != (ssize_t)sizeof(dqs))
+        return;   /* read failed — do not disturb the fallback */
+
+    int open_now = (dqs != 0) ? 1 : 0;
+    if (cmd_open)
+        *cmd_open = open_now;
+
+    if (open_now && query_id && be_entry_addr && st_query_id_off > 0) {
+        uint64_t be_ptr = 0;
+        struct iovec lb = { &be_ptr, sizeof(be_ptr) };
+        struct iovec rb = { (void *)(uintptr_t)be_entry_addr, sizeof(be_ptr) };
+        if (process_vm_readv(pid, &lb, 1, &rb, 1, 0) == (ssize_t)sizeof(be_ptr)
+            && be_ptr) {
+            uint64_t qid = 0;
+            struct iovec lq = { &qid, sizeof(qid) };
+            struct iovec rq = { (void *)(uintptr_t)(be_ptr + st_query_id_off),
+                                sizeof(qid) };
+            if (process_vm_readv(pid, &lq, 1, &rq, 1, 0) == (ssize_t)sizeof(qid))
+                *query_id = qid;
+        }
+    }
+}
+
 int pgwt_sampler_read_targets(const struct pgwt_sample_target *targets, int n,
                               uint32_t *out_vals, uint64_t *read_faults)
 {
@@ -732,6 +796,37 @@ int pgwt_sampler_poll(struct pgwt_daemon *d)
         uint32_t we = s->read_vals[i];
         if (we == 0 || !pgwt_is_idle_event(we))
             d->counters.io_worker_busy_total++;
+    }
+
+    /* T2 command-gate ground truth (EL9 fix). The state_map cmd_open the
+     * targets carry is transition-edge maintained: it is correct for a backend
+     * whose entry existed before its command began, but stuck at 0 for a
+     * command already in flight when the entry was created (attach straddle /
+     * new-backend seed race). That would drop the command's every on-CPU
+     * sample. Verify against the backend's OWN debug_query_string for exactly
+     * the samples at risk — an on-CPU (we==0) reading from a command-gated type
+     * (client/unknown) whose edge-gate is closed. This is the buggy set only;
+     * the common steady state (edge already open, or not on CPU) does zero
+     * extra reads. When ground truth says "in a command", also refresh the
+     * query_id the edge-uprobe likewise missed. */
+    if (d->debug_query_string_addr) {
+        for (int i = 0; i < n; i++) {
+            if (s->read_vals[i] != 0 || targets[i].cmd_open)
+                continue;   /* not on-CPU, or the edge already caught it */
+            if (targets[i].backend_type != PGWT_BT_CLIENT
+                && targets[i].backend_type != PGWT_BT_UNKNOWN)
+                continue;   /* only client/unknown CPU is command-gated */
+            int cg = 0;
+            uint64_t qg = targets[i].query_id;
+            pgwt_read_cmd_gate(targets[i].pid, d->debug_query_string_addr,
+                               d->my_be_entry_addr, d->st_query_id_offset,
+                               &cg, &qg);
+            if (cg) {
+                targets[i].cmd_open = 1;
+                targets[i].query_id = qg;
+                d->counters.cmd_gate_recovered_total++;
+            }
+        }
     }
 
     uint64_t invalid_before = d->counters.invalid_wait_reads_total;

--- a/src/sampler.h
+++ b/src/sampler.h
@@ -159,6 +159,20 @@ int pgwt_sampler_build_batch(const struct pgwt_sample_target *targets,
 uint32_t pgwt_backend_type_flag(enum pgwt_backend_type bt);
 int      pgwt_cpu_sample_recordable(enum pgwt_backend_type bt, int cmd_open);
 
+/* T2 (EL9 fix): read a backend's OWN authoritative command state, bypassing
+ * the transition-edge state_map. The on_report_activity/on_report_query_id
+ * uprobes fire only at command START; a command already in flight when the
+ * state_map entry is created loses that single edge and cmd_open/query_id stay
+ * 0 for the whole command (CPU* == 0, no attribution). Reading each tick is
+ * race-free: cmd_open <- (debug_query_string != NULL); query_id <-
+ * PgBackendStatus.st_query_id (only while in a command, when the offset is
+ * known). Reads against the target's own pid (both are process-local globals).
+ * The cmd_open and query_id outputs are untouched on read failure — the caller
+ * keeps its edge-maintained fallback. dqs_addr==0 (symbol unresolved) is a
+ * no-op. */
+void pgwt_read_cmd_gate(pid_t pid, uint64_t dqs_addr, uint64_t be_entry_addr,
+                        int st_query_id_off, int *cmd_open, uint64_t *query_id);
+
 /* SMP-3: effective sample period for the tick at `now_ns`, given the
  * previous tick's timestamp (0 = first tick → nominal). Late/missed ticks
  * yield a longer period so total sample weight tracks wall time; the result

--- a/tests/test_capture_smoke.py
+++ b/tests/test_capture_smoke.py
@@ -596,19 +596,20 @@ def ctl_query(trace_dir, cmd):
     return ctl_request(trace_dir, {"cmd": cmd})
 
 
-def phase_sampled_cpu_straddle(pm_pid):
+def phase_cpu_straddle(pm_pid, mode):
     """Regression for the edge-vs-level command-gate bug (found in EL9 live
-    validation, latent on ALL platforms). The on_report_activity uprobe
-    sets cmd_open only at command START; a command already IN FLIGHT when
-    the sampler first tracks the backend misses that edge, so cmd_open
-    stays 0 for the whole command and every on-CPU sample is dropped —
-    CPU* collapses to 0. Ubuntu CI missed it because the other CPU phases
-    fire their work AFTER the tracer attaches (edge caught) and CpuStorm
-    uses short re-firing statements. This phase does the opposite: ONE
-    long compute statement is already running before the tracer starts,
-    then sampled CPU must still be counted (via the per-tick
-    debug_query_string ground-truth gate). Pre-fix this asserted ~0."""
-    print("--- Phase: sampled-mode CPU straddle (command in flight at attach) ---")
+    validation, latent on ALL platforms, BOTH tiers). The on_report_activity
+    uprobe sets cmd_open only at command START; a command already IN FLIGHT
+    when the tracer first seeds the backend misses that edge, so cmd_open
+    stays 0 for the whole command and every we==0 (CPU) reading is dropped
+    as non-command churn — CPU* collapses to 0 for that command. Ubuntu CI
+    missed it because the other CPU phases fire their work AFTER attach (edge
+    caught) and CpuStorm uses short re-firing statements. This phase does the
+    opposite: ONE long compute statement is already running before the tracer
+    starts. sampled tier is fixed by the per-tick debug_query_string gate;
+    exact tier by seeding cmd_open from debug_query_string at preseed. Pre-fix
+    both asserted CPU ~0."""
+    print(f"--- Phase: CPU straddle, --mode {mode} (command in flight at attach) ---")
     trace_dir = tempfile.mkdtemp(prefix="pgwt_smoke_straddle_")
     os.chmod(trace_dir, 0o755)
 
@@ -623,15 +624,15 @@ def phase_sampled_cpu_straddle(pm_pid):
     hog.stdin.flush()
     time.sleep(2.5)   # the command is now in flight; its start-edge is past
 
-    tracer = subprocess.Popen(
-        [TRACER, "--mode", "tiered", "--pid", str(pm_pid),
-         "-T", trace_dir, "--duration", "12", "--quiet",
-         "--interval", "5", "--anomaly-aas-factor", "1000000"],
-        stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    argv = [TRACER, "--mode", mode, "--pid", str(pm_pid),
+            "-T", trace_dir, "--duration", "12", "--quiet", "--interval", "5"]
+    if mode == "tiered":
+        argv += ["--anomaly-aas-factor", "1000000"]  # keep it pure sampled
+    tracer = subprocess.Popen(argv, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     try:
-        time.sleep(3.0)          # BPF load + scan finds the in-flight backend
+        time.sleep(3.0)          # BPF load + scan/attach finds the in-flight backend
         win_from = time.time_ns()
-        time.sleep(7.0)          # sampled window over the straddling command
+        time.sleep(7.0)          # window over the straddling command
         win_to = time.time_ns()
         _, stderr = tracer.communicate(timeout=40)
         err = stderr.decode('utf-8', errors='replace')
@@ -658,7 +659,7 @@ def phase_sampled_cpu_straddle(pm_pid):
         # The single straddling backend is ~1 CPU-active session the whole
         # window. Pre-fix (edge-only gate) this was ~0 — the exact defect.
         check(cpu_mean >= 0.5,
-              f"in-flight command's CPU is counted in sampled mode: "
+              f"in-flight command's CPU is counted (--mode {mode}): "
               f"cpu AAS = {cpu_mean:.2f} (edge-vs-level regression; pre-fix ~0)")
 
     subprocess.run(["rm", "-rf", trace_dir])
@@ -948,12 +949,14 @@ def main():
               "hosted runner + live EL8/EL9 boxes (run_all.sh --require-live).")
     else:
         phase_fork_after_attach(pm_pid, args.mode)
+        # CPU straddle (command in flight at attach) — both tiers; the fix is
+        # per-tick for sampled and preseed-seeded for exact.
+        phase_cpu_straddle(pm_pid, args.mode)
         if args.mode == 'tiered':
             # T2 (AAS semantics): CPU-inclusive sampled AAS vs pg_stat_activity
             # ground truth, and the CPU-storm escalation + tier-switch
             # continuity checks (docs/AAS_SEMANTICS_DECISION.md).
             phase_sampled_aas_truth(pm_pid)
-            phase_sampled_cpu_straddle(pm_pid)
             phase_cpu_storm_escalation(pm_pid)
             # T3: manual escalation billing (ESC-1) + de-escalation flush (ESC-2).
             phase_escalation_billing(pm_pid)

--- a/tests/test_capture_smoke.py
+++ b/tests/test_capture_smoke.py
@@ -596,6 +596,74 @@ def ctl_query(trace_dir, cmd):
     return ctl_request(trace_dir, {"cmd": cmd})
 
 
+def phase_sampled_cpu_straddle(pm_pid):
+    """Regression for the edge-vs-level command-gate bug (found in EL9 live
+    validation, latent on ALL platforms). The on_report_activity uprobe
+    sets cmd_open only at command START; a command already IN FLIGHT when
+    the sampler first tracks the backend misses that edge, so cmd_open
+    stays 0 for the whole command and every on-CPU sample is dropped —
+    CPU* collapses to 0. Ubuntu CI missed it because the other CPU phases
+    fire their work AFTER the tracer attaches (edge caught) and CpuStorm
+    uses short re-firing statements. This phase does the opposite: ONE
+    long compute statement is already running before the tracer starts,
+    then sampled CPU must still be counted (via the per-tick
+    debug_query_string ground-truth gate). Pre-fix this asserted ~0."""
+    print("--- Phase: sampled-mode CPU straddle (command in flight at attach) ---")
+    trace_dir = tempfile.mkdtemp(prefix="pgwt_smoke_straddle_")
+    os.chmod(trace_dir, 0o755)
+
+    # One long, single-statement compute query — starts BEFORE the tracer.
+    hog = subprocess.Popen(
+        ["psql", "-U", "postgres", "-d", "postgres"],
+        stdin=subprocess.PIPE, stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL, text=True)
+    hog.stdin.write(
+        "SELECT count(*) FROM generate_series(1,600000000) g "
+        "WHERE (g*g) % 7 = 0;\n")
+    hog.stdin.flush()
+    time.sleep(2.5)   # the command is now in flight; its start-edge is past
+
+    tracer = subprocess.Popen(
+        [TRACER, "--mode", "tiered", "--pid", str(pm_pid),
+         "-T", trace_dir, "--duration", "12", "--quiet",
+         "--interval", "5", "--anomaly-aas-factor", "1000000"],
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    try:
+        time.sleep(3.0)          # BPF load + scan finds the in-flight backend
+        win_from = time.time_ns()
+        time.sleep(7.0)          # sampled window over the straddling command
+        win_to = time.time_ns()
+        _, stderr = tracer.communicate(timeout=40)
+        err = stderr.decode('utf-8', errors='replace')
+    except subprocess.TimeoutExpired:
+        tracer.kill()
+        _, stderr = tracer.communicate()
+        err = stderr.decode('utf-8', errors='replace')
+    finally:
+        try:
+            hog.stdin.write("\\q\n"); hog.stdin.flush()
+        except (BrokenPipeError, ValueError):
+            pass
+        hog.terminate()
+        cleanup_stale_backends()
+
+    resp = server_query(trace_dir, "aas",
+                        extra={"from": win_from, "to": win_to, "buckets": 7})
+    buckets = resp.get("buckets", [])
+    check(len(buckets) > 0,
+          "aas view has buckets over the straddle window" if buckets else
+          f"aas view has buckets (stderr tail: {err[-300:]!r})")
+    if buckets:
+        cpu_mean = sum(b.get("cpu", 0.0) for b in buckets) / len(buckets)
+        # The single straddling backend is ~1 CPU-active session the whole
+        # window. Pre-fix (edge-only gate) this was ~0 — the exact defect.
+        check(cpu_mean >= 0.5,
+              f"in-flight command's CPU is counted in sampled mode: "
+              f"cpu AAS = {cpu_mean:.2f} (edge-vs-level regression; pre-fix ~0)")
+
+    subprocess.run(["rm", "-rf", trace_dir])
+
+
 def phase_sampled_aas_truth(pm_pid):
     """T2 (AAS-1) definition-of-done: sampled AAS — now CPU-inclusive —
     must match pg_stat_activity 1s-sampling ground truth. A CPU-bound
@@ -885,6 +953,7 @@ def main():
             # ground truth, and the CPU-storm escalation + tier-switch
             # continuity checks (docs/AAS_SEMANTICS_DECISION.md).
             phase_sampled_aas_truth(pm_pid)
+            phase_sampled_cpu_straddle(pm_pid)
             phase_cpu_storm_escalation(pm_pid)
             # T3: manual escalation billing (ESC-1) + de-escalation flush (ESC-2).
             phase_escalation_billing(pm_pid)


### PR DESCRIPTION
Splits the **verified-green** straddle/command-gate fixes out of the T8 work branch (t2-fix-el9-cpu-gate, which has since grown in-progress T8 §5) so they can land on master independently. These three commits were all-green across the full CI matrix (PG13/16/17/18, PIE + non-PIE).

- **6fd2bf5** sampler straddle: per-tick `debug_query_string` level gate so on-CPU samples of a command already in flight at attach are counted (was CPU=0; verified 0→93.9% on EL9).
- **3ae19c9** exact-tier straddle: seed `cmd_open` from `debug_query_string` at preseed (verified full-mode 0→39.9%).
- **8b2b510** PIE fix: resolve `debug_query_string` to the per-process runtime VA (load-base adjusted) — the raw-vaddr reads were correct on non-PIE (EL9) but wrong on PIE (PGDG Ubuntu); caught by the new `phase_cpu_straddle` regression on the PG13/PG18 matrix cells.

Found during the EL9 close-out validation of the Trust Milestone. The deeper measured-CPU work (full mode infers CPU from wait gaps) continues as T8 (docs/T8_MEASURED_CPU_PLAN.md) on its own branch.

No AI attribution.