### PR TITLE
Add decisive mode 4 hunt diagnostics

### DIFF
--- a/.github/scripts/mode4_hunt.py
+++ b/.github/scripts/mode4_hunt.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Repeat the full-mode pure-CPU straddle phase until its live view misses."""
+
+import argparse
+import os
+from pathlib import Path
+import re
+import subprocess
+import sys
+import traceback
+
+
+REPO = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO / "tests"))
+
+import test_capture_smoke as t  # noqa: E402
+
+
+PROC_CPU_RE = re.compile(r"/proc on-CPU ([0-9]+(?:\.[0-9]+)?)ms")
+
+
+def write_failure(stderr, summary):
+    strike_path = REPO / "mode4-strike.log"
+    summary_path = REPO / "mode4-hunt-summary.txt"
+    if isinstance(stderr, str):
+        stderr = stderr.encode("utf-8", errors="replace")
+    strike_path.write_bytes(stderr)
+    summary_path.write_text(summary + "\n", encoding="utf-8")
+    print(summary)
+    print("=== complete tracer stderr ===")
+    sys.stdout.write(stderr.decode("utf-8", errors="replace"))
+    if stderr and not stderr.endswith(b"\n"):
+        print()
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--iterations", type=int, required=True)
+    parser.add_argument("--postmaster-pid-file", type=Path, required=True)
+    args = parser.parse_args()
+    if args.iterations <= 0:
+        parser.error("--iterations must be positive")
+
+    pm_pid = int(args.postmaster_pid_file.read_text(encoding="utf-8")
+                 .splitlines()[0])
+    t.TRACER = str(REPO / "pg_wait_tracer")
+    t.SERVER = str(REPO / "pgwt-server")
+    os.environ["PGWT_DEBUG_DUMP_STATE"] = "1"
+
+    current = {"stderr": b""}
+    iteration_checks = []
+    original_popen = subprocess.Popen
+    original_check = t.check
+
+    class CapturingPopen(original_popen):
+        def __init__(self, *popen_args, **popen_kwargs):
+            command = (popen_args[0] if popen_args
+                       else popen_kwargs.get("args", []))
+            executable = command[0] if isinstance(command, (list, tuple)) \
+                and command else command
+            self._mode4_tracer = (
+                executable is not None
+                and os.path.abspath(os.fspath(executable)) == t.TRACER)
+            super().__init__(*popen_args, **popen_kwargs)
+
+        def communicate(self, *comm_args, **comm_kwargs):
+            stdout, stderr = super().communicate(*comm_args, **comm_kwargs)
+            if self._mode4_tracer:
+                current["stderr"] = stderr or b""
+            return stdout, stderr
+
+    def capture_check(condition, message):
+        iteration_checks.append((bool(condition), str(message)))
+        original_check(condition, message)
+
+    t.subprocess.Popen = CapturingPopen
+    t.check = capture_check
+
+    try:
+        for iteration in range(1, args.iterations + 1):
+            current["stderr"] = b""
+            iteration_checks.clear()
+            try:
+                t.phase_pure_cpu_straddle(pm_pid, "full")
+            except Exception:
+                detail = traceback.format_exc()
+                stderr = current["stderr"] + detail.encode("utf-8")
+                write_failure(
+                    stderr,
+                    f"iteration {iteration}/{args.iterations}: driver error")
+                return 1
+
+            live_failed = any(
+                not passed
+                and message.startswith("pure-CPU straddle live view")
+                for passed, message in iteration_checks)
+            proc_cpu_ms = [
+                float(match.group(1))
+                for _, message in iteration_checks
+                for match in [PROC_CPU_RE.search(message)]
+                if match
+            ]
+            proc_burned = any(value > 0.0 for value in proc_cpu_ms)
+            failed_checks = [
+                message for passed, message in iteration_checks if not passed]
+
+            if live_failed and proc_burned:
+                summary = (
+                    f"iteration {iteration}/{args.iterations}: REPRODUCED; "
+                    f"live CPU*=0 while /proc CPU delta was "
+                    f"{max(proc_cpu_ms):.0f}ms")
+                write_failure(current["stderr"], summary)
+                return 1
+
+            if failed_checks:
+                summary = (
+                    f"iteration {iteration}/{args.iterations}: unexpected "
+                    f"phase failure: {'; '.join(failed_checks)}")
+                write_failure(current["stderr"], summary)
+                return 1
+
+            print(f"iteration {iteration}/{args.iterations}: passed")
+    finally:
+        t.subprocess.Popen = original_popen
+        t.check = original_check
+
+    summary = f"not reproduced in {args.iterations}"
+    (REPO / "mode4-strike.log").write_text(summary + "\n", encoding="utf-8")
+    (REPO / "mode4-hunt-summary.txt").write_text(
+        summary + "\n", encoding="utf-8")
+    print(summary)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,14 @@ on:
         description: "Regenerate visual-snapshot baselines and upload them as an artifact"
         type: boolean
         default: false
+      iterations:
+        description: "Number of full-mode pure-CPU straddle attempts"
+        type: string
+        default: "80"
+      pg:
+        description: "PostgreSQL major version for the mode-4 hunt"
+        type: string
+        default: "17"
 
 jobs:
   build-and-unit:
@@ -204,6 +212,116 @@ jobs:
             "GITHUB_STEP_SUMMARY=$GITHUB_STEP_SUMMARY" \
             "BPFTOOL=$BPFTOOL" \
             tests/ci_smoke.sh --pg-version "$V" $FLAGS
+
+  mode4-hunt:
+    name: mode4-hunt
+    if: ${{ github.event_name == 'workflow_dispatch' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Initialize hunt artifacts
+        run: |
+          printf '%s\n' 'hunt did not start' > mode4-strike.log
+          printf '%s\n' 'hunt did not start' > mode4-hunt-summary.txt
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang llvm libbpf-dev libelf-dev \
+            zlib1g-dev liblz4-dev linux-tools-common
+          # Same bpftool fallback as capture-smoke: the runner's HWE azure
+          # kernel may ship linux-tools without a bpftool binary.
+          if bpftool version >/dev/null 2>&1; then
+            BPFTOOL=$(command -v bpftool)
+          else
+            git clone --depth 1 --branch v7.5.0 --recurse-submodules \
+              https://github.com/libbpf/bpftool.git /tmp/bpftool
+            make -C /tmp/bpftool/src -j"$(nproc)"
+            BPFTOOL=/tmp/bpftool/src/bpftool
+          fi
+          "$BPFTOOL" version
+          echo "BPFTOOL=$BPFTOOL" >> "$GITHUB_ENV"
+          test -r /sys/kernel/btf/vmlinux
+
+      - name: Install PostgreSQL ${{ inputs.pg }} (PGDG apt)
+        env:
+          PG_MAJOR: ${{ inputs.pg }}
+        run: |
+          set -x
+          V="$PG_MAJOR"
+          sudo systemctl stop postgresql || true
+          sudo apt-get install -y postgresql-common
+          pg_lsclusters -h | awk '{print $1, $2}' | while read -r ver name; do
+            sudo pg_dropcluster --stop "$ver" "$name" || true
+          done
+          sudo /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -y
+          if ! apt-cache show "postgresql-$V" >/dev/null 2>&1; then
+            echo "postgresql-$V not in the live PGDG repo — adding apt-archive"
+            echo "deb https://apt-archive.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" \
+              | sudo tee /etc/apt/sources.list.d/pgdg-archive.list
+            sudo apt-get update
+          fi
+          sudo apt-get install -y "postgresql-$V" "postgresql-contrib-$V"
+
+      - name: Configure + start PostgreSQL ${{ inputs.pg }}
+        env:
+          PG_MAJOR: ${{ inputs.pg }}
+        run: |
+          set -ex
+          V="$PG_MAJOR"
+          if ! pg_lsclusters -h | awk -v v="$V" '$1 == v && $2 == "main"' | grep -q .; then
+            sudo pg_createcluster "$V" main
+          fi
+          sudo pg_conftool "$V" main set port 5432
+          sudo pg_conftool "$V" main set shared_preload_libraries pg_stat_statements
+          if [ "$V" -ge 14 ]; then
+            sudo pg_conftool "$V" main set compute_query_id on
+          fi
+          sudo sed -i -E 's/(peer|scram-sha-256|md5)$/trust/' \
+            "/etc/postgresql/$V/main/pg_hba.conf"
+          sudo pg_ctlcluster "$V" main start
+          psql -U postgres -d postgres -c "CREATE EXTENSION IF NOT EXISTS pg_stat_statements"
+          psql -U postgres -d postgres -tAc "SELECT version()"
+
+      - name: Build (BPF tracer + pgwt-server)
+        run: make
+
+      - name: Hunt the fourth full-mode straddle failure
+        env:
+          HUNT_ITERATIONS: ${{ inputs.iterations }}
+          PG_MAJOR: ${{ inputs.pg }}
+        run: |
+          set -euo pipefail
+          burn_cpu() {
+            while :; do :; done
+          }
+          burn_cpu &
+          BURNER_ONE=$!
+          burn_cpu &
+          BURNER_TWO=$!
+          cleanup_burners() {
+            kill "$BURNER_ONE" "$BURNER_TWO" 2>/dev/null || true
+            wait "$BURNER_ONE" "$BURNER_TWO" 2>/dev/null || true
+          }
+          trap cleanup_burners EXIT
+
+          sudo env "PATH=/usr/lib/postgresql/$PG_MAJOR/bin:$PATH" \
+            "PGWT_DEBUG_DUMP_STATE=1" \
+            python3 .github/scripts/mode4_hunt.py \
+              --iterations "$HUNT_ITERATIONS" \
+              --postmaster-pid-file \
+              "/var/lib/postgresql/$PG_MAJOR/main/postmaster.pid"
+
+      - name: Upload mode-4 hunt artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: mode4-hunt-${{ inputs.pg }}-${{ github.run_attempt }}
+          path: |
+            mode4-strike.log
+            mode4-hunt-summary.txt
+          if-no-files-found: error
 
   web-ui:
     name: web-ui

--- a/src/map_reader.c
+++ b/src/map_reader.c
@@ -172,6 +172,9 @@ void pgwt_read_state_map(struct pgwt_daemon *d)
     uint64_t now = now_ns();
     int entries = 0;
     int we0_open = 0;
+    int lookup_failed = 0;
+    int we_nonzero = 0;
+    int open_zero = 0;
     int skipped_not_live = 0;
     int skipped_closed = 0;
     static int dbg_scan = -1;
@@ -181,8 +184,10 @@ void pgwt_read_state_map(struct pgwt_daemon *d)
         dbg_scan = getenv("PGWT_DEBUG_DUMP_STATE") != NULL;
     if (dbg_scan)
         fprintf(stderr, "STATEDUMP-SCAN: entries=%d we0_open=%d "
+                "lookup_failed=%d we_nonzero=%d open_zero=%d "
                 "skipped_not_live=%d skipped_closed=%d\n",
-                entries, we0_open, skipped_not_live, skipped_closed);
+                entries, we0_open, lookup_failed, we_nonzero, open_zero,
+                skipped_not_live, skipped_closed);
 
     errno = 0;
     next_rc = bpf_map_get_next_key(state_fd, &skey, &snext);
@@ -207,8 +212,14 @@ void pgwt_read_state_map(struct pgwt_daemon *d)
             uint64_t open_ns = now - sval.last_ts;
             uint32_t we = sval.last_event;
 
-            if (we == 0 && open_ns > 0)
-                we0_open++;
+            if (dbg_scan) {
+                if (we != 0)
+                    we_nonzero++;
+                else if (open_ns == 0)
+                    open_zero++;
+                else
+                    we0_open++;
+            }
 
             /* Store current state for active sessions view */
             struct pgwt_pid_accum *pa_cur = pgwt_get_or_create_pid(&d->accum, snext);
@@ -349,15 +360,71 @@ void pgwt_read_state_map(struct pgwt_daemon *d)
                     }
                 }
             }
+        } else if (dbg_scan) {
+            lookup_failed++;
         }
         skey = snext;
         next_rc = bpf_map_get_next_key(state_fd, &skey, &snext);
     }
 
-    if (dbg_scan)
+    if (dbg_scan) {
         fprintf(stderr, "STATEDUMP-SCAN: entries=%d we0_open=%d "
-                "skipped_not_live=%d skipped_closed=%d\n",
-                entries, we0_open, skipped_not_live, skipped_closed);
+                "lookup_failed=%d we_nonzero=%d open_zero=%d "
+                "skipped_not_live=%d skipped_closed=%d "
+                "state_fd=%d mode=%d cpu_acct=%d\n",
+                entries, we0_open, lookup_failed, we_nonzero, open_zero,
+                skipped_not_live, skipped_closed, state_fd, (int)d->mode,
+                d->cpu_accounting ? 1 : 0);
+
+        int registry_pids = 0;
+        int found = 0;
+        int direct_we0_open = 0;
+        int direct_we_nonzero = 0;
+        int direct_open_zero = 0;
+        int not_found = 0;
+        int pid_lines = 0;
+
+        for (int i = 0; i < d->backends.count; i++) {
+            struct pgwt_backend *be = &d->backends.entries[i];
+            if (!be->is_alive || be->pid <= 0)
+                continue;
+
+            uint32_t pid = (uint32_t)be->pid;
+            struct pgwt_pid_state direct_sval;
+            uint64_t open_ns = 0;
+            int pid_found =
+                bpf_map_lookup_elem(state_fd, &pid, &direct_sval) == 0;
+
+            registry_pids++;
+            if (pid_found) {
+                found++;
+                open_ns = now - direct_sval.last_ts;
+                if (direct_sval.last_event != 0)
+                    direct_we_nonzero++;
+                else if (open_ns == 0)
+                    direct_open_zero++;
+                else
+                    direct_we0_open++;
+            } else {
+                not_found++;
+                memset(&direct_sval, 0, sizeof(direct_sval));
+            }
+
+            if (pid_lines < 8) {
+                fprintf(stderr, "STATEDUMP-DIRECT-PID: pid=%d found=%d "
+                        "we=0x%llx open_ns=%llu\n",
+                        be->pid, pid_found,
+                        (unsigned long long)direct_sval.last_event,
+                        (unsigned long long)open_ns);
+                pid_lines++;
+            }
+        }
+
+        fprintf(stderr, "STATEDUMP-DIRECT: registry_pids=%d found=%d "
+                "we0_open=%d we_nonzero=%d open_zero=%d not_found=%d\n",
+                registry_pids, found, direct_we0_open, direct_we_nonzero,
+                direct_open_zero, not_found);
+    }
 }
 
 /* Read BPF accum_map (PERCPU lightweight mode) and merge into event_accum.


### PR DESCRIPTION
## Summary

This PR adds investigation-only diagnostics for the reopened fourth full-mode pure-CPU straddle failure. It does not propose or include a product fix.

Part 1 sharpens the existing `PGWT_DEBUG_DUMP_STATE` trap in `src/map_reader.c`:

- both initial and final `STATEDUMP-SCAN` lines now report `lookup_failed`, `we_nonzero`, and `open_zero` alongside the existing counters;
- the final scan line also records the actual `state_fd`, runtime `mode`, and `cpu_acct` gate;
- after normal enumeration, debug mode directly looks up every live PID in the daemon's authoritative `d->backends` registry, prints a bounded per-PID sample, and emits one `STATEDUMP-DIRECT` summary.

The enumeration/direct comparison makes the next strike decisive:

| Enumeration | Direct registry lookup | Conclusion |
| --- | --- | --- |
| no live `we==0` entries | `found>0 we0_open>0` | S2 proven: enumeration missed entries that were present in `state_map` |
| empty/no live entries | empty/no live entries | `state_map` was genuinely empty at tick time; investigate the narrower population/lifetime path |
| live `we==0` entries | live `we==0` entries, but no `STATEDUMP-TICK` | scan data exists; fault is in the print/CPU-accounting path |

Part 2 adds the isolated `mode4-hunt` job and its small driver. The job runs only for `workflow_dispatch`, never on push or pull request, and no existing job depends on it. It mirrors the capture-smoke PostgreSQL/PGDG and tracer/server build setup, runs on `ubuntu-latest`, adds two background CPU burners, and repeats `phase_pure_cpu_straddle(pm, 'full')`. On the first qualifying live-CPU miss with a positive `/proc` CPU delta, it saves and prints the complete tracer stderr and fails. Both strike/miss logs and a short summary are always uploaded.

## Run the hunt

Open **Actions → CI → Run workflow**, select this branch, then set:

- `iterations` (default `80`)
- `pg` (default `17`)

A clean miss succeeds with `not reproduced in N`. A strike fails intentionally and uploads `mode4-strike.log` plus `mode4-hunt-summary.txt`.

## Product impact

This is investigation instrumentation plus a manual hunt job, not a product fix. Runtime diagnostics and direct lookups are gated by `PGWT_DEBUG_DUMP_STATE`; when the variable is unset, there is no new output and normal product behavior is unchanged. The three fixed modes (#52/#56/#63) and all existing tests are untouched.

## Validation

- `make BPFTOOL=/tmp/bpftool/src/bpftool`
- `make -C tests check` — all C unit tests passed
- workflow YAML syntax parsed successfully
- hunt driver import/CLI smoke passed
- unset-env smoke emitted no `STATEDUMP-SCAN` or `STATEDUMP-DIRECT` output
- staged diff audit found no unconditional new map-reader diagnostic output
