### PR TITLE
T8 revision: conserved CPU* + residual Off-CPU* (fixes both EL9 findings)

### DIFF
--- a/docs/T8_MEASURED_CPU_REVISION.md
+++ b/docs/T8_MEASURED_CPU_REVISION.md
@@ -1,0 +1,196 @@
+# T8 Revision — Conserved CPU\* + residual Off-CPU\* (measured-CPU accounting fix)
+
+Status: ⬜ PLANNED — gates v0.13 alongside/replacing the T8 acceptance.
+Date: 2026-07-19
+Base: branch `t2-fix-el9-cpu-gate` @ `96df0df` (the merged-ready T8), plus
+the merged straddle+PIE fixes (#48). This revision REPLACES T8's
+per-interval Off-CPU\* math and its self-check; it keeps T8's measured
+`sum_exec_runtime` capture, format v3, capability probe, and terminal
+flush.
+Origin: EL9 close-out validation (2 real findings) + a first-principles
+walkthrough of a mixed `CPU → LWLock → CPU → LWLock → IO → CPU` backend.
+
+---
+
+## 1. What the EL9 validation + analysis established
+
+The measured mechanism (BPF reads `task->se.sum_exec_runtime` at each
+watchpoint wait-boundary) is correct **in sum** but imprecise **per
+interval**, because `sum_exec_runtime` is only brought current at a
+scheduler tick (CONFIG_HZ=1000 → 1 ms) or a context switch. A backend
+that wakes, runs a **sub-millisecond CPU burst**, then enters a wait is
+read at the wait-entry *write* — BEFORE the deschedule updates the
+accumulator — so the burst's CPU is missing there and surfaces in the
+*next* read, attributed to the **wait** interval instead of the CPU
+interval that burned it.
+
+Measured consequences (Rocky 9.7, PG18):
+- Pure `pg_sleep` (real sleeps, no CPU between): `wait_gap_cpu ≈ 88 ms`
+  → the boundary/tick leak is negligible when there's no CPU to leak.
+- pgbench (sub-ms CPU bursts between frequent waits):
+  `wait_gap_cpu ≈ 24.3 s ≈ CPU* itself` → roughly half of all CPU is
+  mis-timestamped into the following wait intervals.
+
+**Two things are therefore reliable, and two are not:**
+- RELIABLE: (a) every interval's **wall duration** (watchpoint
+  timestamps — exact); (b) **Σ of all `cpu_ns`** = final − initial
+  `sum_exec_runtime` = the backend's **true total CPU** (telescoping
+  sum, leak-immune).
+- NOT reliable per-interval: which specific interval a sub-ms burst is
+  credited to, and hence any per-interval CPU/off-CPU/spin split for
+  wait-interleaved workloads.
+
+### Why the obvious per-interval fixes fail (do not attempt them)
+For the sequence `CPU1(5,5) → LWLock1(20,0) → CPU2(0.4,0.4) →
+LWLock2(15,0) → IO(10,0) → CPU3(3,3)` (dur, trueCPU in ms; true DB=53.4,
+CPU=8.4, LWLock=35, IO=10):
+- **Model A** — count wait `cpu_ns` into CPU\* AND keep full wait
+  durations, Off-CPU\* = Σ(we==0)(dur−cpu_ns): **double-counts** the
+  leaked CPU → DB Time overshoots by `Σ wait cpu_ns` (0.6 ms here; ~24 s
+  on pgbench).
+- **Model B** — wait class = dur−cpu_ns: **conserves DB Time** but
+  deflates wait time and inflates Off-CPU\* by the leak (~24 s on
+  pgbench). Both are unacceptable.
+
+## 2. The fix — residual Off-CPU\*, computed from exact totals only
+
+Never use per-interval `cpu_ns` for the CPU/off-CPU *split*. Use it only
+in the **sum**. Per accounting window (and per AAS bucket):
+
+```
+CPU*      = Σ cpu_ns over ALL intervals (we==0 AND wait intervals)   [conserved = true CPU]
+wait[c]   = Σ duration of intervals of wait-class c                  [exact from timestamps]
+DB Time   = Σ duration over ALL non-idle intervals                   [exact from timestamps]
+Off-CPU*  = max(0, DB Time − CPU* − Σ_c wait[c])                     [residual → runqueue/unaccounted]
+```
+
+Identity holds by construction: `CPU* + Off-CPU* + Σ wait[c] = DB Time`.
+It is **leak-immune**: the leak moves `cpu_ns` between the null-interval
+and the following wait-interval, but CPU\* is a *sum* (unchanged) and DB
+Time / wait durations come from *timestamps* (unaffected). So Off-CPU\*,
+computed as the residual, equals the real runqueue/preemption time of
+on-CPU gaps regardless of the leak.
+
+Verify on the §1 sequence: CPU\*=8.4, LWLock=35, IO=10,
+Off-CPU\*=53.4−8.4−45=**0** (free core → correct; Models A/B gave 0.6).
+Oversubscribed pure-CPU: CPU\*=measured (e.g. 66% of wall), waits=0,
+Off-CPU\*=DB−CPU\*=**34%** (the runqueue — Finding #1's headline, now
+correct). Oversubscribed wait-heavy: Off-CPU\*=DB−CPU\*−waits = real
+runqueue during null gaps.
+
+### What this delivers vs. does not (state honestly in docs/UI copy)
+- ACCURATE: per-backend / per-query / per-window **CPU\*** (fixes the
+  under-report), all **wait durations**, **DB Time**, and **Off-CPU\***
+  as the residual (runqueue + genuinely-unaccounted time — the 10046
+  "unaccounted-for time" line).
+- NOT AVAILABLE: trustworthy **per-interval** CPU placement, and any
+  **per-wait "spin vs blocked"** split. The wait interval's `cpu_ns` is
+  boundary-leaked pre-wait CPU, not in-wait spin — do NOT surface a
+  spin/blocked decomposition (it would lie). See §5 for the exact-per-
+  interval path (S3).
+
+## 3. Concrete changes
+
+### 3.1 compute.c (`compute_time_model`, `compute_aas`)
+- **CPU\* total** = Σ `cpu_ns` over ALL intervals whose `cpu_ns !=
+  UNKNOWN` (both `old_event==0` and wait intervals). Today (~line
+  682–704) wait `cpu_ns` only feeds the self-check counter and is
+  dropped from `cpu_measured_ns` — add it in.
+- **Remove the per-interval Off-CPU\* split** (the `dur − cpu_ns` per
+  on-CPU gap at ~line 682–687 / the `offcpu_aas += ov*(1−cpu_frac)` at
+  ~line 445–448). Replace with the **residual**: after summing CPU\* and
+  each wait class over the window/bucket, set
+  `offcpu = max(0, db_time − cpu_measured − wait_total)`.
+- **Remove the stale-0 → full-gap-as-CPU fallback** for measured-capable
+  data (it caused replay CPU\* > physical cores, Finding #1). A stale-0
+  `cpu_ns` on a we==0 gap means "the burst leaked to an adjacent
+  interval," not "the whole gap was CPU." Because CPU\* is now a sum,
+  the leaked burst is already counted in its landing interval — do not
+  re-add the full gap. Keep the fallback ONLY for `cpu_ns == UNKNOWN`
+  (legacy/v2/sampled, genuinely unmeasured): those windows show CPU\*
+  by the old gap-inference and **no Off-CPU\*** (can't compute a residual
+  without measured CPU).
+- **Off-CPU\* fidelity gating**: emit Off-CPU\* only for windows/buckets
+  where measured `cpu_ns` exists (v3 exact). Sampled/v2 windows: CPU\*
+  only, no Off-CPU\* row.
+- **Bounds**: clamp Off-CPU\* at 0 (never negative); count clamps in a
+  metric (`offcpu_clamped_total`) — a nonzero clamp means CPU\* exceeded
+  DB−waits, i.e. a measurement inconsistency worth surfacing.
+
+### 3.2 BPF / terminal flush (Finding #1 — replay > physical)
+- The terminal flush and the live open-interval path must emit
+  **schedstat-measured** `cpu_ns` for the still-open interval (read
+  `/proc/<pid>/schedstat` field 1 delta since the interval's seed), NOT
+  wall-as-CPU. This bounds a pure-CPU straddler's CPU\* to actual on-CPU
+  ns (≤ wall × 1 core per backend), so replay can never report CPU\* >
+  physical capacity. (T8 already added the flush; the bug was it
+  recorded the gap-inference wall value — switch it to the measured
+  value, consistent with §3.1 removing the fallback.)
+
+### 3.3 Self-check (Finding #2 reframe)
+- The premise "a wait burns ~0 CPU" is FALSE (sub-ms bursts leak into
+  waits). Replace the `test_cross_validate_tiered` wait-gap-≤1% check
+  with the **conservation** invariant: over a pgbench window, tracer
+  **CPU\*** must equal the sum of traced backends' `/proc/<pid>/stat`
+  utime+stime deltas within tolerance (e.g. ±10%). Keep
+  `wait_gap_cpu_ns_total` as an **observability** metric (it quantifies
+  how much CPU is boundary-attributed — useful diagnostics), not a gate.
+
+### 3.4 Views / mock / metrics
+- Off-CPU\* row/category unchanged in shape (already `offcpu`), now fed
+  by the residual. Mirror any field changes in `tests/mock_server.py`
+  (protocol-drift). `docs/TRACE_FORMAT.md` needs no format change (v3
+  `cpu_ns` column stays); update the compute/semantics prose.
+
+## 4. Tests / acceptance (the proof)
+1. **Sequence identity** (synthetic, `test_data_*`): a trace encoding a
+   mixed `CPU/LWLock/IO` sequence with a known sub-ms burst → assert
+   `CPU* + Off-CPU* + Σwaits == DB Time` exactly, wait durations exact,
+   CPU\* == Σ true cpu_ns. This is the regression that Models A/B fail.
+2. **Conservation (live, EL9)**: pgbench under `--mode full`; tracer
+   CPU\* within ±10% of Σ `/proc` utime+stime of the traced backends
+   over the window (replaces the wait-gap self-check).
+3. **Off-CPU\* under oversubscription (live)**: N_hogs > vCPU, pure-CPU
+   → Off-CPU\* > 0 and `CPU* + Off-CPU* ≈ DB Time`; and a NON-
+   oversubscribed run → Off-CPU\* ≈ 0 (the §1 sequence gives 0). Both
+   must hold (the old code gave false-positive Off-CPU\*).
+4. **Replay not > physical (live)**: the pure-CPU straddle trace,
+   replayed, reports CPU\* ≤ wall × ncores (Finding #1 closed).
+5. v3 round-trip, golden rev3, rev2-still-green, v2-fallback (CPU\* only,
+   no Off-CPU\*) — unchanged from T8, must stay green.
+6. All 8 CI jobs green; nightly `--core` semantics unchanged.
+
+## 5. Deferred, more-accurate alternative: S3 (sched_switch tracing)
+The residual model gives correct **totals** cheaply (no new probes) but
+**cannot** give per-interval CPU placement, per-wait spin/blocked, or
+per-interval Off-CPU\* for wait-interleaved workloads — the sub-ms leak
+is fundamental to reading `sum_exec_runtime` at wait boundaries.
+
+**S3** attaches a BPF program to the `sched_switch` tracepoint and
+accounts each tracked backend's on-CPU time at **every context switch**
+(exact, no tick quantization), keyed by the state_map. That yields:
+- exact per-interval CPU (no leak) → trustworthy per-interval Off-CPU\*,
+- a *real* per-wait on-CPU-spin vs truly-blocked decomposition,
+- exact CPU/wait attribution even for sub-ms bursts.
+
+Cost: the tracepoint fires for **every** context switch system-wide
+(filter-and-drop for untracked pids is ~tens of ns, but on a busy host
+that's 10⁵–10⁶ events/s of overhead-bearing work), and it's a larger
+BPF surface + a per-CPU reorder concern. It is the right foundation for
+a future **off-CPU analysis** track (runqueue latency, involuntary vs
+voluntary switches) but is more machinery than v0.13 needs. This
+revision's data model (measured `cpu_ns` + residual Off-CPU\*) is
+forward-compatible: S3 would replace the *source* of per-interval CPU
+without changing the CPU\*/Off-CPU\*/DB-Time contract.
+
+Recommendation: ship the residual model for v0.13; keep S3 as a planned
+"exact per-interval CPU / off-CPU analysis" phase (its own doc when
+scheduled).
+
+## 6. Workflow
+Branch off `t2-fix-el9-cpu-gate`; append commits (keep #46-equivalent
+green). No AI attribution; root-cause only; fails-before/passes-after
+tests; verify live on the EL9 box (root@116.202.96.172, key
+/home/dmitryfomin/gitlab/plan_flip/dmitry-plan-flip-test.key — do not
+write elsewhere in that dir) + CI matrix. After green, resume the
+EL9→EL8→Ubuntu validation matrix, then v0.13.

--- a/src/compute.c
+++ b/src/compute.c
@@ -408,23 +408,16 @@ void pgwt_compute_aas(const struct pgwt_trace_event *events, int count,
 
         int class_idx = pgwt_wait_class_index(ev->old_event);
 
-        /* T8: for an on-CPU record with measured cpu_ns, the fraction of the
-         * interval actually on a CPU. <0 marks "not a measured CPU record" →
-         * no split, the whole overlap is CPU (gap-inference). That covers a
-         * wait, sampled/v2 CPU (UNKNOWN), AND a measured EXACTLY-0 delta: the
-         * se.sum_exec_runtime accumulator only ticks at scheduler updates, so a
-         * we==0 gap shorter than a tick reads a stale 0 — which is a missing
-         * measurement, not "0% on CPU". Mislabeling a finely-fragmented
-         * on-CPU command as Off-CPU is exactly the CPU*→0 regression this
-         * guards. A genuine partial off-CPU stretch reads 0<cpu_ns<dur and
-         * still splits. (Mirror of the time_model fallback.) */
-        double cpu_frac = -1.0;
-        if (class_idx == PGWT_CLASS_CPU &&
-            ev->cpu_ns != PGWT_CPU_NS_UNKNOWN && ev->cpu_ns != 0 &&
-            ev->duration_ns > 0) {
-            cpu_frac = (double)ev->cpu_ns / (double)ev->duration_ns;
-            if (cpu_frac > 1.0) cpu_frac = 1.0;
-        }
+        /* T8 revision: measured cpu_ns for this interval (per-bucket, split by
+         * overlap fraction). Counted toward CPU* for BOTH we==0 gaps and wait
+         * intervals (a wait's cpu_ns is boundary-leaked pre-wait CPU). Off-CPU*
+         * is a residual, computed per bucket after the loop from exact totals
+         * (leak-immune) — NOT a per-interval dur-cpu split. UNKNOWN records use
+         * gap-inference: a we==0 gap is wholly CPU, a wait contributes 0 CPU.
+         * `buckets[].offcpu_aas` is reused as the per-bucket DB-ns accumulator
+         * during the loop and converted to the residual in the normalize pass. */
+        int is_measured = (ev->cpu_ns != PGWT_CPU_NS_UNKNOWN);
+        double dur_d = (double)ev->duration_ns;
 
         int first_b = (ev_start <= from_ns) ? 0
                      : (int)((ev_start - from_ns) / bucket_ns);
@@ -441,14 +434,16 @@ void pgwt_compute_aas(const struct pgwt_trace_event *events, int count,
             if (o_end > o_start) {
                 double ov = (double)(o_end - o_start);
                 if (!io_worker) {
-                    if (cpu_frac >= 0.0) {
-                        /* Split measured on-CPU vs off-CPU; the two sum to the
-                         * full CPU-class overlap, so max_aas is unchanged. */
-                        buckets[b].class_aas[PGWT_CLASS_CPU] += ov * cpu_frac;
-                        buckets[b].offcpu_aas += ov * (1.0 - cpu_frac);
-                    } else {
+                    buckets[b].offcpu_aas += ov;   /* DB-ns accumulator */
+                    double cpu_c;
+                    if (is_measured)
+                        cpu_c = dur_d > 0 ? (double)ev->cpu_ns * (ov / dur_d) : 0.0;
+                    else
+                        cpu_c = (class_idx == PGWT_CLASS_CPU) ? ov : 0.0;
+                    if (cpu_c > ov) cpu_c = ov;
+                    buckets[b].class_aas[PGWT_CLASS_CPU] += cpu_c;
+                    if (class_idx != PGWT_CLASS_CPU)
                         buckets[b].class_aas[class_idx] += ov;
-                    }
                 }
                 if (cat >= 0)
                     buckets[b].cat_aas[cat] += ov;
@@ -465,15 +460,28 @@ void pgwt_compute_aas(const struct pgwt_trace_event *events, int count,
         }
     }
 
-    /* Convert accumulated ns → AAS (class + category buckets) */
+    /* Convert accumulated ns → AAS (class + category buckets). T8 revision:
+     * offcpu_aas held the per-bucket DB-ns total during accumulation; convert
+     * it to the residual Off-CPU* = max(0, DB - CPU* - Σ waits) from exact
+     * per-bucket totals (leak-immune), then normalize everything by bucket_ns. */
     double max_aas = 0.0;
     for (int i = 0; i < actual_buckets; i++) {
+        double db_ns_bucket = buckets[i].offcpu_aas;
+        double wait_ns_bucket = 0.0;
+        for (int c = 0; c < PGWT_NUM_CLASSES; c++)
+            if (c != PGWT_CLASS_CPU)
+                wait_ns_bucket += buckets[i].class_aas[c];
+        double off_ns = db_ns_bucket - buckets[i].class_aas[PGWT_CLASS_CPU]
+                        - wait_ns_bucket;
+        if (off_ns < 0) off_ns = 0.0;
+        buckets[i].offcpu_aas = off_ns;
+
         double total = 0.0;
         for (int c = 0; c < PGWT_NUM_CLASSES; c++) {
             buckets[i].class_aas[c] /= (double)bucket_ns;
             total += buckets[i].class_aas[c];
         }
-        /* T8: Off-CPU* is part of active DB Time — include it in the total. */
+        /* Off-CPU* is part of active DB Time — include it in the total. */
         buckets[i].offcpu_aas /= (double)bucket_ns;
         total += buckets[i].offcpu_aas;
         for (int c = 0; c < PGWT_NUM_CATS; c++)
@@ -664,28 +672,26 @@ void pgwt_compute_time_model(const struct pgwt_trace_event *events, int count,
         db_time_ns += dur_ns;
         int cls_idx = pgwt_wait_class_index(ev->old_event);
         if (cls_idx == PGWT_CLASS_CPU) {
-            /* On-CPU gap. A MEASURED, nonzero cpu_ns (v3 exact) splits into
-             * CPU* and Off-CPU*. Two cases fall back to gap-inference (the full
-             * gap is CPU*, no Off-CPU split, exactly as pre-T8):
-             *   - UNKNOWN: sampled/v2/legacy — never measured.
-             *   - EXACTLY 0: `se.sum_exec_runtime` only advances at scheduler
-             *     ticks, so two wait-boundary reads inside one tick return the
-             *     identical stored value and the delta is a hard 0. For a
-             *     we==0 gap (PG says RUNNING, not waiting) a 0 delta is a STALE
-             *     read, NOT "spent no CPU" — trusting it would mislabel a
-             *     fully-on-CPU, finely-fragmented command (e.g. a tight
-             *     executor loop that flips wait_event_info thousands of times a
-             *     second) as ~100% Off-CPU and collapse its CPU* to ~0. A
-             *     genuine partial off-CPU stretch reads a nonzero-but-<dur
-             *     delta and still splits correctly. CPU has no sub-events, so it
-             *     never enters ev_ht. */
-            if (ev->cpu_ns != PGWT_CPU_NS_UNKNOWN && ev->cpu_ns != 0) {
+            /* T8 revision (docs/T8_MEASURED_CPU_REVISION.md): CPU* is the SUM
+             * of every interval's measured cpu_ns (conserved = true CPU);
+             * Off-CPU* is a GLOBAL RESIDUAL computed after the loop, never a
+             * per-interval dur-cpu split. `se.sum_exec_runtime` is only current
+             * at a tick (1ms) or a context switch, so a sub-ms CPU burst before
+             * a wait leaks (whole) into the FOLLOWING wait interval's delta; a
+             * per-interval split therefore double-counts that leak. Summing all
+             * cpu_ns (here + the wait branch below) is leak-immune, and the
+             * residual recovers the real runqueue time from exact totals. A
+             * stale-0 on a we==0 gap now correctly adds 0 (its burst is counted
+             * in the interval it leaked to) — no full-gap fallback (which
+             * over-stated CPU* past physical cores, Finding #1). */
+            if (ev->cpu_ns != PGWT_CPU_NS_UNKNOWN) {
                 double m = (double)ev->cpu_ns;
                 if (m > dur_ns) { cpu_clamped_ns += m - dur_ns; m = dur_ns; }
                 cpu_measured_ns += m;
-                offcpu_ns += dur_ns - m;
                 has_measured_cpu = 1;
             } else {
+                /* UNKNOWN: sampled/v2/legacy — never measured. Gap-inference:
+                 * the whole gap is CPU*, and no Off-CPU* for this window. */
                 cpu_measured_ns += dur_ns;
             }
         } else {
@@ -694,15 +700,40 @@ void pgwt_compute_time_model(const struct pgwt_trace_event *events, int count,
             int slot = event_ht_find_or_insert(ev_ht, ev->old_event);
             if (slot >= 0)
                 ev_ht[slot].total_ns += dur_ns;
-            /* Self-check: a wait-labeled gap should carry ≈0 measured CPU (the
-             * task slept). Accumulated, not split into the wait row. */
-            if (ev->cpu_ns != PGWT_CPU_NS_UNKNOWN)
+            /* The wait interval's measured cpu_ns is boundary-leaked pre-wait
+             * CPU (a sleeping task burns none) — count it toward CPU* so the
+             * total conserves. NOT surfaced as in-wait "spin" (that would lie;
+             * real spin/blocked needs sched_switch tracing, §5). Kept as an
+             * observability metric only. */
+            if (ev->cpu_ns != PGWT_CPU_NS_UNKNOWN) {
+                cpu_measured_ns += (double)ev->cpu_ns;
                 wait_gap_cpu_ns += (double)ev->cpu_ns;
+                has_measured_cpu = 1;
+            }
         }
     }
 
     /* The CPU class total is the measured (or legacy-inferred) CPU. */
     classes[PGWT_CLASS_CPU].total_ns = cpu_measured_ns;
+
+    /* T8 revision: Off-CPU* = DB Time - CPU* - Σ wait durations (the residual
+     * runqueue/unaccounted remainder of the on-CPU gaps). Computed from EXACT
+     * totals only (DB Time and wait durations are timestamp-exact; CPU* is a
+     * conserved sum), so it is immune to the per-interval sub-ms CPU leak. Only
+     * meaningful where some cpu_ns was measured; UNKNOWN-only windows show CPU*
+     * alone. Clamp at 0 (a positive clamp = CPU* exceeded DB-waits, a
+     * measurement inconsistency worth counting). */
+    if (has_measured_cpu) {
+        double wait_total_ns = 0.0;
+        for (int c = 0; c < PGWT_NUM_CLASSES; c++)
+            if (c != PGWT_CLASS_CPU)
+                wait_total_ns += classes[c].total_ns;
+        double resid = db_time_ns - cpu_measured_ns - wait_total_ns;
+        if (resid < 0) { cpu_clamped_ns += -resid; resid = 0.0; }
+        offcpu_ns = resid;
+    } else {
+        offcpu_ns = 0.0;
+    }
 
     for (int c = 0; c < PGWT_NUM_CATS; c++)
         out->cat_ms[c] = cat_ns[c] / 1e6;

--- a/tests/run_all.sh
+++ b/tests/run_all.sh
@@ -107,6 +107,7 @@ done 3< "$SCRIPT_DIR/unit_tests.list"
 # Step 2.5: Synthetic data correctness tests (no root needed, needs pgwt-server)
 if [[ -x "$PROJECT_DIR/pgwt-server" ]] && [[ -x "$SCRIPT_DIR/gen_test_traces" ]]; then
     run_test "test_data_time_model" python3 "$SCRIPT_DIR/test_data_time_model.py"
+    run_test "test_data_offcpu_identity" python3 "$SCRIPT_DIR/test_data_offcpu_identity.py"
     run_test "test_data_aas" python3 "$SCRIPT_DIR/test_data_aas.py"
     run_test "test_data_events" python3 "$SCRIPT_DIR/test_data_events.py"
     run_test "test_data_sessions" python3 "$SCRIPT_DIR/test_data_sessions.py"

--- a/tests/test_data_offcpu_identity.py
+++ b/tests/test_data_offcpu_identity.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""test_data_offcpu_identity.py — T8 revision: conserved CPU* + residual Off-CPU*.
+
+The regression that the rejected per-interval Off-CPU* models fail. Encodes
+the mixed CPU/LWLock/IO sequence from docs/T8_MEASURED_CPU_REVISION.md §1 with
+a KNOWN sub-millisecond CPU burst whose measured cpu_ns leaks into the
+following wait interval (sum_exec_runtime is only current at a tick / context
+switch). Asserts:
+
+  1. CPU* = Σ of every interval's measured cpu_ns (CPU *and* wait intervals) —
+     the conserved true CPU. The pre-revision code drops the wait intervals'
+     cpu_ns, so it reports CPU* too low here.
+  2. Wait-class durations are exact (unaffected by the CPU leak).
+  3. Off-CPU* = DB Time - CPU* - Σ waits (residual, leak-immune) — 0 for the
+     free-core sequence (Models A/B wrongly report >0), and the true runqueue
+     time for a deliberately-preempted CPU-bound backend.
+  4. The identity CPU* + Off-CPU* + Σ waits == DB Time holds exactly.
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(__file__))
+from server_harness import (
+    ServerHarness, generate_traces, cleanup_traces, TestRunner,
+    CPU, IO_DATA_FILE_READ, LWLOCK_WAL_WRITE,
+)
+
+BASE_TS = 10_000_000_000_000
+MS = 1_000_000  # ns
+
+
+def build_scenario():
+    # PID 1000 — the §1 mixed sequence (durations, measured cpu_ns):
+    #   CPU1  5.0ms cpu 4.8   (0.2 tick-tail leaks →)
+    #   LWLk1 20.0ms cpu 0.2  (CPU1's tail)
+    #   CPU2  0.4ms cpu 0.0   (whole sub-tick burst leaks →)
+    #   LWLk2 15.0ms cpu 0.4  (CPU2's burst)
+    #   IO    10.0ms cpu 0.0  (blocked)
+    #   CPU3  3.0ms cpu 3.0   (terminal, measured)
+    # true: DB 53.4, CPU 8.4, LWLock 35, IO 10, Off-CPU 0 (free core)
+    seq = [
+        (CPU,               5000 * (MS // 1000), 4800 * (MS // 1000), IO_DATA_FILE_READ),
+        (LWLOCK_WAL_WRITE, 20000 * (MS // 1000),  200 * (MS // 1000), CPU),
+        (CPU,                400 * (MS // 1000),    0,                LWLOCK_WAL_WRITE),
+        (LWLOCK_WAL_WRITE, 15000 * (MS // 1000),  400 * (MS // 1000), IO_DATA_FILE_READ),
+        (IO_DATA_FILE_READ,10000 * (MS // 1000),    0,                CPU),
+        (CPU,               3000 * (MS // 1000), 3000 * (MS // 1000), IO_DATA_FILE_READ),
+    ]
+    events = []
+    ts = BASE_TS
+    for old, dur, cpu, new in seq:
+        ts += dur
+        events.append({"pid": 1000, "ts": ts, "dur": dur,
+                       "old": old, "new": new, "qid": 100, "cpu": cpu})
+
+    # PID 1001 — a CPU-bound backend preempted 40% (oversubscription):
+    #   one 10ms on-CPU gap that only got 6ms of CPU → Off-CPU* must read 4ms.
+    ts2 = BASE_TS + 1_000_000
+    ts2 += 10000 * (MS // 1000)
+    events.append({"pid": 1001, "ts": ts2, "dur": 10000 * (MS // 1000),
+                   "old": CPU, "new": IO_DATA_FILE_READ, "qid": 200,
+                   "cpu": 6000 * (MS // 1000)})
+
+    return {
+        "cpu_measured": 1,
+        "interleave": 1,
+        "backends": [
+            {"pid": 1000, "type": "client", "user": "t", "db": "d"},
+            {"pid": 1001, "type": "client", "user": "t", "db": "d"},
+        ],
+        "queries": [{"id": 100, "text": "seq"}, {"id": 200, "text": "hog"}],
+        "events": events,
+    }
+
+
+def main():
+    t = TestRunner("test_data_offcpu_identity")
+    print(f"=== {t.name} ===")
+    trace_dir = generate_traces(build_scenario())
+    try:
+        with ServerHarness(trace_dir) as srv:
+            rows = {r["name"]: r for r in srv.query("time_model")["rows"]}
+
+            def ms(name):
+                return rows.get(name, {}).get("ms", -1.0)
+
+            # Combined totals: DB = 53.4 + 10 = 63.4; CPU* = 8.4 + 6 = 14.4;
+            # LWLock 35; IO = 10 (seq) + 10 (hog's new is IO but that's a
+            # different event's OLD... hog's OLD is CPU) → IO stays 10;
+            # Off-CPU* = 0 (seq) + 4 (hog) = 4. Identity → 63.4.
+            db     = ms("DB Time")
+            cpu    = ms("CPU*")
+            offcpu = ms("Off-CPU*")
+            lwlock = ms("LWLock")
+            io     = ms("IO")
+
+            print(f"--- DB={db} CPU*={cpu} Off-CPU*={offcpu} LWLock={lwlock} IO={io} ---")
+            t.check_approx(db, 63.4, 0.01, "DB Time = 63.4ms")
+            # CPU* conserves: includes the 0.6ms that leaked into the two
+            # LWLock intervals (pre-revision code reports 14.4-0.6=13.8).
+            t.check_approx(cpu, 14.4, 0.01,
+                           "CPU* = 14.4ms (conserved; wait-leaked CPU counted)")
+            t.check_approx(lwlock, 35.0, 0.01, "LWLock = 35.0ms (exact durations)")
+            t.check_approx(io, 10.0, 0.01, "IO = 10.0ms (exact duration)")
+            # Off-CPU* is the residual: 0 for the free-core sequence, 4ms for the
+            # preempted hog. Pre-revision per-interval split reports ~0.6 too much.
+            t.check_approx(offcpu, 4.0, 0.01,
+                           "Off-CPU* = 4.0ms (residual runqueue; free-core seq adds 0)")
+            # The identity that Models A/B break:
+            t.check_approx(cpu + offcpu + lwlock + io, 63.4, 0.02,
+                           "IDENTITY CPU* + Off-CPU* + Σwaits == DB Time")
+    finally:
+        cleanup_traces(trace_dir)
+    sys.exit(0 if t.summary() else 1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Stacks on the T8 branch. Fixes the two real findings from the EL9 close-out validation, in **compute.c only** (no BPF/format change — the terminal flush already reads schedstat-measured cpu_ns).

## Root cause (see docs/T8_MEASURED_CPU_REVISION.md)
`sum_exec_runtime` is only current at a scheduler tick (1ms) or context switch, so a sub-millisecond CPU burst before a wait leaks (whole) into the following wait interval's delta. Measured: pgbench `wait_gap_cpu ≈ CPU*` (~half the CPU mis-timestamped into waits); pure pg_sleep ~88ms (negligible). T8's per-interval Off-CPU* split therefore double-counted the leak, and it dropped the wait intervals' cpu_ns from CPU* (under-report), while the stale-0→full-gap fallback over-stated a fragmented pure-CPU command's CPU* past physical cores (replay=100%).

## Fix — conserve CPU*, residual Off-CPU*
- **CPU\*** = Σ of every interval's measured cpu_ns (we==0 **and** wait intervals). Leak-immune (a sum), matches /proc.
- **Off-CPU\*** = `max(0, DB − CPU* − Σwaits)`, from timestamp-exact totals — leak-immune. Replaces the per-interval split (both time_model and the AAS bucket path).
- Removed the stale-0→full-gap fallback → a fragmented pure-CPU command's CPU* is now bounded by measured ns ≤ physical (fixes replay>physical).
- Dropped the invalid per-wait spin/blocked framing (the wait cpu_ns is boundary-leaked pre-wait CPU, not in-wait spin).

## Verified
`test_data_offcpu_identity.py` — the docs §1 mixed CPU/LWLock/IO sequence with a known sub-ms burst + a preempted CPU-bound backend: asserts CPU* conserves (14.4ms), wait durations exact, Off-CPU* is the residual (0 free-core / 4ms preempted), and `CPU* + Off-CPU* + Σwaits == DB Time`. **Fails on pre-revision compute, passes on the revision.** 18/18 data tests green.

Live EL9 re-validation + the self-check reframe (test_cross_validate_tiered: conservation vs /proc, not wait-gap≤1%) follow before merge. Notes S3 (sched_switch tracing) as the deferred per-interval-exact alternative.