### PR TITLE
debug(capture): shutdown state_map dump makes the next straddle flake self-diagnosing

### DIFF
--- a/docs/ROADMAP_AND_STATUS.md
+++ b/docs/ROADMAP_AND_STATUS.md
@@ -1329,6 +1329,18 @@ to a CHANGELOG entry).
   (`state_reseeds_total`, sched counters), so the next CI hit yields the
   entry's actual `{last_event, last_ts, on_cpu_ts, cpu_ns_total,
   last_cpu_ns, wp_live}` instead of another inference cycle.
+  **FIRST CAPTURE (2026-08-04, PG18 CI, the dump's maiden run):** the hog's
+  shutdown entry was HEALTHY AND COUNTABLE — `last_event=CPU*, cmd_open=1,
+  on_cpu_ts open (age 90ms), cpu_ns_total=14.93s, last_cpu_ns=0` — i.e. the
+  live read's inputs at shutdown yield cpu_open ≈ 15s, byte-identical in
+  shape to a PASSING box run's end state. The fourth mode is therefore a
+  TICK-TIME phenomenon invisible to the shutdown snapshot. Context captured:
+  a ZOMBIE second CPU hog from a prior phase (cmd_open=0, still burning at
+  shutdown) sharing the 2 vCPUs, `wp_attach_failures_total=1`,
+  `wait_gap_cpu_ns_total=1.77s`. Instrumentation extended with
+  `STATEDUMP-TICK` (per-tick cpu_open computation inputs in the live
+  reader, same env gate) — the next hit shows what each tick actually
+  computed.
 
 - **Multi-window %DB: windowed-delta drift of measured-CPU vs wall.** The
   multi-window `--view` (Last 1s / Last 3s) differences two cumulative ring

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -9,6 +9,7 @@
 #include "output.h"
 #include "perf_event.h"
 #include "provider_coop.h"
+#include "wait_event.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -452,6 +453,15 @@ int pgwt_daemon_init(struct pgwt_daemon *d)
         d->skel->rodata->test_no_sched_oncpu = true;
         fprintf(stderr, "WARN: PGWT_TEST_NO_SCHED_ONCPU — sched_switch on_cpu_ts "
                 "open suppressed (deterministic straddle-CPU repro; TEST ONLY)\n");
+    }
+    /* DEBUG HOOK (PGWT_DEBUG_DUMP_STATE): see pgwt_debug_dump_state_map — the
+     * final state_map is dumped to stderr at shutdown for the reopened
+     * straddle live-CPU investigation. Announced here so the hook can never
+     * be active silently, same discipline as the PGWT_TEST_* hooks above. */
+    if (getenv("PGWT_DEBUG_DUMP_STATE")) {
+        fprintf(stderr, "WARN: PGWT_DEBUG_DUMP_STATE — final state_map will be "
+                "dumped to stderr at shutdown (STATEDUMP lines; DEBUG ONLY, "
+                "never set in production)\n");
     }
     if (!d->cpu_accounting) {
         /* No BTF → tp_btf/sched_switch can't load: don't try, and fall back
@@ -1029,8 +1039,106 @@ int pgwt_daemon_run(struct pgwt_daemon *d)
     return 0;
 }
 
+/* PGWT_DEBUG_DUMP_STATE (DEBUG ONLY): dump the final BPF state_map to stderr
+ * at shutdown — the self-diagnosing payload for the reopened straddle
+ * live-CPU flake (docs/ROADMAP_AND_STATUS.md "REOPENED 2026-08-04 — a FOURTH
+ * straddle live-CPU mode exists"). Three shipped fixes each closed a distinct
+ * mode (#52 scan recovery, #56 fire-time on_cpu_ts open, #63 stale-state
+ * sweep) yet a `live CPU* = 0ms, trace correct` run still occurs, and every
+ * CI hit so far cost an inference cycle because the hog's end-state died with
+ * the daemon. This prints each entry's RAW fields exactly as the last live
+ * tick saw them — decoded alongside, fabricating nothing (no clamping, no
+ * derived verdicts) — plus one STATEDUMP-META line with the self-metrics
+ * (control.c names) that discriminate between the known modes. Capped at
+ * PGWT_STATEDUMP_MAX entries: the flaky phase tracks a handful of backends,
+ * and a capped dump on a big map says so loudly instead of flooding.
+ * Zero cost when the env is unset (one getenv per shutdown). */
+#define PGWT_STATEDUMP_MAX 64
+
+static void pgwt_debug_dump_state_map(struct pgwt_daemon *d)
+{
+    if (!getenv("PGWT_DEBUG_DUMP_STATE") || !d->skel)
+        return;
+    int state_fd = bpf_map__fd(d->skel->maps.state_map);
+    if (state_fd < 0)
+        return;   /* init-failure path: skeleton opened but never loaded */
+
+    /* Same clock base as bpf_ktime / attach_ts (see preseed_state_map), so
+     * the printed ages are directly comparable to the entry timestamps. */
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    uint64_t now = (uint64_t)ts.tv_sec * 1000000000ULL + ts.tv_nsec;
+
+    int backends_tracked = 0;
+    for (int i = 0; i < d->backends.count; i++)
+        if (d->backends.entries[i].is_alive)
+            backends_tracked++;
+
+    /* META first so a truncated/partial log still carries the counters. */
+    fprintf(stderr,
+            "STATEDUMP-META: cpu_accounting=%d backends_tracked=%d "
+            "state_reseeds_total=%llu invalid_wait_reads_total=%llu "
+            "wp_attach_failures_total=%llu state_map_full_total=%llu "
+            "cpu_ns_total=%llu offcpu_ns_total=%llu "
+            "cpu_clamped_ns_total=%llu wait_gap_cpu_ns_total=%llu\n",
+            d->cpu_accounting ? 1 : 0, backends_tracked,
+            (unsigned long long)d->counters.state_reseeds_total,
+            (unsigned long long)d->counters.invalid_wait_reads_total,
+            (unsigned long long)d->counters.wp_attach_failures_total,
+            (unsigned long long)d->counters.state_map_full_total,
+            (unsigned long long)d->counters.cpu_ns_total,
+            (unsigned long long)d->counters.offcpu_ns_total,
+            (unsigned long long)d->counters.cpu_clamped_ns_total,
+            (unsigned long long)d->counters.wait_gap_cpu_ns_total);
+
+    uint32_t key = 0, next;
+    struct pgwt_pid_state st;
+    int n = 0;
+    while (bpf_map_get_next_key(state_fd, &key, &next) == 0) {
+        if (bpf_map_lookup_elem(state_fd, &next, &st) == 0) {
+            if (++n > PGWT_STATEDUMP_MAX) {
+                fprintf(stderr, "STATEDUMP: ... truncated at %d entries "
+                        "(map holds more)\n", PGWT_STATEDUMP_MAX);
+                break;
+            }
+            char ev_name[80];
+            pgwt_event_full_name(st.last_event, ev_name, sizeof(ev_name));
+            /* on_cpu_ts: 0 = no open on-CPU stretch (the straddle-flake
+             * signature when paired with a stale wait label); nonzero is
+             * printed raw with its age. Ages are signed on purpose — a
+             * negative age would itself be a finding (clock skew), never
+             * clamped away. */
+            char oncpu[64];
+            if (st.on_cpu_ts)
+                snprintf(oncpu, sizeof(oncpu), "%llu(age_ms=%.1f)",
+                         (unsigned long long)st.on_cpu_ts,
+                         ((double)now - (double)st.on_cpu_ts) / 1e6);
+            else
+                snprintf(oncpu, sizeof(oncpu), "0");
+            fprintf(stderr,
+                    "STATEDUMP: pid=%u wp_live=%u cmd_open=%u "
+                    "last_event=0x%08x(%s) last_ts=%llu(age_ms=%.1f) "
+                    "on_cpu_ts=%s cpu_ns_total=%llu last_cpu_ns=%llu "
+                    "last_query_id=0x%llx\n",
+                    next, st.wp_live, st.cmd_open, st.last_event, ev_name,
+                    (unsigned long long)st.last_ts,
+                    ((double)now - (double)st.last_ts) / 1e6,
+                    oncpu,
+                    (unsigned long long)st.cpu_ns_total,
+                    (unsigned long long)st.last_cpu_ns,
+                    (unsigned long long)st.last_query_id);
+        }
+        key = next;
+    }
+}
+
 void pgwt_daemon_cleanup(struct pgwt_daemon *d)
 {
+    /* DEBUG (PGWT_DEBUG_DUMP_STATE): capture the state_map's end-state BEFORE
+     * anything below detaches watchpoints or flushes entries — the dump must
+     * show exactly what the last live tick saw. No-op unless the env is set. */
+    pgwt_debug_dump_state_map(d);
+
     /* Close any open escalation window (detaches watchpoints, writes the END
      * marker) before the event writer is torn down. */
     pgwt_escalation_cleanup(d);

--- a/src/map_reader.c
+++ b/src/map_reader.c
@@ -10,6 +10,7 @@
 
 #include <string.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <stdbool.h>
 #include <time.h>
 
@@ -244,6 +245,27 @@ void pgwt_read_state_map(struct pgwt_daemon *d)
                         uint64_t m = exact - sval.last_cpu_ns;
                         cpu_open = m < open_ns ? m : open_ns;   /* clamp to wall */
                     }
+                    /* PGWT_DEBUG_DUMP_STATE tick-time companion of the
+                     * shutdown STATEDUMP (fourth-mode investigation): the
+                     * 2026-08-04 CI hit proved the SHUTDOWN state healthy and
+                     * countable while every tick printed CPU* = 0 — the
+                     * discriminator is what THIS computation saw per tick.
+                     * DEBUG ONLY; env checked once. */
+                    static int dbg_tick = -1;
+                    if (dbg_tick < 0)
+                        dbg_tick = getenv("PGWT_DEBUG_DUMP_STATE") != NULL;
+                    if (dbg_tick)
+                        fprintf(stderr, "STATEDUMP-TICK: pid=%u open_ns=%llu "
+                                "cpu_ns_total=%llu on_cpu_age=%lld exact=%llu "
+                                "last_cpu_ns=%llu cpu_open=%llu\n",
+                                snext,
+                                (unsigned long long)open_ns,
+                                (unsigned long long)sval.cpu_ns_total,
+                                sval.on_cpu_ts
+                                    ? (long long)(now - sval.on_cpu_ts) : -1,
+                                (unsigned long long)exact,
+                                (unsigned long long)sval.last_cpu_ns,
+                                (unsigned long long)cpu_open);
                 }
 
                 /* Per-PID accumulation */

--- a/tests/test_capture_smoke.py
+++ b/tests/test_capture_smoke.py
@@ -774,7 +774,16 @@ def phase_pure_cpu_straddle(pm_pid, mode):
     be_pid = None
     oncpu_before = oncpu_after = None
     win_from = win_shutdown = 0
-    tracer = subprocess.Popen(argv, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    # Self-diagnosis (docs/ROADMAP_AND_STATUS.md "REOPENED 2026-08-04 — a
+    # FOURTH straddle live-CPU mode exists"): this phase's live-CPU check is
+    # the flake's only witness, so ALWAYS arm the daemon's shutdown state_map
+    # dump (STATEDUMP:/STATEDUMP-META: stderr lines, pgwt_debug_dump_state_map
+    # in src/daemon.c). A passing run keeps the dump inside the captured
+    # stderr and prints nothing extra; a failing run surfaces it below, so
+    # the next CI hit hands us the hog's actual end-state instead of another
+    # inference cycle.
+    tracer = subprocess.Popen(argv, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                              env={**os.environ, "PGWT_DEBUG_DUMP_STATE": "1"})
     try:
         time.sleep(3.0)                 # BPF load + scan/attach seeds the backend
         be_pid = find_active_do_backend()
@@ -803,6 +812,17 @@ def phase_pure_cpu_straddle(pm_pid, mode):
     #    Pre-T8 this row was 0.0 for a waitless command (the exact symptom).
     live = parse_time_model(out)
     live_cpu = live.get('CPU*', 0.0)
+    if live_cpu <= 0.0:
+        # THE flake fired (see the Popen env above): print the hog pid and
+        # the daemon's shutdown state_map dump BEFORE check() records the
+        # failure, so the CI log itself answers which end-state produced
+        # live CPU* = 0. Raw daemon lines, unfiltered by content — the dump
+        # is the diagnostic payload, never interpreted here.
+        print(f"=== STRADDLE LIVE CPU* = 0 — shutdown state_map dump "
+              f"(hog be_pid={be_pid}) ===")
+        for _line in err.splitlines():
+            if _line.startswith("STATEDUMP"):
+                print(_line)
     check(live_cpu > 0.0,
           f"pure-CPU straddle live view shows CPU* > 0 (--mode {mode}): "
           f"CPU* = {live_cpu:.0f}ms (pre-T8 ~0; stderr {err[-160:]!r})")


### PR DESCRIPTION
Step 2 of the current sequence — instrumentation for the **reopened** straddle live-CPU investigation (fourth mode: failed *with* the #63 sweep active, no reseed line — so not the seed→arm race; evidence needed, not another theory).

## What it does

`PGWT_DEBUG_DUMP_STATE=1` → at the top of daemon cleanup (before escalation close / open-interval flush / BPF teardown, so entries read exactly as the last live tick saw them), the daemon prints:

- `STATEDUMP-META:` `cpu_accounting`, `backends_tracked`, `state_reseeds_total`, `invalid_wait_reads_total`, `wp_attach_failures_total`, `state_map_full_total` + the four T8 measured-CPU totals
- `STATEDUMP:` per entry — pid, `wp_live`, `cmd_open`, `last_event` (hex **+ decoded name**), `last_ts` (raw + age), `on_cpu_ts` (raw + age), `cpu_ns_total`, `last_cpu_ns`, `last_query_id`

Raw fields with decode alongside — nothing clamped or fabricated (negative ages would *surface* clock skew, not hide it). Capped at 64 entries with a loud truncation line; zero cost when unset; loud DEBUG-ONLY warn when armed.

`phase_pure_cpu_straddle` always arms it and, **only on the live-CPU FAIL**, prints the hog pid + all STATEDUMP lines into the test output — the next CI occurrence hands us the hog's actual end-state (frozen wait label vs open-but-flat stretch vs missing entry) directly in the job log. All phase assertions byte-identical.

## Validation

EL8 box (Rocky 8.10 / PG13): pass run 3/3 with nothing extra printed (healthy hog entry confirmed present in captured stderr: `on_cpu_ts age 293ms, cpu_ns_total 12.3s`); forced-fail driver run proves the dump machinery fires end-to-end. Local C unit suite fully green. Userspace-only — no BPF changes.