### PR TITLE
fix(cpu): open on_cpu_ts at the watchpoint fire so a pure-CPU straddler shows live CPU

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,22 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+- **fix(cpu): pure-CPU straddler live CPU\*.** The measured-CPU live view
+  intermittently reported `CPU* = 0` for a waitless pure-CPU command that
+  straddled capture (~2% of runs, PG13 on 2-vCPU CI, never on a real box; the
+  terminal flush and the `/proc` magnitude cross-check were correct — only the
+  periodic live read was 0). A backend momentarily in a wait at the attach
+  instant seeds `on_cpu_ts = 0`; after it leaves that wait the `on_watchpoint`
+  transition to on-CPU advanced `last_cpu_ns` but never opened `on_cpu_ts`, so a
+  backend that then ran uninterrupted (no `sched_switch` to open it — common
+  when a CPU-bound backend owns a core on a quiet host) kept its on-CPU
+  accumulator flat and read `cpu_open == 0` for the whole stretch. Fixed by
+  opening `on_cpu_ts` at every watchpoint fire (the backend is provably on-CPU
+  there) — a no-op in normal operation. New deterministic regression
+  `phase_straddle_livecpu_deterministic` + a `PGWT_TEST_NO_SCHED_ONCPU` hook
+  (sched_switch inert) reproduces the miss on every run (live `CPU*` 9027ms with
+  the fix vs a 66ms background floor without).
+
 ## [0.13] — 2026-07-21
 
 The **Trust Milestone** (Track T, `docs/ROADMAP_AND_STATUS.md`) — a

--- a/src/backend.c
+++ b/src/backend.c
@@ -211,7 +211,13 @@ static int preseed_state_map(struct pgwt_daemon *d, pid_t pid, uint64_t addr,
              * (we==0) so a command straddling attach has its CPU measured from
              * the seed instant. attach_ts is CLOCK_MONOTONIC == bpf_ktime. */
             .cpu_ns_total = 0,
-            .on_cpu_ts    = (d->cpu_accounting && current_wei == 0) ? attach_ts : 0,
+            /* Open the on-CPU stretch at the seed iff the backend is running
+             * (we==0) now. TEST HOOK PGWT_TEST_NO_SCHED_ONCPU also forces this
+             * to 0 so on_cpu_ts can ONLY come from a watchpoint fire, making the
+             * straddle live-CPU repro deterministic (background backends on-CPU
+             * at seed can't then pollute the system-wide live CPU*). */
+            .on_cpu_ts    = (d->cpu_accounting && current_wei == 0 &&
+                             !getenv("PGWT_TEST_NO_SCHED_ONCPU")) ? attach_ts : 0,
             .last_cpu_ns  = 0,
         };
         uint32_t pid_key = pid;

--- a/src/bpf/pg_wait_tracer.bpf.c
+++ b/src/bpf/pg_wait_tracer.bpf.c
@@ -48,6 +48,17 @@ volatile const u64 debug_query_string_addr = 0; /* VA of debug_query_string glob
  * load even where the field is absent, so this is a belt-and-suspenders gate. */
 volatile const bool cpu_accounting = 0;
 
+/* TEST HOOK (PGWT_TEST_NO_SCHED_ONCPU): deterministically reproduce the
+ * live-view CPU*=0 straddle flake. When 1, on_sched_switch does NOT open
+ * on_cpu_ts for the incoming task, so a backend's on-CPU stretch is opened
+ * ONLY by the seed (current_wei==0) or a watchpoint fire. A backend that seeds
+ * OFF-CPU (in a real wait at attach, so on_cpu_ts starts 0) and then runs a
+ * waitless pure-CPU loop therefore reads live CPU* == 0 without the
+ * watchpoint-fire on_cpu_ts open below, and CPU* > 0 with it — on EVERY run,
+ * independent of the scheduler. This isolates exactly that fix. Test-only;
+ * never set in production (it disables sched-driven CPU accounting). */
+volatile const bool test_no_sched_oncpu = 0;
+
 /* Command-open gate (T2, docs/AAS_SEMANTICS_DECISION.md): per-PG-version
  * BackendState enum values for the pgstat_report_activity uprobe. PG13-17:
  * STATE_RUNNING=2, STATE_FASTPATH=4; PG18+ inserted STATE_STARTING so they
@@ -255,6 +266,13 @@ int BPF_PROG(on_sched_switch, bool preempt,
 {
     if (!cpu_accounting)
         return 0;
+    /* TEST HOOK: with sched_switch inert, on_cpu_ts is established ONLY by the
+     * seed (current_wei==0, also forced to 0 under this hook — see backend.c)
+     * or a watchpoint fire. A backend seeded off-CPU that then runs a waitless
+     * loop therefore has live CPU iff the watchpoint-fire on_cpu_ts open exists,
+     * making the straddle-CPU repro deterministic. Test-only. */
+    if (test_no_sched_oncpu)
+        return 0;
     u64 now = bpf_ktime_get_ns();
 
     u32 ppid = BPF_CORE_READ(prev, pid);
