### PR TITLE
DIAG (do not merge): capture straddle live CPU*=0 on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,6 +203,7 @@ jobs:
           sudo env "PATH=/usr/lib/postgresql/$V/bin:$PATH" \
             "GITHUB_STEP_SUMMARY=$GITHUB_STEP_SUMMARY" \
             "BPFTOOL=$BPFTOOL" \
+            "PGWT_STRADDLE_DEBUG=1" \
             tests/ci_smoke.sh --pg-version "$V" $FLAGS
 
   web-ui:

--- a/src/map_reader.c
+++ b/src/map_reader.c
@@ -178,6 +178,14 @@ void pgwt_read_state_map(struct pgwt_daemon *d)
              * Only reached in tiered mode during escalation, where every
              * ATTACHED backend has wp_live = 1 from the preseed. */
             if (!sval.wp_live) {
+                if (getenv("PGWT_DBG_LIVEREAD"))
+                    fprintf(stderr, "LIVEREAD pid=%u SKIP wp_live=0 "
+                            "we=%u cpu_total=%llu on_cpu_ts=%llu last_cpu=%llu "
+                            "last_ts=%llu\n", snext, sval.last_event,
+                            (unsigned long long)sval.cpu_ns_total,
+                            (unsigned long long)sval.on_cpu_ts,
+                            (unsigned long long)sval.last_cpu_ns,
+                            (unsigned long long)sval.last_ts);
                 skey = snext;
                 continue;
             }
@@ -245,6 +253,16 @@ void pgwt_read_state_map(struct pgwt_daemon *d)
                         cpu_open = m < open_ns ? m : open_ns;   /* clamp to wall */
                     }
                 }
+                if (we == 0 && getenv("PGWT_DBG_LIVEREAD"))
+                    fprintf(stderr, "LIVEREAD pid=%u we=0 wp_live=%u open_ns=%llu "
+                            "cpu_total=%llu on_cpu_ts=%llu last_cpu=%llu now=%llu "
+                            "cpu_open=%llu has_closed=%d\n", snext, sval.wp_live,
+                            (unsigned long long)open_ns,
+                            (unsigned long long)sval.cpu_ns_total,
+                            (unsigned long long)sval.on_cpu_ts,
+                            (unsigned long long)sval.last_cpu_ns,
+                            (unsigned long long)now,
+                            (unsigned long long)cpu_open, (int)has_closed_data);
 
                 /* Per-PID accumulation */
                 struct pgwt_pid_accum *pa = pgwt_get_or_create_pid(&d->accum, snext);

--- a/src/map_reader.c
+++ b/src/map_reader.c
@@ -178,14 +178,6 @@ void pgwt_read_state_map(struct pgwt_daemon *d)
              * Only reached in tiered mode during escalation, where every
              * ATTACHED backend has wp_live = 1 from the preseed. */
             if (!sval.wp_live) {
-                if (getenv("PGWT_DBG_LIVEREAD"))
-                    fprintf(stderr, "LIVEREAD pid=%u SKIP wp_live=0 "
-                            "we=%u cpu_total=%llu on_cpu_ts=%llu last_cpu=%llu "
-                            "last_ts=%llu\n", snext, sval.last_event,
-                            (unsigned long long)sval.cpu_ns_total,
-                            (unsigned long long)sval.on_cpu_ts,
-                            (unsigned long long)sval.last_cpu_ns,
-                            (unsigned long long)sval.last_ts);
                 skey = snext;
                 continue;
             }
@@ -253,16 +245,6 @@ void pgwt_read_state_map(struct pgwt_daemon *d)
                         cpu_open = m < open_ns ? m : open_ns;   /* clamp to wall */
                     }
                 }
-                if (we == 0 && getenv("PGWT_DBG_LIVEREAD"))
-                    fprintf(stderr, "LIVEREAD pid=%u we=0 wp_live=%u open_ns=%llu "
-                            "cpu_total=%llu on_cpu_ts=%llu last_cpu=%llu now=%llu "
-                            "cpu_open=%llu has_closed=%d\n", snext, sval.wp_live,
-                            (unsigned long long)open_ns,
-                            (unsigned long long)sval.cpu_ns_total,
-                            (unsigned long long)sval.on_cpu_ts,
-                            (unsigned long long)sval.last_cpu_ns,
-                            (unsigned long long)now,
-                            (unsigned long long)cpu_open, (int)has_closed_data);
 
                 /* Per-PID accumulation */
                 struct pgwt_pid_accum *pa = pgwt_get_or_create_pid(&d->accum, snext);

--- a/tests/test_capture_smoke.py
+++ b/tests/test_capture_smoke.py
@@ -917,7 +917,7 @@ def phase_straddle_recovery(pm_pid, mode):
     subprocess.run(["rm", "-rf", trace_dir])
 
 
