### PR TITLE
Fix straddle scan-race: recover pre-existing backends the one-shot scan misses

### DIFF
--- a/docs/FUTURE_WORK.md
+++ b/docs/FUTURE_WORK.md
@@ -102,22 +102,6 @@ CPU\* toward exact, without changing the sampled tier's ~0-overhead
 character (the read is one map lookup per backend per tick, already done
 for query_id).
 
-## Investigate: pure-compute straddling CLIENT backend intermittently untracked
-
-Found in EL9 validation (2026-07-19) via test_cpu_time. A client backend
-running a pure-compute DO block (no waits) that STRADDLES attach was
-sometimes NOT in the tracer's initial-scan set (only aux processes
-attached), so its CPU showed as DB≈0 in the live `--view`. The recorded
-TRACE path and the fork-after-attach path capture it correctly, and
-phase_pure_cpu_straddle (CI, all PG versions) validates the capability —
-so this is an intermittent initial-scan/connect race for a specific
-setup (kill+restart the client backend, then attach quickly), not a
-systematic gap. Root-cause the scan timing (does the scan run before the
-client backend's PGPROC is resolvable / does address-validation skip it
-silently?). Related: the live `--view time_model` of a genuinely on-CPU
-backend must never render it as idle — verify the map_reader open-
-interval classification once the scan issue is understood.
-
 ## Parallel-worker CPU roll-up to the leader's query
 
 T2 counts parallel workers' CPU under their own query_id in

--- a/src/backend.c
+++ b/src/backend.c
@@ -271,6 +271,13 @@ int pgwt_scan_existing_backends(struct pgwt_daemon *d)
         return -1;
     }
 