@@ -312,6 +330,13 @@ int on_watchpoint(struct bpf_perf_event_data *ctx)
              * it, just establish last_cpu_ns so the next real transition's
              * cpu_ns delta is correct. */
             st->last_cpu_ns = read_task_cpu_ns_for(st, seed_now);
+            /* Same on-CPU open as the real-transition path below: the backend
+             * is executing this write, so if no sched_switch-in has opened its
+             * stretch, open it here — otherwise the live read stays flat at 0
+             * for a backend that runs uninterrupted after seeding. No-op when
+             * cpu_accounting is off (read_task_cpu_ns_for returns 0 anyway). */
+            if (st->on_cpu_ts == 0)
+                st->on_cpu_ts = seed_now;
             st->wp_live = 1;
             return 0;
         }
@@ -363,6 +388,21 @@ int on_watchpoint(struct bpf_perf_event_data *ctx)
         /* Advance the CPU base on every emitted transition (T8). */
         st->last_cpu_ns = cpu_now;
 
+        /* S3 live-read fix: the backend is ON-CPU at this fire — it is executing
+         * this write. If no sched_switch-in has opened its on-CPU stretch (we
+         * attached mid-run and never saw its switch-in, or it seeded from a
+         * transient wait so on_cpu_ts started 0), on_cpu_ts is 0 here and
+         * read_task_cpu_ns_for() returns a FLAT cpu_ns_total. A backend that
+         * then runs uninterrupted (no sched_switch — common when a CPU-bound
+         * backend owns a core on a low-CPU host) keeps exact == last_cpu_ns, so
+         * the live view reads cpu_open == 0 for the whole on-CPU interval that
+         * starts here — even though the terminal flush (post-switch accumulator)
+         * records it correctly. Open the stretch now so the live read measures
+         * it. The "== 0" guard never clobbers a stretch sched_switch is already
+         * tracking; `now` is a conservative lower bound on the true start. */
+        if (st->on_cpu_ts == 0)
+            st->on_cpu_ts = now;
+
         /* Clear query_id when entering Client:ClientRead or any idle event.
          * At this point no query is running — the backend is waiting for
          * the next command. Without this, Client:ClientRead time between
@@ -386,8 +426,11 @@ int on_watchpoint(struct bpf_perf_event_data *ctx)
             .wait_event_addr = wait_addr,
             /* S3: the backend is on-CPU now (it just wrote wait_event_info);
              * open its on-CPU stretch here so the first interval measures. The
-             * base is 0 — cpu_ns deltas are taken from this attach onward. */
-            .on_cpu_ts = init_now,
+             * base is 0 — cpu_ns deltas are taken from this attach onward.
+             * (test_no_sched_oncpu forces 0 so this path cannot contribute live
+             * CPU either — under the hook on_cpu_ts is established ONLY by the
+             * real-transition open above, isolating that fix for the test.) */
+            .on_cpu_ts = test_no_sched_oncpu ? 0 : init_now,
             .cpu_ns_total = 0,
             .last_cpu_ns = 0,
         };

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -429,6 +429,14 @@ int pgwt_daemon_init(struct pgwt_daemon *d)
      * schedstat-less kernels is deferred; see the PR notes.) */
     d->cpu_accounting = (access("/sys/kernel/btf/vmlinux", R_OK) == 0);
     d->skel->rodata->cpu_accounting = d->cpu_accounting;
