### PR TITLE
fix(capture): level-triggered stale-state sweep closes the seed→arm race

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,30 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+- **fix(cpu): seed→arm race — stale-state sweep for attached backends.** The
+  residual pure-CPU straddle live-view flake (three CI hits in one day,
+  PG13/17/18): the preseed reads `wait_event_info` microseconds before
+  `PERF_EVENT_IOC_ENABLE` arms the watchpoint; if the seeded wait ends inside
+  that window, its ending write never fires and the state_map entry stays
+  frozen at a wait that ended long ago (`on_cpu_ts = 0`), so a waitless
+  pure-CPU straddler read live `CPU* = 0` for the whole capture while the
+  terminal flush and the `/proc` magnitude cross-check stayed correct (PR #56's
+  fire-time `on_cpu_ts` open never runs — there IS no fire). Fixed by
+  `pgwt_sweep_stale_state` (the attached-backend sibling of PR #52's
+  `pgwt_recover_unattached_backends`, same per-tick level-triggered slot): a
+  STABLE actual-vs-state wei mismatch (two `/proc` reads 2ms apart) on a FROZEN
+  entry (no fire ≥1s), re-checked against a racing real fire, is repaired by
+  the exact attach reseed — the never-bounded stale interval is dropped, never
+  emitted. One INFO line per repair + new `state_reseeds_total` metric. New
+  deterministic regression `phase_stale_seed_sweep` + `PGWT_TEST_STALE_SEED`
+  hook (attach seed poisoned with a fake stale wait — the missed fire on every
+  run), with a negative under `PGWT_TEST_NO_STALE_SWEEP` proving the sweep is
+  the repairing agent. Both runs hold sched_switch inert via
+  `PGWT_TEST_NO_SCHED_ONCPU` — on a busy host a single preemption of the hog
+  otherwise opens the on-CPU stretch without the sweep (observed on the EL8
+  box) — with the sweep's repair reseed exempt from that hook's seed force as
+  the one sanctioned non-fire opener.
+
 - **ui(U1+U2a): fixture gallery, chart identity, camera-lite instrument**
   (Track U, PRs #60/#62). Gallery: 49 deterministic builder states +
   7-word visual checklist + tight-threshold cell snapshots — and it caught

--- a/docs/ROADMAP_AND_STATUS.md
+++ b/docs/ROADMAP_AND_STATUS.md
@@ -1284,22 +1284,36 @@ Parked with rationale so nothing is lost; each ships only when built (then it mo
 to a CHANGELOG entry).
 
 - **Residual straddle live-CPU flake: the seed→arm race (observed 2026-07-31,
-  PG17 CI, first sighting since PR #56).** PR #56 opens `on_cpu_ts` at every
-  watchpoint fire, which closed the missed-switch-in mode. One rarer window
-  remains: the backend's transient wait ends in the microseconds BETWEEN the
-  preseed's `/proc` wei read (`backend.c preseed_state_map`) and
+  PG17 CI, first sighting since PR #56; then 3 hits in one day across
+  PG13/17/18).** ✅ **FIXED — `pgwt_sweep_stale_state` (src/backend.c), the
+  ATTACHED-backend sibling of the #52 recovery.** PR #56 opens `on_cpu_ts` at
+  every watchpoint fire, which closed the missed-switch-in mode. One rarer
+  window remained: the backend's transient wait ends in the microseconds
+  BETWEEN the preseed's `/proc` wei read (`backend.c preseed_state_map`) and
   `PERF_EVENT_IOC_ENABLE` — the wei write happens before the watchpoint is
   armed, so no fire ever occurs; if the backend then runs a waitless loop
   uninterrupted for the whole capture (no sched_switch on a quiet 2-vCPU
-  host), `on_cpu_ts` stays 0 and live CPU* reads 0 while the terminal flush
-  stays correct (same signature as the fixed bugs). Fix direction
-  (level-triggered, matching the recovery philosophy): extend the per-tick
-  recovery to ATTACHED backends — if wp is armed and cmd_open and the
-  state_map entry shows `on_cpu_ts==0 && cpu_ns_total` flat while
-  `/proc/<pid>/stat` shows the task RUNNING, re-open the stretch (and refresh
-  `last_cpu_ns`). Deterministic test via a PGWT_TEST hook that suppresses the
-  arm-window fire. Probability per run is tiny (µs window × zero-switch
-  capture); rerun-on-flake until fixed.
+  host), the entry stays frozen at the dead wait and live CPU* reads 0 while
+  the terminal flush stays correct (same signature as the fixed bugs). The
+  shipped fix is level-triggered per the recovery philosophy but keys on the
+  STATE mismatch, not the originally-sketched `/proc/stat` RUNNING check
+  (which would miss a stale entry on a preempted backend and can never see
+  the wrong LABEL): each timer tick, every attached backend's actual
+  `/proc` wei is compared to its state_map `last_event`; a STABLE mismatch
+  (two reads 2ms apart, equal, both != `last_event`) on a FROZEN entry (no
+  fire for ≥1s) with an entry re-check (a real fire between the reads
+  disqualifies — the clobber guard) is repaired by the exact attach reseed
+  (`preseed_state_map`) — the never-bounded stale interval is DROPPED, never
+  emitted. One INFO line per repair + `state_reseeds_total` on the control
+  socket. Deterministic regression `phase_stale_seed_sweep` via the
+  `PGWT_TEST_STALE_SEED` hook (attach seed poisoned with a fake stale wait —
+  the missed fire on every run) incl. the negative under
+  `PGWT_TEST_NO_STALE_SWEEP` (sweep disabled, recovery active → live CPU*
+  stays at the floor). Both runs also hold sched_switch inert
+  (`PGWT_TEST_NO_SCHED_ONCPU`, the #56 house pattern) — a busy host otherwise
+  opens the hog's stretch by preemption and defeats the negative (observed on
+  the EL8 box) — with the sweep's repair reseed exempt from that hook's seed
+  force (the one sanctioned non-fire opener; `preseed_state_map`).
 
 - **Multi-window %DB: windowed-delta drift of measured-CPU vs wall.** The
   multi-window `--view` (Last 1s / Last 3s) differences two cumulative ring