+    /* TEST HOOK (PGWT_TEST_STRADDLE_SKIP): deterministically reproduce the
+     * initial-scan straddle race by skipping any backend that is inside a
+     * command at scan time (debug_query_string set) — exactly the pre-existing
+     * pure-CPU straddler the race loses. pgwt_recover_unattached_backends must
+     * then pick it up on a later tick. Never set in production. */
+    int skip_straddle = getenv("PGWT_TEST_STRADDLE_SKIP") != NULL;
+
     int count = 0;
     struct dirent *ent;
     while ((ent = readdir(proc)) != NULL) {
@@ -298,6 +305,26 @@ int pgwt_scan_existing_backends(struct pgwt_daemon *d)
 
         if (ppid != d->postmaster_pid)
             continue;
+
+        /* TEST HOOK: skip a straddling in-command backend (see top of fn) so
+         * pgwt_recover_unattached_backends must attach it later. */
+        if (skip_straddle && d->debug_query_string_addr) {
+            char mp[64];
+            snprintf(mp, sizeof(mp), "/proc/%d/mem", pid);
+            int mf = open(mp, O_RDONLY);
+            if (mf >= 0) {
+                uint64_t dqs = 0;
+                ssize_t got = pread(mf, &dqs, sizeof(dqs),
+                                    (off_t)d->debug_query_string_addr);
+                close(mf);
+                if (got == (ssize_t)sizeof(dqs) && dqs) {
+                    fprintf(stderr, "WARN: PGWT_TEST_STRADDLE_SKIP — skipping "
+                            "in-command PID %d at scan (recovery must attach)\n",
+                            pid);
+                    continue;
+                }
+            }
+        }
 
         /* This is a postgres child. Resolve its wait_event_info address
          * (PG17+ my_wait_event_info global; PG<17 MyProc + offset).
@@ -415,6 +442,86 @@ int pgwt_scan_existing_backends(struct pgwt_daemon *d)
     }
     closedir(proc);
     return count;
+}
+
+/* Periodic recovery for the initial-scan straddle race (docs/FUTURE_WORK.md).
+ *
+ * pgwt_scan_existing_backends runs ONCE at startup. A pre-existing backend
+ * whose wait_event_info was transiently unresolvable at that single instant
+ * (a /proc read race under load — much likelier on a 2-CPU CI runner, and on
+ * PG13 where the address is *MyProc + offset, an extra indirection) is either
+ * skipped outright (its /proc/stat read failed) or routed to the bootstrap
+ * path. The bootstrap watchpoint fires only on a wait_event_info WRITE, which
+ * a backend already past InitProcess never does again — so a WAITLESS command
+ * (pure compute: no wait boundaries, so the trace stays empty and only the
+ * live open-interval read would show its CPU) stays untraced for its whole
+ * life and reads CPU* = 0. There was no recovery: the timer GC only reaps DEAD
+ * backends, never re-attaches a missed live one.
+ *
+ * This re-scans /proc each tick and attaches any postmaster child that still
+ * lacks a live watchpoint but is now resolvable AND initialized (its PGPROC is
+ * in shared memory — the same predicate handle_fork uses to attach directly).
+ * Idempotent: a backend already holding a live watchpoint (wp_fd >= 0) is
+ * skipped cheaply. A freshly-forked backend still in InitProcess points at its
+ * process-LOCAL dummy (addr_is_shared != 1) and is left to its bootstrap
+ * watchpoint, which WILL fire for it. Cheap: one /proc pass, the same
+ * resolution the scan uses. Returns the number of backends recovered. */
+int pgwt_recover_unattached_backends(struct pgwt_daemon *d)
+{
+    if (!pgwt_mode_uses_watchpoints(d))
+        return 0;
+
+    DIR *proc = opendir("/proc");
+    if (!proc)
+        return 0;
+
+    int recovered = 0;
+    struct dirent *ent;
+    while ((ent = readdir(proc)) != NULL) {
+        pid_t pid = atoi(ent->d_name);
+        if (pid <= 0)
+            continue;
+
+        /* Already attached with a live watchpoint — nothing to recover. This
+         * is the common case (every healthy backend), kept cheap. */
+        struct pgwt_backend *be = pgwt_find_backend(&d->backends, pid);
+        if (be && be->wp_fd >= 0)
+            continue;
+
+        /* Postmaster child? (ppid == postmaster, field 4 of /proc/pid/stat). */
+        char stat_path[64];
+        snprintf(stat_path, sizeof(stat_path), "/proc/%d/stat", pid);
+        FILE *f = fopen(stat_path, "r");
+        if (!f)
+            continue;
+        char stat_line[512];
+        if (!fgets(stat_line, sizeof(stat_line), f)) { fclose(f); continue; }
+        fclose(f);
+        char *last_paren = strrchr(stat_line, ')');
+        if (!last_paren)
+            continue;
+        char state;
+        int ppid;
+        if (sscanf(last_paren + 1, " %c %d", &state, &ppid) != 2)
+            continue;
+        if (ppid != d->postmaster_pid)
+            continue;
+
+        /* Resolvable AND initialized (PGPROC in shm)? Attach directly — the
+         * level-triggered version of handle_fork's direct-attach fast path. A
+         * still-initializing backend (local dummy) is left to bootstrap. */
+        uint64_t ptr = pgwt_resolve_backend_wait_addr(d, pid);
+        if (ptr != 0 && pgwt_addr_is_shared(pid, ptr) == 1) {
+            if (pgwt_handle_init(d, pid, ptr) == 0) {
+                recovered++;
+                if (d->verbose)
+                    fprintf(stderr, "INFO: recovered unattached backend PID %d "
+                            "(initial-scan straddle race)\n", pid);
+            }
+        }
+    }
+    closedir(proc);
+    return recovered;
 }
 
 /* CAP-2/3: post-scan offset confirmation. Only reached when the initial scan

--- a/src/backend.h
+++ b/src/backend.h
@@ -43,6 +43,12 @@ void pgwt_backend_init(struct pgwt_backend_table *bt);
  * (skips bootstrap — they are already initialized). */
 int pgwt_scan_existing_backends(struct pgwt_daemon *d);
 
+/* Periodic level-triggered recovery for the initial-scan straddle race: attach
+ * any postmaster child that still lacks a live watchpoint but is now resolvable
+ * + initialized (the one-shot scan may have missed/limbo'd it under load).
+ * Idempotent; safe to call every tick. Returns the count recovered. */
+int pgwt_recover_unattached_backends(struct pgwt_daemon *d);
+
 /* Handle a new fork from postmaster. Attaches bootstrap watchpoint. */
 int pgwt_handle_fork(struct pgwt_daemon *d, pid_t child_pid);
 

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -76,6 +76,15 @@ static void handle_timer(struct pgwt_daemon *d)
         }
     }
 
+    /* Straddle-race recovery: re-attach any pre-existing backend the one-shot
+     * startup scan missed or left in bootstrap limbo (a transient resolve race,
+     * fatal for a waitless pure-CPU command whose bootstrap watchpoint never
+     * fires). Level-triggered and idempotent — runs before the state_map read
+     * so a recovery this tick is reflected in this tick's view. Full/tiered
+     * only (no-op in sampled/lightweight, which resolve lazily). */
+    if (!d->lightweight_mode && !getenv("PGWT_TEST_NO_RECOVERY"))
+        pgwt_recover_unattached_backends(d);
+
     /* ESC-1: enforce the escalation budget mid-window (cheap no-op unless a
      * budget-limited window is open and has reached its cap). */
     pgwt_escalation_check_budget(d);