+    /* TEST HOOK: see pg_wait_tracer.bpf.c test_no_sched_oncpu. Forces the
+     * live CPU*=0 straddle repro deterministically by suppressing the
+     * sched_switch on_cpu_ts open. Test-only; loud so it can never be missed. */
+    if (getenv("PGWT_TEST_NO_SCHED_ONCPU")) {
+        d->skel->rodata->test_no_sched_oncpu = true;
+        fprintf(stderr, "WARN: PGWT_TEST_NO_SCHED_ONCPU — sched_switch on_cpu_ts "
+                "open suppressed (deterministic straddle-CPU repro; TEST ONLY)\n");
+    }
     if (!d->cpu_accounting) {
         /* No BTF → tp_btf/sched_switch can't load: don't try, and fall back
          * to gap-inference (cpu_ns UNKNOWN, no Off-CPU*). */

--- a/tests/test_capture_smoke.py
+++ b/tests/test_capture_smoke.py
@@ -904,6 +904,95 @@ def phase_straddle_recovery(pm_pid, mode):
     subprocess.run(["rm", "-rf", trace_dir])
 
 
+def phase_straddle_livecpu_deterministic(pm_pid):
+    """DETERMINISTIC regression for the live-view CPU*=0 straddle flake (the
+    on_watchpoint on_cpu_ts open, src/bpf/pg_wait_tracer.bpf.c). phase_pure_cpu_
+    straddle above exercises the same edge, but the miss is a TIMING race: it
+    needs the backend to (a) be in a wait at the attach instant so its seed
+    leaves on_cpu_ts=0, AND (b) then run uninterrupted so no sched_switch opens
+    on_cpu_ts — reproducing only ~2% of runs on 2-vCPU CI (PG13), never on a
+    real box. The live read then measures exact==cpu_ns_total (flat) and reports
+    CPU*=0 for the whole on-CPU stretch, while the terminal flush records it
+    correctly (the observed "live=0 but trace+magnitude pass").
+
+    This forces BOTH conditions so the miss is reproduced ON EVERY RUN:
+      (a) the backend is in Timeout:PgSleep when the tracer seeds it (a real
+          wait → current_wei != 0 → on_cpu_ts seeded 0), then runs a WAITLESS
+          pure-CPU loop; and
+      (b) PGWT_TEST_NO_SCHED_ONCPU makes sched_switch inert AND forces the seed
+          on_cpu_ts to 0, so on_cpu_ts can be established ONLY by a watchpoint
+          fire.
+    The single pg_sleep→loop transition is that fire: WITH the fix it opens
+    on_cpu_ts and the live view reads CPU* ≈ wall-since-loop-start; WITHOUT it
+    on_cpu_ts stays 0 and CPU* is exactly 0 — the exact CI failure, made
+    deterministic. Full mode only (needs watchpoints + cpu_accounting)."""
+    print("--- Phase: straddle live-CPU DETERMINISTIC (pg_sleep→loop, "
+          "sched_switch inert) ---")
+    trace_dir = tempfile.mkdtemp(prefix="pgwt_smoke_detcpu_")
+    os.chmod(trace_dir, 0o755)
+
+    # pg_sleep long enough that the tracer's BPF-load + scan seeds the backend
+    # WHILE it is still in the wait (so current_wei != 0 → on_cpu_ts=0), then a
+    # waitless pure-CPU loop (same int4-safe nested loop as the straddle hog).
+    hog = subprocess.Popen(
+        ["psql", "-U", "postgres", "-d", "postgres"],
+        stdin=subprocess.PIPE, stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL, text=True)
+    hog.stdin.write(
+        "SELECT pg_sleep(8);\n"
+        "DO $$ DECLARE x bigint := 0; BEGIN "
+        "FOR o IN 1..100000 LOOP "
+        "FOR i IN 1..1000000 LOOP x := x + i; END LOOP; x := 0; "
+        "END LOOP; END $$;\n")
+    hog.stdin.flush()
+    time.sleep(0.3)   # backend is entering pg_sleep before the tracer attaches
+
+    argv = [TRACER, "--mode", "full", "--pid", str(pm_pid),
+            "-T", trace_dir, "--duration", "20", "--interval", "4",
+            "--view", "time_model"]
+    env = {**os.environ, "PGWT_TEST_NO_SCHED_ONCPU": "1"}
+    tracer = subprocess.Popen(argv, stdout=subprocess.PIPE,
+                              stderr=subprocess.PIPE, env=env)
+    try:
+        stdout, stderr = tracer.communicate(timeout=55)
+    except subprocess.TimeoutExpired:
+        tracer.kill()
+        stdout, stderr = tracer.communicate()
+    finally:
+        try:
+            hog.stdin.write("\\q\n"); hog.stdin.flush()
+        except (BrokenPipeError, ValueError):
+            pass
+        hog.terminate()
+        cleanup_stale_backends()
+    out = STRIP_ANSI.sub('', stdout.decode('utf-8', errors='replace'))
+    err = stderr.decode('utf-8', errors='replace')
+
+    # The hook must actually have armed (else the test proves nothing).
+    check("PGWT_TEST_NO_SCHED_ONCPU" in err,
+          "sched_switch on_cpu_ts open suppressed (test hook active)")
+    # The payoff: the pg_sleep→loop watchpoint fire opened on_cpu_ts, so the
+    # waitless loop's ongoing on-CPU stretch is measured LIVE — several seconds
+    # of it by the final tick (its on-CPU time from pg_sleep end to trace end,
+    # ~8s, independent of box speed since the loop is CPU-bound). WITHOUT the fix
+    # the open interval reads 0 and CPU* is only a fixed ~tens-of-ms background
+    # floor (idle bgworkers' brief closed on-CPU intervals, counted at wall);
+    # measured 9027ms vs 66ms on PG13 — a >130x separation. The 2000ms gate sits
+    # ~4x below the multi-second signal and ~30x above that floor: a
+    # discriminator, not a tuned pass line. (A CPU/DB-Time ratio can't be used —
+    # DB Time also carries the 8s pg_sleep wait, diluting even the fixed run to
+    # ~27%.)
+    live = parse_time_model(out)
+    live_cpu = live.get('CPU*', 0.0)
+    check(live_cpu > 2000.0,
+          f"pg_sleep→loop straddler shows MULTI-SECOND live CPU* via the "
+          f"watchpoint on_cpu_ts open (sched_switch inert): CPU* = {live_cpu:.0f}ms "
+          f"(pre-fix ~0 loop CPU, only a ~tens-of-ms background floor; "
+          f"stderr {err[-120:]!r})")
+
+    subprocess.run(["rm", "-rf", trace_dir])
+
+
 def phase_sampled_aas_truth(pm_pid):
     """T2 (AAS-1) definition-of-done: sampled AAS — now CPU-inclusive —
     must match pg_stat_activity 1s-sampling ground truth. A CPU-bound
@@ -1201,6 +1290,11 @@ def main():
         # (covered by phase_pure_cpu_straddle above), not this recovery.
         if args.mode == 'full':
             phase_straddle_recovery(pm_pid, args.mode)
+            # Deterministic regression for the live-view CPU*=0 straddle flake:
+            # a pg_sleep→loop straddler with sched_switch forced inert reads
+            # multi-second live CPU* only if the watchpoint fire opens on_cpu_ts
+            # (the fix). Full mode only (needs watchpoints + cpu_accounting).
+            phase_straddle_livecpu_deterministic(pm_pid)
         if args.mode == 'tiered':
             # T2 (AAS semantics): CPU-inclusive sampled AAS vs pg_stat_activity
             # ground truth, and the CPU-storm escalation + tier-switch


### PR DESCRIPTION
## The bug

The measured-CPU **live view** intermittently reported `CPU* = 0` for a waitless pure-CPU command that straddled capture — ~2% of runs, PG13 on the 2-vCPU CI runners, never reproducible on a real box. It was the residual of the straddle work: the attach itself was fine (the terminal-flush trace **and** the `/proc` on-CPU magnitude cross-check both passed on the same run), only the periodic live read was 0.

Observed on a caught CI run (`--mode full`):

```
FAIL: pure-CPU straddle live view shows CPU* > 0: CPU* = 0ms
PASS: pure-CPU straddle trace carries CPU after terminal flush: cpu_ms = 35182 (has_measured_cpu=True)
PASS: pure-CPU straddle measured CPU 16511ms within ±20% of /proc on-CPU 17180ms (ratio 0.96)
```

## Root cause

Live on-CPU ns is `exact = cpu_ns_total + (on_cpu_ts ? now - on_cpu_ts : 0)`, from the `sched_switch` accumulator. `on_cpu_ts` is opened only by a `sched_switch`-in, or by the seed when the backend is on-CPU (`current_wei == 0`) at attach.

When a backend is momentarily in a **wait** at the attach instant (`current_wei != 0` → seed leaves `on_cpu_ts = 0`), then leaves that wait, the `on_watchpoint` transition to on-CPU advanced `last_cpu_ns` but **never opened `on_cpu_ts`**. If the backend then ran **uninterrupted** (no `sched_switch` — common when a CPU-bound backend owns a core on a quiet 2-vCPU host), `on_cpu_ts` stayed 0 and `cpu_ns_total` stayed flat, so `exact == last_cpu_ns` and the live read computed `cpu_open == 0` for the entire on-CPU stretch. `current_wei == 0` seeds are immune (one switch-out makes `cpu_ns_total > 0` forever), which is why it needed the rare transient-wait-at-attach coincidence.

## Fix

The backend is provably on-CPU at **every** watchpoint fire (it is executing the instrumented write), so open `on_cpu_ts` whenever it is 0 — at both the real-transition and the `wp_live == 0` seed-fire paths. This is a **no-op in normal operation** (`sched_switch`-in has already set `on_cpu_ts` before any fire); it only corrects the missed-switch-in case. `now` is a conservative lower bound on the true start.

## Test

`phase_straddle_livecpu_deterministic` reproduces the miss on **every** run: a `pg_sleep→loop` straddler (seeds in a real wait → `on_cpu_ts = 0`) plus a `PGWT_TEST_NO_SCHED_ONCPU` hook that makes `sched_switch` inert and forces the seed `on_cpu_ts` to 0, so `on_cpu_ts` can be established only by the watchpoint fire under test. With the fix the live view reads multi-second `CPU*` (9027ms on PG13), without it only a ~tens-of-ms background floor (66ms) — a >130x separation. The hook is env-gated and inert in production.

Verified on a PG13 box (kernel 6.8): full-mode smoke **36/36**, tiered **47/47**; fix-present PASS vs fix-removed FAIL confirmed by rebuilding the control on-box.