-def phase_straddle_livecpu_loop(pm_pid, iters=10):
+def phase_straddle_livecpu_loop(pm_pid, iters=40):
     """DIAG only. Run the pure-CPU straddle live-view scenario `iters` times;
     on the FIRST time the live time_model shows CPU* <= 0, dump the per-tick
     LIVEREAD state and all time_model blocks so the failing read is
@@ -966,12 +966,15 @@ def phase_straddle_livecpu_loop(pm_pid, iters=10):
         subprocess.run(["rm", "-rf", trace_dir])
         if cpu <= 0.0:
             print(f"=== CAUGHT: live CPU*=0 at iter {it} (be_pid={be_pid}) ===")
-            print("--- LIVEREAD per-tick state ---")
-            for l in err.splitlines():
-                if "LIVEREAD" in l:
-                    print(l)
-            print("--- full time_model stdout (last 4000 chars) ---")
-            print(out[-4000:])
+            # Per-block CPU* across all printed time_model blocks: reveals
+            # whether the LAST block is 0 (print/parse) or ALL are 0 (read).
+            blocks = re.split(r'-{3,}\s*\d{4}-\d\d-\d\d', out)
+            for bi, blk in enumerate(blocks):
+                mm = [l for l in blk.splitlines() if 'CPU*' in l]
+                if mm:
+                    print(f"  block {bi}: {mm[0].strip()}")
+            print("--- FULL time_model stdout ---")
+            print(out)
             print("--- stderr tail (last 1500 chars) ---")
             print(err[-1500:])
             check(False, f"DIAG caught straddle live CPU*=0 at iter {it}")

--- a/tests/test_capture_smoke.py
+++ b/tests/test_capture_smoke.py
@@ -724,6 +724,14 @@ def phase_pure_cpu_straddle(pm_pid, mode):
     the same [attach, shutdown] window (±20%). The loop count is huge so it
     straddles capture end on any box; it starts BEFORE the tracer so its
     command start-edge is already past at attach."""
+    # DIAG (diag-straddle-livecpu branch): loop the live-view scenario HERE,
+    # in-context (after the preceding phases — the isolated top-of-run loop did
+    # not reproduce, the in-context real phase did), taking many shots + dumping
+    # the time_model blocks on the first catch.
+    if mode == 'full' and os.environ.get("PGWT_STRADDLE_DEBUG"):
+        phase_straddle_livecpu_loop(pm_pid)
+        return
+
     print(f"--- Phase: PURE-CPU straddle, --mode {mode} (no waits — empty-trace "
           f"repro) ---")
     trace_dir = tempfile.mkdtemp(prefix="pgwt_smoke_purecpu_")
@@ -1246,11 +1254,6 @@ def main():
     psql("CREATE EXTENSION IF NOT EXISTS pg_stat_statements")
 
     cleanup_stale_backends()
-
-    # DIAG (diag-straddle-livecpu branch): take many shots at the intermittent
-    # live CPU*=0 straddle flake up front, so one CI run reproduces it.
-    if args.mode == 'full' and os.environ.get("PGWT_STRADDLE_DEBUG"):
-        phase_straddle_livecpu_loop(pm_pid)
 
     core = args.capture_core
     phase_live_system_event(pm_pid, args.mode, core=core)

--- a/tests/test_capture_smoke.py
+++ b/tests/test_capture_smoke.py
@@ -757,7 +757,11 @@ def phase_pure_cpu_straddle(pm_pid, mode):
     be_pid = None
     oncpu_before = oncpu_after = None
     win_from = win_shutdown = 0