@@ -743,6 +752,22 @@ int pgwt_daemon_init(struct pgwt_daemon *d)
      * it would trace garbage (or nothing) labeled as real. */
     if (pgwt_confirm_wait_offset(d) != 0)
         goto fail;
+
+    /* Straddle-race recovery at startup. The one-shot scan above can miss a
+     * pre-existing backend (its /proc read raced) or leave it in bootstrap
+     * limbo (its wait_event_info resolve returned 0 transiently) — fatal for a
+     * pure-CPU straddler whose bootstrap watchpoint never fires. Re-attempt a
+     * few times over the first ~600ms: the transient that caused the miss is
+     * gone by now, so the re-resolve succeeds and the backend is attached
+     * BEFORE any measurement window opens (not one display interval later, as
+     * the per-tick backstop in handle_timer would). Cheap no-op when the scan
+     * already attached everything. */
+    if (pgwt_mode_uses_watchpoints(d) && !getenv("PGWT_TEST_NO_RECOVERY")) {
+        for (int i = 0; i < 3; i++) {
+            pgwt_recover_unattached_backends(d);
+            usleep(200000);   /* 200ms between passes */
+        }
+    }
 
     /* Create timer fd */
     d->timer_fd = timerfd_create(CLOCK_MONOTONIC, TFD_CLOEXEC);

--- a/tests/test_capture_smoke.py
+++ b/tests/test_capture_smoke.py
@@ -835,6 +835,75 @@ def phase_pure_cpu_straddle(pm_pid, mode):
     subprocess.run(["rm", "-rf", trace_dir])
 
 