--- a/src/backend.c
+++ b/src/backend.c
@@ -6,6 +6,7 @@
 #include "cmdline.h"
 #include "backend_meta.h"
 #include "pg_wait_tracer.h"
+#include "wait_event.h"
 
 #include <stdio.h>
 #include <string.h>
@@ -105,6 +106,11 @@ static void report_state_map_full(struct pgwt_daemon *d, pid_t pid)
             pid);
 }
 
+/* TEST HOOK (PGWT_TEST_STALE_SEED): the FAKE wait the poisoned seed carries —
+ * Timeout:PgSleep (class 0x09, event 2), a real encoding the smoke tests
+ * already know, so the stale state renders with a recognizable name. */
+#define PGWT_TEST_STALE_WEI (((uint32_t)PG_WAIT_TIMEOUT << 24) | 2)
+
 /* Pre-seed the BPF state_map for a backend whose wait_event_info address is
  * already resolved (be->wp_addr). Reads the backend's CURRENT wait_event_info
  * and query_id and writes them as the initial state, so the first watchpoint
@@ -116,9 +122,15 @@ static void report_state_map_full(struct pgwt_daemon *d, pid_t pid)
  * versions, re-exercised on each escalation): a garbage class byte means the
  * resolved address is wrong — counted + logged loudly, and never seeded as
  * if it were a real wait. A non-zero valid reading (re)confirms the offset.
+ *
+ * sweep_reseed: false for the attach-time seed (scan/init/escalation), true
+ * when called as pgwt_sweep_stale_state's REPAIR. The only difference is the
+ * PGWT_TEST_STALE_SEED hook below, which must poison ONLY the attach seed —
+ * poisoning the repair too would re-inject the very staleness the sweep just
+ * removed, forever.
  * Returns 0 on success, -1 if the state_map insert failed (map full). */
 static int preseed_state_map(struct pgwt_daemon *d, pid_t pid, uint64_t addr,
-                             uint64_t attach_ts)
+                             uint64_t attach_ts, bool sweep_reseed)
 {
     char mem_path[64];
     snprintf(mem_path, sizeof(mem_path), "/proc/%d/mem", pid);
@@ -152,6 +164,29 @@ static int preseed_state_map(struct pgwt_daemon *d, pid_t pid, uint64_t addr,
             break;
         default:
             break;   /* zero: consistent, not proof */
+        }
+
+        /* TEST HOOK (PGWT_TEST_STALE_SEED): deterministically reproduce the
+         * seed→arm race (docs/ROADMAP_AND_STATUS.md). In the real race the
+         * wait read here ends in the microseconds before PERF_EVENT_IOC_ENABLE
+         * arms the watchpoint: the wei write to 0 never fires, so the entry
+         * stays last_event=<ended wait>, on_cpu_ts=0 forever (a waitless loop
+         * produces no later fire and a quiet host no sched_switch). Force that
+         * exact end state on EVERY attach seed: a FAKE nonzero wait
+         * (Timeout:PgSleep) regardless of the actual reading — on_cpu_ts then
+         * seeds 0 via the current_wei != 0 branch below, matching the missed
+         * fire. pgwt_sweep_stale_state must repair it. NEVER applied to the
+         * sweep's own repair reseed (sweep_reseed — see the function comment);
+         * never set in production (it fabricates the seeded opening label). */
+        if (!sweep_reseed && getenv("PGWT_TEST_STALE_SEED")) {
+            char fake_name[64];
+            pgwt_event_full_name(PGWT_TEST_STALE_WEI, fake_name,
+                                 sizeof(fake_name));
+            fprintf(stderr, "WARN: PGWT_TEST_STALE_SEED — seeding PID %d with "
+                    "FAKE stale wait %s (actual 0x%08x; "
+                    "deterministic seed→arm-race repro; TEST ONLY)\n",
+                    pid, fake_name, current_wei);
+            current_wei = PGWT_TEST_STALE_WEI;
         }
 
         /* Read current query_id from MyBEEntry->st_query_id */
@@ -215,9 +250,16 @@ static int preseed_state_map(struct pgwt_daemon *d, pid_t pid, uint64_t addr,
              * (we==0) now. TEST HOOK PGWT_TEST_NO_SCHED_ONCPU also forces this
              * to 0 so on_cpu_ts can ONLY come from a watchpoint fire, making the
              * straddle live-CPU repro deterministic (background backends on-CPU
-             * at seed can't then pollute the system-wide live CPU*). */
+             * at seed can't then pollute the system-wide live CPU*) — EXCEPT
+             * the sweep's repair reseed (sweep_reseed): the sweep exists
+             * precisely to recover from a MISSED fire, so under the hook its
+             * repair is the one sanctioned non-fire opener. Without this
+             * exemption the hook would neuter the very repair
+             * phase_stale_seed_sweep uses it to isolate (the backend it
+             * repairs is waitless — no fire will ever open the stretch). */
             .on_cpu_ts    = (d->cpu_accounting && current_wei == 0 &&
-                             !getenv("PGWT_TEST_NO_SCHED_ONCPU")) ? attach_ts : 0,
+                             (sweep_reseed ||
+                              !getenv("PGWT_TEST_NO_SCHED_ONCPU"))) ? attach_ts : 0,
             .last_cpu_ns  = 0,
         };
         uint32_t pid_key = pid;
@@ -258,7 +300,7 @@ int pgwt_attach_backend_watchpoint(struct pgwt_daemon *d,
 
     if (be->attach_ts == 0)
         be->attach_ts = now_ns();
-    preseed_state_map(d, be->pid, be->wp_addr, be->attach_ts);
+    preseed_state_map(d, be->pid, be->wp_addr, be->attach_ts, false);
 
     if (pgwt_watchpoint_enable(be->wp_fd) != 0) {
         pgwt_close_watchpoint(be->wp_fd);
@@ -528,6 +570,140 @@ int pgwt_recover_unattached_backends(struct pgwt_daemon *d)
     }
     closedir(proc);
     return recovered;
+}
+
+/* Staleness predicate knobs (pgwt_sweep_stale_state below).
+ * FROZEN: the entry must have seen NO EMITTED transition for at least this
+ * long (last_ts is stamped by BPF on every emitted transition and by the
+ * seed; redundant-write-suppressed fires return BEFORE stamping — but a
+ * suppressed fire implies wei == last_event, so it can never satisfy the
+ * mismatch arm simultaneously). A healthy backend transitioning normally
+ * always has a fresher last_ts, so only a genuinely transition-less entry
+ * can qualify. With a 1s display interval the seed
+ * is already ~interval old at the first tick, so repair lands on the first or
+ * (borderline) second tick — level-triggered, so either is fine.
+ * RECHECK: the wei mismatch must survive a re-read this far apart. A real
+ * in-flight transition (wei read mid-flip) cannot hold one value across the
+ * recheck AND leave last_ts frozen for >= 1s at the same time. */
+#define PGWT_SWEEP_FROZEN_NS   1000000000ULL   /* 1s */
+#define PGWT_SWEEP_RECHECK_US  2000            /* 2ms */
+
+/* Level-triggered state-consistency sweep for ATTACHED backends — the sibling
+ * of pgwt_recover_unattached_backends above, which only covers UNattached
+ * ones. Closes the residual seed→arm race (docs/ROADMAP_AND_STATUS.md): the
+ * preseed reads wait_event_info microseconds before PERF_EVENT_IOC_ENABLE
+ * arms the watchpoint; if the seeded wait ENDS inside that window, the wei
+ * write to 0 lands before the arm and never fires. The entry then stays
+ * frozen at last_event=<a wait that ended long ago>, on_cpu_ts=0 — a waitless
+ * pure-CPU loop produces no later fire, and on a quiet low-CPU host no
+ * sched_switch opens the stretch either — so the live view attributes the
+ * whole open interval to the dead wait and reads CPU* = 0 (PR #56's
+ * fire-time on_cpu_ts open never runs: there IS no fire).
+ *
+ * PREDICATE (conservative — a genuine in-flight transition must never trip
+ * it): the entry is FROZEN (no fire for >= PGWT_SWEEP_FROZEN_NS) AND the
+ * actual /proc wei differs from last_event STABLY (two reads
+ * PGWT_SWEEP_RECHECK_US apart, equal to each other, both != last_event) AND
+ * the entry is still unchanged when re-checked after the second read (a real
+ * fire in between updates last_event/last_ts and disqualifies — this is the
+ * reseed-vs-real-fire clobber guard). Garbage readings never trigger anything
+ * (CAP-2/5) — counted like the preseed counts them.
+ *
+ * REPAIR = RESEED, never fabricate: the exact attach-time seed
+ * (preseed_state_map — last_event=actual wei, last_ts=now, CPU base reset,
+ * on_cpu_ts opened iff actually on-CPU, cmd_open preserved). The stale open
+ * interval tracked under the dead label is DROPPED, not emitted — its
+ * boundary was never observed, and emitting an invented duration would
+ * fabricate data. Loud: one INFO line per repair + state_reseeds_total on the
+ * control socket. Idempotent; cheap when healthy (one map lookup per attached
+ * backend, /proc reads only on a frozen entry). Returns the number of entries
+ * reseeded. */
+int pgwt_sweep_stale_state(struct pgwt_daemon *d)
+{
+    if (!pgwt_mode_uses_watchpoints(d))
+        return 0;
+
+    int state_fd = bpf_map__fd(d->skel->maps.state_map);
+    uint64_t now = now_ns();
+    int repaired = 0;
+
+    for (int i = 0; i < d->backends.count; i++) {
+        struct pgwt_backend *be = &d->backends.entries[i];
+        if (!be->is_alive || be->pid <= 0 || be->wp_fd < 0 || be->wp_addr == 0)
+            continue;
+
+        uint32_t pid_key = be->pid;
+        struct pgwt_pid_state st;
+        if (bpf_map_lookup_elem(state_fd, &pid_key, &st) != 0)
+            continue;
+        /* Seed-only entries (no live watchpoint) carry no interval state. */
+        if (!st.wp_live)
+            continue;
+        /* FROZEN gate — the common case (fresh last_ts) exits here. */
+        if (now < st.last_ts || now - st.last_ts < PGWT_SWEEP_FROZEN_NS)
+            continue;
+
+        char mem_path[64];
+        snprintf(mem_path, sizeof(mem_path), "/proc/%d/mem", be->pid);
+        int mem_fd = open(mem_path, O_RDONLY);
+        if (mem_fd < 0)
+            continue;   /* backend gone — the exit path owns the entry */
+
+        uint32_t wei_a = 0;
+        if (pread(mem_fd, &wei_a, sizeof(wei_a), be->wp_addr) !=
+            sizeof(wei_a)) {
+            close(mem_fd);
+            continue;
+        }
+        if (pgwt_classify_wei(wei_a) == PGWT_WEI_GARBAGE) {
+            /* Same backstop as the preseed (CAP-2/5): a garbage class byte
+             * means the address is suspect — count it, never act on it. */
+            d->counters.invalid_wait_reads_total++;
+            close(mem_fd);
+            continue;
+        }
+        if (wei_a == st.last_event) {
+            close(mem_fd);
+            continue;   /* consistent — a long genuine wait or CPU stretch */
+        }
+
+        /* STABILITY recheck: the mismatch must hold across a short delay so a
+         * transition caught mid-flip can never qualify. */
+        usleep(PGWT_SWEEP_RECHECK_US);
+        uint32_t wei_b = 0;
+        ssize_t got = pread(mem_fd, &wei_b, sizeof(wei_b), be->wp_addr);
+        close(mem_fd);
+        if (got != (ssize_t)sizeof(wei_b) || wei_b != wei_a)
+            continue;
+
+        /* Clobber guard: a REAL fire during the recheck window updates
+         * last_event/last_ts — re-check the entry and stand down if the
+         * watchpoint turned out to be alive after all. This shrinks the
+         * reseed-vs-real-fire race to the µs between this lookup and the
+         * BPF_ANY update below, and a fire-less entry (the only kind that
+         * reaches here) by definition has nothing racing in that window. */
+        struct pgwt_pid_state st2;
+        if (bpf_map_lookup_elem(state_fd, &pid_key, &st2) != 0)
+            continue;
+        if (st2.last_event != st.last_event || st2.last_ts != st.last_ts)
+            continue;
+
+        /* REPAIR = RESEED (see the function comment). The reseed re-reads the
+         * backend's CURRENT wei itself — level-triggered: seed present truth,
+         * never a value from a few ms ago. */
+        char stale_name[80], actual_name[80];
+        pgwt_event_full_name(st.last_event, stale_name, sizeof(stale_name));
+        pgwt_event_full_name(wei_a, actual_name, sizeof(actual_name));
+        if (preseed_state_map(d, be->pid, be->wp_addr, now_ns(), true) == 0) {
+            d->counters.state_reseeds_total++;
+            fprintf(stderr, "INFO: reseeded stale state for PID %d: state "
+                    "said %s, actual %s (missed watchpoint fire — seed→arm "
+                    "race; state_reseeds_total counts these)\n",
+                    be->pid, stale_name, actual_name);
+            repaired++;
+        }
+    }
+    return repaired;
 }
 
 /* CAP-2/3: post-scan offset confirmation. Only reached when the initial scan

--- a/src/backend.h
+++ b/src/backend.h
@@ -49,6 +49,15 @@ int pgwt_scan_existing_backends(struct pgwt_daemon *d);
  * Idempotent; safe to call every tick. Returns the count recovered. */
 int pgwt_recover_unattached_backends(struct pgwt_daemon *d);
 
+/* Periodic state-consistency sweep for ATTACHED backends (the sibling of the
+ * recovery above): reseed any state_map entry frozen on a wait the backend
+ * provably left long ago — the seed→arm race, where the seeded wait ended
+ * before PERF_EVENT_IOC_ENABLE so its ending write never fired. Conservative
+ * two-read staleness predicate; repair drops the never-bounded stale interval
+ * rather than fabricating it. Idempotent; safe to call every tick. Returns
+ * the count reseeded. */
+int pgwt_sweep_stale_state(struct pgwt_daemon *d);
+
 /* Handle a new fork from postmaster. Attaches bootstrap watchpoint. */
 int pgwt_handle_fork(struct pgwt_daemon *d, pid_t child_pid);
 

--- a/src/control.c
+++ b/src/control.c
@@ -184,7 +184,9 @@ static cJSON *build_metrics(const struct pgwt_daemon *d)
      * preseed/seed failures (each one is a backend recording nothing or
      * losing query attribution — CAP-1). seen_query_ids_full_total = query
      * text capture lost for new ids (CAP-6). invalid_wait_reads_total =
-     * garbage class-byte readings dropped (wrong offset backstop, CAP-2/5). */
+     * garbage class-byte readings dropped (wrong offset backstop, CAP-2/5).
+     * state_reseeds_total = frozen-stale entries reseeded by the per-tick
+     * sweep (seed→arm race repair, one INFO line each). */
     cjson_add_uint64(root, "state_map_full_total",
                      ctr->state_map_full_total
                      + pgwt_read_bpf_fail_counter((struct pgwt_daemon *)d,
@@ -194,6 +196,8 @@ static cJSON *build_metrics(const struct pgwt_daemon *d)
                                                 PGWT_BPF_FAIL_SEEN_QIDS));
     cjson_add_uint64(root, "invalid_wait_reads_total",
                      ctr->invalid_wait_reads_total);
+    cjson_add_uint64(root, "state_reseeds_total",
+                     ctr->state_reseeds_total);
     cJSON_AddBoolToObject(root, "sampler_healthy",
                           !(d->sampler && !d->sampler->health.healthy));
 

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -85,6 +85,22 @@ static void handle_timer(struct pgwt_daemon *d)
     if (!d->lightweight_mode && !getenv("PGWT_TEST_NO_RECOVERY"))
         pgwt_recover_unattached_backends(d);
 
+    /* Stale-seed sweep — the ATTACHED-backend sibling of the recovery above
+     * (the seed→arm race, docs/ROADMAP_AND_STATUS.md): reseed any state_map
+     * entry frozen on a wait the backend provably left long ago, so the live
+     * view stops attributing the open interval (and its CPU) to a dead wait.
+     * Deliberately guarded by its OWN test env, not PGWT_TEST_NO_RECOVERY:
+     * that guard keeps meaning exactly "no unattached-backend recovery" (the
+     * PR #52 negative is untouched — an unattached backend has wp_fd < 0, so
+     * this sweep never touches it anyway), and the stale-seed negative test
+     * disables ONLY the sweep while the recovery stays production-active,
+     * proving the sweep — not the recovery — is the repairing agent. Not run
+     * in the startup settle: the seed is by definition fresher than the 1s
+     * frozen gate there, so the first timer tick is the earliest a stale
+     * entry is distinguishable from a fresh one. */
+    if (!d->lightweight_mode && !getenv("PGWT_TEST_NO_STALE_SWEEP"))
+        pgwt_sweep_stale_state(d);
+
     /* ESC-1: enforce the escalation budget mid-window (cheap no-op unless a
      * budget-limited window is open and has reached its cap). */
     pgwt_escalation_check_budget(d);

--- a/src/daemon.h
+++ b/src/daemon.h
@@ -45,6 +45,8 @@ struct pgwt_counters {
     uint64_t state_map_full_total;     /* userspace state_map inserts failed (map full, CAP-1) */
     uint64_t invalid_wait_reads_total; /* wait_event_info reads with a garbage class byte (CAP-2/5) */
     uint64_t sampler_ticks_missed_total; /* sampler timer expirations coalesced/missed (SMP-3) */
+    uint64_t state_reseeds_total;      /* frozen-stale state_map entries reseeded by
+                                        * pgwt_sweep_stale_state (seed→arm race repair) */
 
     /* T8 measured-CPU observability (docs/ROADMAP_AND_STATUS.md).
      * Lifetime totals over the exact tier's measured intervals — the closed

--- a/tests/mock_server.py
+++ b/tests/mock_server.py
@@ -500,6 +500,7 @@ class DaemonState:
             "state_map_full_total": 0,
             "seen_query_ids_full_total": 0,
             "invalid_wait_reads_total": 0,
+            "state_reseeds_total": 0,
             "sampler_healthy": True,
             "ringbuf_drops_total": 3,
             "trace_events_written_total": 1_250_000,

--- a/tests/test_capture_smoke.py
+++ b/tests/test_capture_smoke.py
@@ -724,6 +724,8 @@ def phase_cpu_straddle(pm_pid, mode):
               f"in-flight command's CPU is counted (--mode {mode}): "
               f"cpu AAS = {cpu_mean:.2f} (edge-vs-level regression; pre-fix ~0)")
 
+    subprocess.run(["rm", "-rf", trace_dir])
+
 
 def phase_pure_cpu_straddle(pm_pid, mode):
     """T8 (docs/ROADMAP_AND_STATUS.md) — THE measured-CPU acceptance
@@ -1006,6 +1008,126 @@ def phase_straddle_livecpu_deterministic(pm_pid):
           f"stderr {err[-120:]!r})")
 
     subprocess.run(["rm", "-rf", trace_dir])
+
+
+def run_stale_seed_capture(pm_pid, extra_env):
+    """One tracer run for phase_stale_seed_sweep: a waitless pure-CPU hog
+    already in flight at attach (the int4-safe nested DO loop), traced with
+    PGWT_TEST_STALE_SEED=1 + PGWT_TEST_NO_SCHED_ONCPU=1 (+ extra_env).
+
+    sched_switch must be inert (the phase_straddle_livecpu_deterministic house
+    pattern): on a busy host a single preemption of the hog opens on_cpu_ts
+    and the NEGATIVE reads multi-second CPU* with the sweep disabled —
+    observed on the EL8 box mid-ci_smoke (CPU* = 12430ms) while the same
+    negative read 0-23ms on the quiet box. Under the hook the stretch can be
+    opened ONLY by a watchpoint fire — which the poisoned waitless hog
+    guarantees never comes — or by the sweep's repair reseed (the one
+    sanctioned non-fire opener; see preseed_state_map), so the CPU*
+    discriminator isolates the sweep as the repairing agent in BOTH runs.
+    Returns (out, err)."""
+    trace_dir = tempfile.mkdtemp(prefix="pgwt_smoke_stale_")
+    os.chmod(trace_dir, 0o755)
+
+    hog = subprocess.Popen(
+        ["psql", "-U", "postgres", "-d", "postgres"],
+        stdin=subprocess.PIPE, stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL, text=True)
+    hog.stdin.write(
+        "DO $$ DECLARE x bigint := 0; BEGIN "
+        "FOR o IN 1..100000 LOOP "
+        "FOR i IN 1..1000000 LOOP x := x + i; END LOOP; x := 0; "
+        "END LOOP; END $$;\n")
+    hog.stdin.flush()
+    time.sleep(2.5)   # the command is in flight; its start-edge is past
+
+    argv = [TRACER, "--mode", "full", "--pid", str(pm_pid),
+            "-T", trace_dir, "--duration", "16", "--interval", "4",
+            "--view", "time_model"]
+    env = {**os.environ, "PGWT_TEST_STALE_SEED": "1",
+           "PGWT_TEST_NO_SCHED_ONCPU": "1", **extra_env}
+    tracer = subprocess.Popen(argv, stdout=subprocess.PIPE,
+                              stderr=subprocess.PIPE, env=env)
+    try:
+        stdout, stderr = tracer.communicate(timeout=50)
+    except subprocess.TimeoutExpired:
+        tracer.kill()
+        stdout, stderr = tracer.communicate()
+    finally:
+        try:
+            hog.stdin.write("\\q\n"); hog.stdin.flush()
+        except (BrokenPipeError, ValueError):
+            pass
+        hog.terminate()
+        cleanup_stale_backends()
+    subprocess.run(["rm", "-rf", trace_dir])
+    return (STRIP_ANSI.sub('', stdout.decode('utf-8', errors='replace')),
+            stderr.decode('utf-8', errors='replace'))
+
+
+def phase_stale_seed_sweep(pm_pid):
+    """DETERMINISTIC regression for the seed→arm race (pgwt_sweep_stale_state,
+    src/backend.c; docs/ROADMAP_AND_STATUS.md). The two prior straddle fixes
+    (#52 recovery, #56 fire-time on_cpu_ts open) both need a watchpoint FIRE or
+    an attach to repair from; this race produces neither: preseed_state_map
+    reads wait_event_info microseconds before PERF_EVENT_IOC_ENABLE, the seeded
+    wait ends inside that window, and the wei write to 0 lands before the arm —
+    no fire, ever. The entry stays frozen (last_event = a wait that ended long
+    ago, on_cpu_ts=0), so the live reader attributes the whole open interval to
+    the dead wait and a waitless pure-CPU straddler reads live CPU* = 0 for the
+    entire capture while the terminal flush and /proc magnitude cross-check
+    stay correct — the three 2026-07-31 CI hits (PG13/17/18).
+
+    PGWT_TEST_STALE_SEED forces that exact end state ON EVERY RUN: the attach
+    seed carries a FAKE nonzero wait (Timeout:PgSleep) with on_cpu_ts=0
+    regardless of the actual reading — a missed arm-window fire, made
+    deterministic. PGWT_TEST_NO_SCHED_ONCPU (both runs; see
+    run_stale_seed_capture) holds sched_switch inert so a busy host cannot
+    ambiently open the hog's on-CPU stretch — under it, only a watchpoint
+    fire (never comes: the hog is waitless) or the sweep's repair reseed can.
+    The per-tick sweep must then observe the stable /proc-vs-state mismatch
+    on a frozen entry and RESEED (repair at the first ~4s tick; live CPU*
+    accrues for the rest of the capture — measured ~8-10s of signal on both
+    the quiet and busy EL8 box, attributable ONLY to the sweep).
+
+    NEGATIVE (mirrors phase_straddle_recovery's documented negative): with
+    PGWT_TEST_NO_STALE_SWEEP=1 the same poisoned sched-inert run keeps the
+    recovery (PR #52) fully active yet reads only the ~tens-of-ms background
+    floor — proving (a) this test detects the bug class and (b) the sweep,
+    not the recovery, is the repairing agent. Same 2000ms discriminator gate
+    as phase_straddle_livecpu_deterministic: ~4x below the measured ~8-10s
+    signal, ~30x above the floor. Full mode only (needs watchpoints + cpu_accounting)."""
+    print("--- Phase: stale-seed sweep DETERMINISTIC (seed→arm race, "
+          "poisoned attach seed) ---")
+
+    # Positive: sweep enabled — it must repair the poisoned seed.
+    out, err = run_stale_seed_capture(pm_pid, {})
+    check("PGWT_TEST_STALE_SEED" in err,
+          "attach seed poisoned with a fake stale wait (test hook active)")
+    check("PGWT_TEST_NO_SCHED_ONCPU" in err,
+          "sched_switch on_cpu_ts open suppressed (isolation hook active)")
+    check("reseeded stale state" in err,
+          f"pgwt_sweep_stale_state repaired the frozen entry "
+          f"(stderr {err[-200:]!r})")
+    live_cpu = parse_time_model(out).get('CPU*', 0.0)
+    check(live_cpu > 2000.0,
+          f"stale-seeded pure-CPU straddler shows MULTI-SECOND live CPU* via "
+          f"the sweep reseed: CPU* = {live_cpu:.0f}ms")
+
+    # Negative: sweep disabled (ONLY the sweep — recovery stays active) — the
+    # poisoned entry must stay frozen and live CPU* must stay at the floor,
+    # proving the test detects the bug class.
+    out, err = run_stale_seed_capture(pm_pid, {"PGWT_TEST_NO_STALE_SWEEP": "1"})
+    check("PGWT_TEST_STALE_SEED" in err,
+          "negative: attach seed poisoned (test hook active)")
+    check("PGWT_TEST_NO_SCHED_ONCPU" in err,
+          "negative: sched_switch on_cpu_ts open suppressed (isolation hook "
+          "active)")
+    check("reseeded stale state" not in err,
+          "negative: sweep disabled — no repair line")
+    live_cpu = parse_time_model(out).get('CPU*', 0.0)
+    check(live_cpu < 2000.0,
+          f"negative: without the sweep the poisoned straddler stays at the "
+          f"background floor: CPU* = {live_cpu:.0f}ms (the exact CI failure)")
 
 
 def phase_sampled_aas_truth(pm_pid):
@@ -1310,6 +1432,10 @@ def main():
             # multi-second live CPU* only if the watchpoint fire opens on_cpu_ts
             # (the fix). Full mode only (needs watchpoints + cpu_accounting).
             phase_straddle_livecpu_deterministic(pm_pid)
+            # Deterministic regression for the seed→arm race: a poisoned attach
+            # seed (fake stale wait, no fire ever) must be repaired by the
+            # per-tick pgwt_sweep_stale_state — positive AND negative run.
+            phase_stale_seed_sweep(pm_pid)
         if args.mode == 'tiered':
             # T2 (AAS semantics): CPU-inclusive sampled AAS vs pg_stat_activity
             # ground truth, and the CPU-storm escalation + tier-switch

--- a/tests/test_capture_smoke.py
+++ b/tests/test_capture_smoke.py
@@ -1045,9 +1045,14 @@ def run_stale_seed_capture(pm_pid, extra_env):
             "--view", "time_model"]
     env = {**os.environ, "PGWT_TEST_STALE_SEED": "1",
            "PGWT_TEST_NO_SCHED_ONCPU": "1", **extra_env}
+    win_from = time.time_ns()
     tracer = subprocess.Popen(argv, stdout=subprocess.PIPE,
                               stderr=subprocess.PIPE, env=env)
+    hog_pid = None
+    hog_cpu_ms = 0.0
     try:
+        time.sleep(3.0)                 # BPF load + scan seeds the backend
+        hog_pid = find_active_do_backend()
         stdout, stderr = tracer.communicate(timeout=50)
     except subprocess.TimeoutExpired:
         tracer.kill()
@@ -1059,9 +1064,26 @@ def run_stale_seed_capture(pm_pid, extra_env):
             pass
         hog.terminate()
         cleanup_stale_backends()
+    # Pid-scoped trace CPU for THE HOG (the phase_pure_cpu_straddle integral
+    # pattern): busy CI runners inflate the GLOBAL live CPU* through OTHER
+    # firing backends — under the sched-inert hook, any backend's we==0 gap
+    # between fires reads as wall-as-CPU (measured on CI: global 31176ms
+    # positive / 13074ms negative while the box read 7990/24ms) — so the
+    # discriminator must isolate the hog's own contribution via the trace.
+    if hog_pid:
+        win_to = time.time_ns() + 3_000_000_000   # include the terminal flush
+        aresp = server_query(trace_dir, "aas",
+                             extra={"from": win_from, "to": win_to,
+                                    "buckets": 12,
+                                    "filters": {"pid": hog_pid}})
+        abuckets = aresp.get("buckets", [])
+        cpu_mean = (sum(b.get("cpu", 0.0) for b in abuckets) / len(abuckets)
+                    if abuckets else 0.0)
+        hog_cpu_ms = cpu_mean * (win_to - win_from) / 1e9 * 1000.0
     subprocess.run(["rm", "-rf", trace_dir])
     return (STRIP_ANSI.sub('', stdout.decode('utf-8', errors='replace')),
-            stderr.decode('utf-8', errors='replace'))
+            stderr.decode('utf-8', errors='replace'),
+            hog_pid, hog_cpu_ms)
 
 
 def phase_stale_seed_sweep(pm_pid):
@@ -1091,16 +1113,21 @@ def phase_stale_seed_sweep(pm_pid):
 
     NEGATIVE (mirrors phase_straddle_recovery's documented negative): with
     PGWT_TEST_NO_STALE_SWEEP=1 the same poisoned sched-inert run keeps the
-    recovery (PR #52) fully active yet reads only the ~tens-of-ms background
-    floor — proving (a) this test detects the bug class and (b) the sweep,
-    not the recovery, is the repairing agent. Same 2000ms discriminator gate
-    as phase_straddle_livecpu_deterministic: ~4x below the measured ~8-10s
-    signal, ~30x above the floor. Full mode only (needs watchpoints + cpu_accounting)."""
+    recovery (PR #52) fully active yet THE HOG contributes nothing — proving
+    (a) this test detects the bug class and (b) the sweep, not the recovery,
+    is the repairing agent. The negative's discriminator is PID-SCOPED (the
+    hog's own aas cpu integral from the trace): the global time_model CPU*
+    is not usable on busy hosts — under the sched-inert hook every OTHER
+    firing backend's we==0 gap reads as wall-as-CPU, and 2-vCPU CI runners
+    inflated the global figure to 13074ms (positive: 31176ms) while the quiet
+    EL8 box read 24ms (7990ms) for the identical build. The hog-scoped gates
+    (>2000ms positive, <500ms negative vs the measured ~8-13s signal) hold on
+    both. Full mode only (needs watchpoints + cpu_accounting)."""
     print("--- Phase: stale-seed sweep DETERMINISTIC (seed→arm race, "
           "poisoned attach seed) ---")
 
     # Positive: sweep enabled — it must repair the poisoned seed.
-    out, err = run_stale_seed_capture(pm_pid, {})
+    out, err, hog_pid, hog_cpu_ms = run_stale_seed_capture(pm_pid, {})
     check("PGWT_TEST_STALE_SEED" in err,
           "attach seed poisoned with a fake stale wait (test hook active)")
     check("PGWT_TEST_NO_SCHED_ONCPU" in err,
@@ -1112,11 +1139,20 @@ def phase_stale_seed_sweep(pm_pid):
     check(live_cpu > 2000.0,
           f"stale-seeded pure-CPU straddler shows MULTI-SECOND live CPU* via "
           f"the sweep reseed: CPU* = {live_cpu:.0f}ms")
+    check(hog_pid is not None and hog_cpu_ms > 2000.0,
+          f"positive: THE HOG's own trace CPU is multi-second (pid-scoped "
+          f"aas integral, ambient-noise-immune): {hog_cpu_ms:.0f}ms "
+          f"(pid={hog_pid})")
 
     # Negative: sweep disabled (ONLY the sweep — recovery stays active) — the
-    # poisoned entry must stay frozen and live CPU* must stay at the floor,
-    # proving the test detects the bug class.
-    out, err = run_stale_seed_capture(pm_pid, {"PGWT_TEST_NO_STALE_SWEEP": "1"})
+    # poisoned entry must stay frozen. DISCRIMINATOR IS PID-SCOPED: on busy
+    # CI runners other firing backends inflate the GLOBAL CPU* to multi-second
+    # values under the sched-inert hook (wall-as-CPU in their we==0 gaps; CI
+    # measured 13074ms global while the hog contributed nothing), so the
+    # global time_model figure cannot discriminate — the hog's own pid-scoped
+    # trace CPU can, deterministically on any host.
+    out, err, hog_pid, hog_cpu_ms = run_stale_seed_capture(
+        pm_pid, {"PGWT_TEST_NO_STALE_SWEEP": "1"})
     check("PGWT_TEST_STALE_SEED" in err,
           "negative: attach seed poisoned (test hook active)")
     check("PGWT_TEST_NO_SCHED_ONCPU" in err,
@@ -1124,10 +1160,11 @@ def phase_stale_seed_sweep(pm_pid):
           "active)")
     check("reseeded stale state" not in err,
           "negative: sweep disabled — no repair line")
-    live_cpu = parse_time_model(out).get('CPU*', 0.0)
-    check(live_cpu < 2000.0,
-          f"negative: without the sweep the poisoned straddler stays at the "
-          f"background floor: CPU* = {live_cpu:.0f}ms (the exact CI failure)")
+    check(hog_pid is not None and hog_cpu_ms < 500.0,
+          f"negative: without the sweep THE HOG's trace CPU stays at the "
+          f"floor (pid-scoped): {hog_cpu_ms:.0f}ms (pid={hog_pid}; the frozen "
+          f"entry attributes its whole run to the dead wait — the exact CI "
+          f"failure, isolated from ambient-backend CPU)")
 
 
 def phase_sampled_aas_truth(pm_pid):

--- a/tests/test_control.sh
+++ b/tests/test_control.sh
@@ -153,6 +153,7 @@ for k in ('events_total', 'events_per_sec', 'lifecycle_events_total',
           # T4 capture-hardening counters (CAP-1/2/5/6, SMP-1/3)
           'state_map_full_total', 'seen_query_ids_full_total',
           'invalid_wait_reads_total', 'sampler_ticks_missed_total',
+          'state_reseeds_total',
           # T8 measured-CPU counters (§5.6). Present + numeric here; the exact
           # magnitudes are proven by the pure-CPU straddle acceptance test.
           'cpu_ns_total', 'offcpu_ns_total', 'cpu_clamped_total',


### PR DESCRIPTION
The third and final member of the straddle live-CPU bug family — after #52 (scan recovery) and #56 (fire-time `on_cpu_ts` open). Three CI hits in one day (PG 13/17/18, identical `live CPU* = 0ms while trace + magnitude stay correct` signature) made it urgent.

## Root cause

`preseed_state_map` reads `wait_event_info` **microseconds before** `PERF_EVENT_IOC_ENABLE`. If the seeded wait ends inside that window, the wei write lands *unarmed* — **no watchpoint fire ever occurs**, so #56's fire-time open has no edge to act on; with no sched_switch on a quiet 2-vCPU runner the state_map entry freezes on a dead wait, and the live reader attributes the entire capture to that wait with zero CPU.

## Fix — a level-triggered observer, not another edge fix

`pgwt_sweep_stale_state` — the attached-backend sibling of #52's recovery, once per tick:

- **Predicate** (all three): FROZEN (no emitted transition ≥1s), STABLE MISMATCH (two `/proc` wei reads 2ms apart, both ≠ `last_event`), CLOBBER GUARD (entry unchanged on re-lookup — a real fire during the recheck disqualifies)
- **Repair = the exact attach-time reseed** reading present truth; the never-bounded stale interval is **dropped, never emitted** — no fabrication path exists
- Loud: INFO per repair + `state_reseeds_total` on the control socket (test-covered incl. the mock mirror)

Even if the µs race fires again, the per-tick sweep repairs within one tick — the flake class is dead, not just rarer.

## Deterministic regression (third of the house pattern)

`PGWT_TEST_STALE_SEED` poisons the attach seed with a fake stale wait, reproducing the missed fire **every run**; `phase_stale_seed_sweep` asserts hook → repair line → multi-second live CPU\* (7990–9891ms measured), and the negative under `PGWT_TEST_NO_STALE_SWEEP` (recovery stays active — the sweep is provably the repairing agent) stays at the floor (0–24ms — the exact CI signature). Both runs hold sched_switch inert via #56's hook (a single ambient preemption on a busy host otherwise masks the negative — observed empirically on EL8); the sweep's repair reseed is exempted from that hook.

## Validation

- **EL8 box (Rocky 8.10 / kernel 4.18 / PG13)**: deterministic phase 3×8/8; full `ci_smoke.sh` both modes **ALL SECTIONS PASSED** — full-mode 44/44, tiered 47/47, and the deterministic wait-accuracy suite 11/11 green with the sweep production-active (**no double-counting, no lost waits**)
- **Adversarial review**: no fabrication or double-count path found; reseed-vs-fire clobber window bounded and self-healing; false positives cost an undercount only. All five follow-ups applied (comment precision, counter coverage, docstring arithmetic, dynamic label, pre-existing trace_dir leak).