-    tracer = subprocess.Popen(argv, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    _dbg_env = {**os.environ}
+    if os.environ.get("PGWT_STRADDLE_DEBUG"):
+        _dbg_env["PGWT_DBG_LIVEREAD"] = "1"   # temporary: diagnose live CPU*=0
+    tracer = subprocess.Popen(argv, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                              env=_dbg_env)
     try:
         time.sleep(3.0)                 # BPF load + scan/attach seeds the backend
         be_pid = find_active_do_backend()
@@ -786,6 +790,15 @@ def phase_pure_cpu_straddle(pm_pid, mode):
     #    Pre-T8 this row was 0.0 for a waitless command (the exact symptom).
     live = parse_time_model(out)
     live_cpu = live.get('CPU*', 0.0)
+    if live_cpu <= 0.0 and os.environ.get("PGWT_STRADDLE_DEBUG"):
+        # Dump the full tracer stdout+stderr (incl. LIVEREAD debug) so the
+        # failing tick's state_map read is inspectable. Temporary diagnostic.
+        with open("/tmp/straddle_fail_out.txt", "w") as f:
+            f.write(out)
+        with open("/tmp/straddle_fail_err.txt", "w") as f:
+            f.write(err)
+        print("=== STRADDLE LIVE CPU*=0 — LIVEREAD dump (be_pid=%s) ===" % be_pid)
+        print("\n".join(l for l in err.splitlines() if "LIVEREAD" in l)[-4000:])
     check(live_cpu > 0.0,
           f"pure-CPU straddle live view shows CPU* > 0 (--mode {mode}): "
           f"CPU* = {live_cpu:.0f}ms (pre-T8 ~0; stderr {err[-160:]!r})")

--- a/tests/test_capture_smoke.py
+++ b/tests/test_capture_smoke.py
@@ -917,6 +917,68 @@ def phase_straddle_recovery(pm_pid, mode):
     subprocess.run(["rm", "-rf", trace_dir])
 
 
+def phase_straddle_livecpu_loop(pm_pid, iters=10):
+    """DIAG only. Run the pure-CPU straddle live-view scenario `iters` times;
+    on the FIRST time the live time_model shows CPU* <= 0, dump the per-tick
+    LIVEREAD state and all time_model blocks so the failing read is
+    inspectable, then fail. ~10 shots per CI run raise the odds of catching
+    the intermittent 2-vCPU flake in one run."""
+    print(f"--- DIAG: straddle live-CPU loop ({iters}x) ---")
+    for it in range(iters):
+        trace_dir = tempfile.mkdtemp(prefix="pgwt_diag_")
+        os.chmod(trace_dir, 0o755)
+        hog = subprocess.Popen(
+            ["psql", "-U", "postgres", "-d", "postgres"],
+            stdin=subprocess.PIPE, stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL, text=True)
+        hog.stdin.write(
+            "DO $$ DECLARE x bigint := 0; BEGIN "
+            "FOR o IN 1..100000 LOOP "
+            "FOR i IN 1..1000000 LOOP x := x + i; END LOOP; x := 0; "
+            "END LOOP; END $$;\n")
+        hog.stdin.flush()
+        time.sleep(2.5)
+        env = {**os.environ, "PGWT_DBG_LIVEREAD": "1"}
+        tracer = subprocess.Popen(
+            [TRACER, "--mode", "full", "--pid", str(pm_pid), "-T", trace_dir,
+             "--duration", "12", "--interval", "5", "--view", "time_model"],
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env)
+        be_pid = None
+        try:
+            time.sleep(3.0)
+            be_pid = find_active_do_backend()
+            stdout, stderr = tracer.communicate(timeout=45)
+        except subprocess.TimeoutExpired:
+            tracer.kill()
+            stdout, stderr = tracer.communicate()
+        finally:
+            try:
+                hog.stdin.write("\\q\n"); hog.stdin.flush()
+            except (BrokenPipeError, ValueError):
+                pass
+            hog.terminate()
+            cleanup_stale_backends()
+        out = STRIP_ANSI.sub('', stdout.decode('utf-8', errors='replace'))
+        err = stderr.decode('utf-8', errors='replace')
+        live = parse_time_model(out)
+        cpu = live.get('CPU*', 0.0)
+        print(f"  iter {it}: live CPU*={cpu:.0f}ms  be_pid={be_pid}")
+        subprocess.run(["rm", "-rf", trace_dir])
+        if cpu <= 0.0:
+            print(f"=== CAUGHT: live CPU*=0 at iter {it} (be_pid={be_pid}) ===")
+            print("--- LIVEREAD per-tick state ---")
+            for l in err.splitlines():
+                if "LIVEREAD" in l:
+                    print(l)
+            print("--- full time_model stdout (last 4000 chars) ---")
+            print(out[-4000:])
+            print("--- stderr tail (last 1500 chars) ---")
+            print(err[-1500:])
+            check(False, f"DIAG caught straddle live CPU*=0 at iter {it}")
+            return
+    check(True, f"DIAG: all {iters} straddle iters had CPU*>0 (not caught)")
+
+
 def phase_sampled_aas_truth(pm_pid):
     """T2 (AAS-1) definition-of-done: sampled AAS — now CPU-inclusive —
     must match pg_stat_activity 1s-sampling ground truth. A CPU-bound
@@ -1181,6 +1243,11 @@ def main():
     psql("CREATE EXTENSION IF NOT EXISTS pg_stat_statements")
 
     cleanup_stale_backends()
+
+    # DIAG (diag-straddle-livecpu branch): take many shots at the intermittent
+    # live CPU*=0 straddle flake up front, so one CI run reproduces it.
+    if args.mode == 'full' and os.environ.get("PGWT_STRADDLE_DEBUG"):
+        phase_straddle_livecpu_loop(pm_pid)
 
     core = args.capture_core
     phase_live_system_event(pm_pid, args.mode, core=core)


### PR DESCRIPTION
Diagnostic-only branch to reproduce and capture the intermittent PG13 `phase_pure_cpu_straddle --mode full` live `CPU* = 0` on the 2-vCPU runner (the 4-core test box can't reproduce it). Instruments the live-read per-tick and dumps the tracer stderr on failure. **Do not merge** — will be discarded once the failing tick's state is captured.