+def phase_straddle_recovery(pm_pid, mode):
+    """DETERMINISTIC regression for the initial-scan straddle race
+    (pgwt_recover_unattached_backends, docs/FUTURE_WORK.md). phase_pure_cpu_
+    straddle above exercises the same edge but the miss is a TIMING race — it
+    reproduced only intermittently on 2-CPU CI runners (PG13), never on a real
+    box. PGWT_TEST_STRADDLE_SKIP forces the one-shot scan to skip the in-flight
+    backend, reproducing that transient-resolve miss ON EVERY RUN. The
+    level-triggered recovery (startup settle + per-tick backstop) must attach it
+    anyway, so a waitless pure-CPU straddler that the scan lost still reads
+    CPU*>0. Without the recovery (PGWT_TEST_NO_RECOVERY) this reads ~0 — that is
+    the exact CI failure. Runs -v so the scan-skip WARN and the recovery INFO
+    are both visible and asserted."""
+    print(f"--- Phase: straddle recovery, --mode {mode} (scan forced to miss "
+          f"the in-flight backend) ---")
+    trace_dir = tempfile.mkdtemp(prefix="pgwt_smoke_recover_")
+    os.chmod(trace_dir, 0o755)
+
+    hog = subprocess.Popen(
+        ["psql", "-U", "postgres", "-d", "postgres"],
+        stdin=subprocess.PIPE, stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL, text=True)
+    hog.stdin.write(
+        "DO $$ DECLARE x bigint := 0; BEGIN "
+        "FOR o IN 1..100000 LOOP "
+        "FOR i IN 1..1000000 LOOP x := x + i; END LOOP; x := 0; "
+        "END LOOP; END $$;\n")
+    hog.stdin.flush()
+    time.sleep(2.5)   # the command is in flight; its start-edge is past
+
+    argv = [TRACER, "--mode", mode, "--pid", str(pm_pid),
+            "-T", trace_dir, "--duration", "12", "--interval", "5",
+            "--view", "time_model", "-v"]
+    if mode == "tiered":
+        argv += ["--anomaly-aas-factor", "1000000"]
+    env = {**os.environ, "PGWT_TEST_STRADDLE_SKIP": "1"}
+    tracer = subprocess.Popen(argv, stdout=subprocess.PIPE,
+                              stderr=subprocess.PIPE, env=env)
+    try:
+        stdout, stderr = tracer.communicate(timeout=45)
+    except subprocess.TimeoutExpired:
+        tracer.kill()
+        stdout, stderr = tracer.communicate()
+    finally:
+        try:
+            hog.stdin.write("\\q\n"); hog.stdin.flush()
+        except (BrokenPipeError, ValueError):
+            pass
+        hog.terminate()
+        cleanup_stale_backends()
+    out = STRIP_ANSI.sub('', stdout.decode('utf-8', errors='replace'))
+    err = stderr.decode('utf-8', errors='replace')
+
+    # The hook must actually have fired (else the test proves nothing).
+    check("PGWT_TEST_STRADDLE_SKIP" in err,
+          "scan was forced to skip the in-flight backend (test hook active)")
+    # The recovery — not the scan — must have attached it.
+    check("recovered unattached backend" in err,
+          "pgwt_recover_unattached_backends attached the scan-missed straddler "
+          f"(stderr {err[-200:]!r})")
+    # And the payoff: its CPU is visible despite the scan miss.
+    live = parse_time_model(out)
+    live_cpu = live.get('CPU*', 0.0)
+    check(live_cpu > 0.0,
+          f"scan-missed pure-CPU straddler still shows CPU* > 0 via recovery "
+          f"(--mode {mode}): CPU* = {live_cpu:.0f}ms")
+
+    subprocess.run(["rm", "-rf", trace_dir])
+
+
 def phase_sampled_aas_truth(pm_pid):
     """T2 (AAS-1) definition-of-done: sampled AAS — now CPU-inclusive —
     must match pg_stat_activity 1s-sampling ground truth. A CPU-bound
@@ -1125,6 +1194,13 @@ def main():
         # T8: PURE-CPU straddle (waitless DO-loop) — the measured-CPU
         # acceptance test. Live + trace + /proc magnitude cross-check.
         phase_pure_cpu_straddle(pm_pid, args.mode)
+        # Deterministic straddle-recovery guard: force the scan to miss the
+        # in-flight backend; the level-triggered recovery must attach it anyway.
+        # Full mode only — the recovery is a watchpoint-mode feature; in
+        # sampled/tiered the straddler is found by the sampler's lazy discovery
+        # (covered by phase_pure_cpu_straddle above), not this recovery.
+        if args.mode == 'full':
+            phase_straddle_recovery(pm_pid, args.mode)
         if args.mode == 'tiered':
             # T2 (AAS semantics): CPU-inclusive sampled AAS vs pg_stat_activity
             # ground truth, and the CPU-storm escalation + tier-switch


### PR DESCRIPTION
Follow-up to #51 — held the v0.13 release to fix this properly rather than ship over it.

## The race
`pgwt_scan_existing_backends` runs **once** at startup; the timer only GCs
DEAD backends, never re-attaches a missed live one. A pre-existing backend
whose `wait_event_info` resolve raced at that instant (a `/proc` read glitch
— likelier on a 2-CPU CI runner, and on **PG13** where the address is
`*MyProc + offset`) is skipped or routed to bootstrap. The bootstrap
watchpoint fires only on a `wait_event_info` **write**, which a backend past
`InitProcess` never repeats — so a **waitless pure-CPU command** stays
untraced and reads **CPU\* = 0**. This is the intermittent
`phase_pure_cpu_straddle` failure (PG13 capture-smoke, `--mode full`) that
blocked v0.13.

## The fix
`pgwt_recover_unattached_backends` — a **level-triggered** recovery that
re-scans `/proc` and attaches any postmaster child still lacking a live
watchpoint but now resolvable + initialized (PGPROC in shm). Idempotent;
leaves still-initializing backends to bootstrap. Runs as a settle right
after the startup scan (attaches a missed straddler before any measurement
window opens) and every timer tick as the backstop.

## Determinism
Not reproducible on a real box (30+ iters, PG13/PG18, 2-core taskset — all
green); needs CI contention. `PGWT_TEST_STRADDLE_SKIP` forces the scan-miss
every run; the new `phase_straddle_recovery` asserts the recovery attaches
it and CPU\* > 0 (`PGWT_TEST_NO_RECOVERY` proves the negative). Live: scan
forced to miss → **CPU\* 17.5ms (no recovery) vs 10624ms (recovery) vs
10626ms (baseline)**.

## Verified
- capture-smoke **34/34 on PG18 AND PG13** (`--mode full`, pure-CPU straddle magnitude 0.98)
- full `run_all --require-live` **64/0/3** on Ubuntu 24.04

Closes the `docs/FUTURE_WORK.md` straddle-race entry.