### PR TITLE
Instrument mode 4 main-loop liveness and stall durations

### DIFF
--- a/src/backend.c
+++ b/src/backend.c
@@ -83,10 +83,15 @@ static uint64_t now_ns(void)
  * if the backend has not set MyProc / the pointer yet. */
 uint64_t pgwt_resolve_backend_wait_addr(struct pgwt_daemon *d, pid_t pid)
 {
+    uint64_t started_ns = pgwt_debug_block_begin(d);
+    uint64_t addr;
     if (d->use_myproc)
-        return pgwt_resolve_wait_addr_via_myproc(pid, d->my_wait_ptr_addr,
+        addr = pgwt_resolve_wait_addr_via_myproc(pid, d->my_wait_ptr_addr,
                                                  d->pgproc_wait_offset);
-    return pgwt_read_pointer(pid, d->my_wait_ptr_addr);
+    else
+        addr = pgwt_read_pointer(pid, d->my_wait_ptr_addr);
+    pgwt_debug_block_end(d, "backend_wait_addr_resolve", pid, started_ns);
+    return addr;
 }
 
 /* Loud, once-only report that the BPF state_map is full (CAP-1). Every
@@ -291,7 +296,11 @@ int pgwt_attach_backend_watchpoint(struct pgwt_daemon *d,
      * an unseeded (or stale, on re-escalation) state entry and the opening
      * interval was mis-timed. */
     int wp_prog_fd = bpf_program__fd(d->skel->progs.on_watchpoint);
+    uint64_t started_ns = pgwt_debug_block_begin(d);
     be->wp_fd = pgwt_open_watchpoint_disabled(be->pid, be->wp_addr, wp_prog_fd);
+    pgwt_debug_block_end(d, be->wp_fd < 0 ? "watchpoint_open_failed"
+                                          : "watchpoint_open",
+                         be->pid, started_ns);
     if (be->wp_fd < 0) {
         /* Process likely exited before attach — caller decides on cleanup. */
         d->counters.wp_attach_failures_total++;
@@ -300,10 +309,19 @@ int pgwt_attach_backend_watchpoint(struct pgwt_daemon *d,
 
     if (be->attach_ts == 0)
         be->attach_ts = now_ns();
+    started_ns = pgwt_debug_block_begin(d);
     preseed_state_map(d, be->pid, be->wp_addr, be->attach_ts, false);
+    pgwt_debug_block_end(d, "watchpoint_preseed", be->pid, started_ns);
 
-    if (pgwt_watchpoint_enable(be->wp_fd) != 0) {
+    started_ns = pgwt_debug_block_begin(d);
+    int enable_rc = pgwt_watchpoint_enable(be->wp_fd);
+    pgwt_debug_block_end(d, enable_rc != 0 ? "watchpoint_enable_failed"
+                                           : "watchpoint_enable",
+                         be->pid, started_ns);
+    if (enable_rc != 0) {
+        started_ns = pgwt_debug_block_begin(d);
         pgwt_close_watchpoint(be->wp_fd);
+        pgwt_debug_block_end(d, "watchpoint_close", be->pid, started_ns);
         be->wp_fd = -1;
         d->counters.wp_attach_failures_total++;
         return -1;
@@ -407,7 +425,10 @@ int pgwt_scan_existing_backends(struct pgwt_daemon *d)
          *                         whole scan proves nothing,
          *                         pgwt_confirm_wait_offset() re-polls. */
         if (!d->wait_offset_validated) {
+            uint64_t started_ns = pgwt_debug_block_begin(d);
             int v = pgwt_validate_wait_addr(pid, ptr);
+            pgwt_debug_block_end(d, "backend_wait_addr_validate", pid,
+                                 started_ns);
             if (v == PGWT_WEI_GARBAGE) {
                 fprintf(stderr,
                         "FATAL: resolved wait_event_info for PID %d holds a value "
@@ -477,10 +498,16 @@ int pgwt_scan_existing_backends(struct pgwt_daemon *d)
             continue;
         }
 
-        if (pgwt_parse_cmdline(pid, &be->meta) == 0)
+        uint64_t started_ns = pgwt_debug_block_begin(d);
+        int cmdline_rc = pgwt_parse_cmdline(pid, &be->meta);
+        pgwt_debug_block_end(d, "backend_cmdline_read", pid, started_ns);
+        if (cmdline_rc == 0)
             be->meta_parsed = true;
-        if (d->backend_meta)
+        if (d->backend_meta) {
+            started_ns = pgwt_debug_block_begin(d);
             pgwt_bm_write(d->backend_meta, pid, &be->meta);
+            pgwt_debug_block_end(d, "backend_meta_write", pid, started_ns);
+        }
 
         if (d->verbose)
             fprintf(stderr, "INFO: attached to PID %d (%s), watchpoint at 0x%lx\n",
@@ -559,7 +586,10 @@ int pgwt_recover_unattached_backends(struct pgwt_daemon *d)
          * level-triggered version of handle_fork's direct-attach fast path. A
          * still-initializing backend (local dummy) is left to bootstrap. */
         uint64_t ptr = pgwt_resolve_backend_wait_addr(d, pid);
-        if (ptr != 0 && pgwt_addr_is_shared(pid, ptr) == 1) {
+        uint64_t started_ns = pgwt_debug_block_begin(d);
+        int addr_shared = ptr != 0 ? pgwt_addr_is_shared(pid, ptr) : 0;
+        pgwt_debug_block_end(d, "backend_addr_shared", pid, started_ns);
+        if (ptr != 0 && addr_shared == 1) {
             if (pgwt_handle_init(d, pid, ptr) == 0) {
                 recovered++;
                 if (d->verbose)
@@ -807,8 +837,14 @@ int pgwt_handle_fork(struct pgwt_daemon *d, pid_t child_pid)
 
     /* Attach bootstrap watchpoint on my_wait_event_info pointer address */
     int bootstrap_prog_fd = bpf_program__fd(d->skel->progs.on_bootstrap);
+    uint64_t started_ns = pgwt_debug_block_begin(d);
     be->bootstrap_fd = pgwt_open_watchpoint(child_pid, d->my_wait_ptr_addr,
                                              bootstrap_prog_fd);
+    pgwt_debug_block_end(d,
+                         be->bootstrap_fd < 0
+                             ? "bootstrap_watchpoint_open_failed"
+                             : "bootstrap_watchpoint_open",
+                         child_pid, started_ns);
     if (be->bootstrap_fd < 0) {
         /* Race: child may have already exited or initialized.
          * Try direct init path (version-aware address resolution). */
@@ -843,7 +879,10 @@ int pgwt_handle_fork(struct pgwt_daemon *d, pid_t child_pid)
      * watchpoint will catch that write. (PG<17: MyProc starts NULL, and a
      * non-NULL PGPROC is in shm, so the same predicate holds.) */
     uint64_t ptr = pgwt_resolve_backend_wait_addr(d, child_pid);
-    if (ptr != 0 && pgwt_addr_is_shared(child_pid, ptr) == 1) {
+    started_ns = pgwt_debug_block_begin(d);
+    int addr_shared = ptr != 0 ? pgwt_addr_is_shared(child_pid, ptr) : 0;
+    pgwt_debug_block_end(d, "backend_addr_shared", child_pid, started_ns);
+    if (ptr != 0 && addr_shared == 1) {
         if (d->verbose)
             fprintf(stderr, "INFO: fork PID %d already initialized "
                     "(fork->attach race) — attaching directly\n", child_pid);
@@ -867,13 +906,17 @@ int pgwt_handle_init(struct pgwt_daemon *d, pid_t pid, uint64_t addr)
 
     /* Close bootstrap watchpoint if any */
     if (be->bootstrap_fd >= 0) {
+        uint64_t started_ns = pgwt_debug_block_begin(d);
         pgwt_close_watchpoint(be->bootstrap_fd);
+        pgwt_debug_block_end(d, "bootstrap_watchpoint_close", pid, started_ns);
         be->bootstrap_fd = -1;
     }
 
     /* Close previous watchpoint if re-initializing */
     if (be->wp_fd >= 0) {
+        uint64_t started_ns = pgwt_debug_block_begin(d);
         pgwt_close_watchpoint(be->wp_fd);
+        pgwt_debug_block_end(d, "watchpoint_close", pid, started_ns);
         be->wp_fd = -1;
     }
 
@@ -883,7 +926,9 @@ int pgwt_handle_init(struct pgwt_daemon *d, pid_t pid, uint64_t addr)
      * the offset/address is wrong — refuse rather than trace nonsense; a
      * zero reading is NOT proof (keep validating on later backends). */
     if (!d->wait_offset_validated) {
+        uint64_t started_ns = pgwt_debug_block_begin(d);
         int v = pgwt_validate_wait_addr(pid, addr);
+        pgwt_debug_block_end(d, "backend_wait_addr_validate", pid, started_ns);
         if (v == PGWT_WEI_GARBAGE) {
             fprintf(stderr,
                     "FATAL: resolved wait_event_info for PID %d holds a value "
@@ -915,10 +960,16 @@ int pgwt_handle_init(struct pgwt_daemon *d, pid_t pid, uint64_t addr)
         return -1;
     }
 
-    if (pgwt_parse_cmdline(pid, &be->meta) == 0)
+    uint64_t started_ns = pgwt_debug_block_begin(d);
+    int cmdline_rc = pgwt_parse_cmdline(pid, &be->meta);
+    pgwt_debug_block_end(d, "backend_cmdline_read", pid, started_ns);
+    if (cmdline_rc == 0)
         be->meta_parsed = true;
-    if (d->backend_meta)
+    if (d->backend_meta) {
+        started_ns = pgwt_debug_block_begin(d);
         pgwt_bm_write(d->backend_meta, pid, &be->meta);
+        pgwt_debug_block_end(d, "backend_meta_write", pid, started_ns);
+    }
 
     if (d->verbose)
         fprintf(stderr, "INFO: PID %d initialized (%s), real watchpoint at 0x%lx\n",
@@ -933,15 +984,19 @@ int pgwt_handle_exit(struct pgwt_daemon *d, pid_t pid)
     if (!be) return 0;
 
     /* Close watchpoint fds */
+    uint64_t started_ns = pgwt_debug_block_begin(d);
     pgwt_close_watchpoint(be->wp_fd);
     be->wp_fd = -1;
     pgwt_close_watchpoint(be->bootstrap_fd);
     be->bootstrap_fd = -1;
+    pgwt_debug_block_end(d, "watchpoint_close", pid, started_ns);
 
     /* Delete BPF map entries for this PID */
     int state_fd = bpf_map__fd(d->skel->maps.state_map);
     uint32_t key = pid;
+    started_ns = pgwt_debug_block_begin(d);
     bpf_map_delete_elem(state_fd, &key);
+    pgwt_debug_block_end(d, "backend_state_delete", pid, started_ns);
 
     be->is_alive = false;
 

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -27,6 +27,23 @@
 #include <bpf/bpf.h>
 #include "pg_wait_tracer.skel.h"
 
+#define PGWT_DEBUG_BLOCK_NS (50ULL * 1000ULL * 1000ULL)
+
+uint64_t pgwt_debug_monotonic_ns(void)
+{
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return (uint64_t)ts.tv_sec * 1000000000ULL + ts.tv_nsec;
+}
+
+void pgwt_debug_block_report(const char *op, pid_t pid, uint64_t started_ns)
+{
+    uint64_t ended_ns = pgwt_debug_monotonic_ns();
+    if (ended_ns >= started_ns && ended_ns - started_ns > PGWT_DEBUG_BLOCK_NS)
+        fprintf(stderr, "STATEDUMP-BLOCK: op=%s pid=%d dur_ms=%.3f\n",
+                op, pid, (double)(ended_ns - started_ns) / 1e6);
+}
+
 /* Ring buffer callback for lifecycle events */
 static int handle_lifecycle_event(void *ctx, void *data, size_t data_sz)
 {
@@ -37,17 +54,23 @@ static int handle_lifecycle_event(void *ctx, void *data, size_t data_sz)
 
     d->counters.lifecycle_events_total++;
 
+    const char *op = "lifecycle_unknown";
+    uint64_t started_ns = pgwt_debug_block_begin(d);
     switch (ev->type) {
     case PGWT_LIFECYCLE_FORK:
+        op = "lifecycle_fork";
         pgwt_handle_fork(d, ev->pid);
         break;
     case PGWT_LIFECYCLE_INIT:
+        op = "lifecycle_init";
         pgwt_handle_init(d, ev->pid, ev->addr);
         break;
     case PGWT_LIFECYCLE_EXIT:
+        op = "lifecycle_exit";
         pgwt_handle_exit(d, ev->pid);
         break;
     case PGWT_LIFECYCLE_QUERY_TEXT: {
+        op = "lifecycle_query_text";
         /* Query text captured by BPF from debug_query_string */
         struct pgwt_query_text_event *qte = data;
         if (d->query_text_capture && qte->query_id != 0) {
@@ -57,18 +80,32 @@ static int handle_lifecycle_event(void *ctx, void *data, size_t data_sz)
         break;
     }
     }
+    pgwt_debug_block_end(d, op, ev->pid, started_ns);
     return 0;
 }
 
 static void handle_timer(struct pgwt_daemon *d)
 {
+    if (d->debug_dump_state)
+        d->debug_timer_entries++;
+
     uint64_t expirations;
+    uint64_t started_ns = pgwt_debug_block_begin(d);
     ssize_t r = read(d->timer_fd, &expirations, sizeof(expirations));
-    (void)r;
+    pgwt_debug_block_end(d, "timerfd_read", 0, started_ns);
+    if (d->debug_dump_state && r == (ssize_t)sizeof(expirations)) {
+        d->debug_timer_expirations += expirations;
+        if (expirations > d->debug_max_timer_expirations)
+            d->debug_max_timer_expirations = expirations;
+    }
 
     /* Health check: is PostgreSQL still alive? */
     if (d->daemon_mode) {
-        if (kill(d->postmaster_pid, 0) != 0) {
+        started_ns = pgwt_debug_block_begin(d);
+        int pg_alive_rc = kill(d->postmaster_pid, 0);
+        pgwt_debug_block_end(d, "postmaster_health_check",
+                             d->postmaster_pid, started_ns);
+        if (pg_alive_rc != 0) {
             fprintf(stderr, "\npg_wait_tracer: PostgreSQL (PID %d) stopped\n",
                     d->postmaster_pid);
             d->exit_reason = PGWT_EXIT_PG_DEAD;
@@ -77,14 +114,27 @@ static void handle_timer(struct pgwt_daemon *d)
         }
     }
 
+    /* Print at the first non-PG-death point in the handler. In particular,
+     * this is before recovery/sweep and every live-map read: a TIMER line with
+     * no later SCAN line means the handler entered and stalled in that prefix;
+     * no TIMER line means dispatch never reached the handler. */
+    bool mode_uses_wp = pgwt_mode_uses_watchpoints(d);
+    if (d->debug_dump_state)
+        fprintf(stderr, "STATEDUMP-TIMER: tick=%d mode_uses_wp=%d "
+                "lightweight=%d\n",
+                d->tick, (int)mode_uses_wp, (int)d->lightweight_mode);
+
     /* Straddle-race recovery: re-attach any pre-existing backend the one-shot
      * startup scan missed or left in bootstrap limbo (a transient resolve race,
      * fatal for a waitless pure-CPU command whose bootstrap watchpoint never
      * fires). Level-triggered and idempotent — runs before the state_map read
      * so a recovery this tick is reflected in this tick's view. Full/tiered
      * only (no-op in sampled/lightweight, which resolve lazily). */
-    if (!d->lightweight_mode && !getenv("PGWT_TEST_NO_RECOVERY"))
+    if (!d->lightweight_mode && !getenv("PGWT_TEST_NO_RECOVERY")) {
+        started_ns = pgwt_debug_block_begin(d);
         pgwt_recover_unattached_backends(d);
+        pgwt_debug_block_end(d, "backend_recovery_scan", 0, started_ns);
+    }
 
     /* Stale-seed sweep — the ATTACHED-backend sibling of the recovery above
      * (the seed→arm race, docs/ROADMAP_AND_STATUS.md): reseed any state_map
@@ -99,16 +149,24 @@ static void handle_timer(struct pgwt_daemon *d)
      * in the startup settle: the seed is by definition fresher than the 1s
      * frozen gate there, so the first timer tick is the earliest a stale
      * entry is distinguishable from a fresh one. */
-    if (!d->lightweight_mode && !getenv("PGWT_TEST_NO_STALE_SWEEP"))
+    if (!d->lightweight_mode && !getenv("PGWT_TEST_NO_STALE_SWEEP")) {
+        started_ns = pgwt_debug_block_begin(d);
         pgwt_sweep_stale_state(d);
+        pgwt_debug_block_end(d, "stale_state_sweep", 0, started_ns);
+    }
 
     /* ESC-1: enforce the escalation budget mid-window (cheap no-op unless a
      * budget-limited window is open and has reached its cap). */
+    started_ns = pgwt_debug_block_begin(d);
     pgwt_escalation_check_budget(d);
+    pgwt_debug_block_end(d, "escalation_budget_check", 0, started_ns);
 
     /* In lightweight mode, read BPF accum_map into event_accum first */
-    if (d->lightweight_mode)
+    if (d->lightweight_mode) {
+        started_ns = pgwt_debug_block_begin(d);
         pgwt_read_accum_map(d);
+        pgwt_debug_block_end(d, "accum_map_read", 0, started_ns);
+    }
 
     /* Copy cumulative event_accum to display accum,
      * then add open intervals from state_map.
@@ -117,23 +175,24 @@ static void handle_timer(struct pgwt_daemon *d)
      * open intervals — skip it. The live display for sampled mode is not
      * fidelity-aware until A3; recorded SAMPLES blocks carry the real data. */
     struct pgwt_time_model saved_tm = d->accum.tm;
+    started_ns = pgwt_debug_block_begin(d);
     pgwt_accum_copy_used(&d->accum, d->event_accum);
+    pgwt_debug_block_end(d, "accumulator_copy", 0, started_ns);
     d->accum.prev_tm = saved_tm;
-    bool mode_uses_wp = pgwt_mode_uses_watchpoints(d);
-    static int dbg_timer = -1;
-    if (dbg_timer < 0)
-        dbg_timer = getenv("PGWT_DEBUG_DUMP_STATE") != NULL;
-    if (dbg_timer)
-        fprintf(stderr, "STATEDUMP-TIMER: tick=%d mode_uses_wp=%d "
-                "lightweight=%d\n",
-                d->tick, (int)mode_uses_wp, (int)d->lightweight_mode);
-    if (mode_uses_wp)
+    if (mode_uses_wp) {
+        started_ns = pgwt_debug_block_begin(d);
         pgwt_read_state_map(d);
+        pgwt_debug_block_end(d, "state_map_read", 0, started_ns);
+    }
 
-    if (d->ring.slots)
+    if (d->ring.slots) {
+        started_ns = pgwt_debug_block_begin(d);
         pgwt_ring_push(&d->ring, &d->accum);
+        pgwt_debug_block_end(d, "snapshot_ring_push", 0, started_ns);
+    }
 
     if (!d->quiet) {
+        started_ns = pgwt_debug_block_begin(d);
         switch (d->view) {
         case PGWT_VIEW_TIME_MODEL:
             pgwt_print_time_model(d);
@@ -155,12 +214,14 @@ static void handle_timer(struct pgwt_daemon *d)
             break;
         }
         fflush(stdout);
+        pgwt_debug_block_end(d, "view_output", 0, started_ns);
     }
 
     /* GC: sweep backend table every 60s for dead processes.
      * Handles PIDs that exited without triggering on_exit tracepoint
      * (e.g., SIGKILL, or race condition during high churn). */
     if (d->tick > 0 && d->tick % 60 == 0) {
+        started_ns = pgwt_debug_block_begin(d);
         for (int i = 0; i < d->backends.count; i++) {
             struct pgwt_backend *be = &d->backends.entries[i];
             if (be->is_alive && be->pid > 0 && kill(be->pid, 0) != 0) {
@@ -170,26 +231,34 @@ static void handle_timer(struct pgwt_daemon *d)
                 pgwt_handle_exit(d, be->pid);
             }
         }
+        pgwt_debug_block_end(d, "backend_gc", 0, started_ns);
     }
 
     /* Trace file: check hourly rotation, periodic cleanup */
     if (d->event_writer) {
+        started_ns = pgwt_debug_block_begin(d);
         pgwt_writer_check_rotation(d->event_writer);
         if (d->tick > 0 && d->tick % 60 == 0)
             pgwt_writer_cleanup_old_files(d->event_writer);
+        pgwt_debug_block_end(d, "event_writer_maintenance", 0, started_ns);
     }
     if (d->summary_writer) {
+        started_ns = pgwt_debug_block_begin(d);
         pgwt_summary_flush(d->summary_writer);
         pgwt_summary_check_rotation(d->summary_writer);
         if (d->tick > 0 && d->tick % 60 == 0)
             pgwt_summary_cleanup_old_files(d->summary_writer);
+        pgwt_debug_block_end(d, "summary_writer_maintenance", 0, started_ns);
     }
 
     /* CAP-6: the BPF seen_query_ids dedup map (4096 entries) never ages;
      * once full, query TEXT for new query_ids is silently never captured
      * again. Log it once; seen_query_ids_full_total keeps counting. */
-    if (!d->seen_qids_full_logged
-        && pgwt_read_bpf_fail_counter(d, PGWT_BPF_FAIL_SEEN_QIDS) > 0) {
+    started_ns = pgwt_debug_block_begin(d);
+    uint64_t seen_qids_failures = d->seen_qids_full_logged ? 0
+        : pgwt_read_bpf_fail_counter(d, PGWT_BPF_FAIL_SEEN_QIDS);
+    pgwt_debug_block_end(d, "bpf_fail_counter_read", 0, started_ns);
+    if (!d->seen_qids_full_logged && seen_qids_failures > 0) {
         d->seen_qids_full_logged = true;
         fprintf(stderr,
                 "WARN: BPF seen_query_ids map is FULL (4096 unique query_ids)"
@@ -250,7 +319,9 @@ static void arm_sample_timer_jittered(struct pgwt_daemon *d)
 static void handle_sample_timer(struct pgwt_daemon *d)
 {
     uint64_t expirations = 0;
+    uint64_t started_ns = pgwt_debug_block_begin(d);
     ssize_t r = read(d->sample_timer_fd, &expirations, sizeof(expirations));
+    pgwt_debug_block_end(d, "sample_timerfd_read", 0, started_ns);
     /* SMP-3: expirations > 1 means the daemon stalled and ticks coalesced —
      * those samples are gone. The sampler compensates by weighting each tick
      * with the MEASURED inter-tick elapsed time (see pgwt_sampler_poll), so
@@ -261,9 +332,14 @@ static void handle_sample_timer(struct pgwt_daemon *d)
         d->counters.sampler_ticks_missed_total += expirations - 1;
     /* Re-arm FIRST so a slow poll delays the next tick (measured-elapsed
      * weighting absorbs it) instead of bursting. */
+    started_ns = pgwt_debug_block_begin(d);
     arm_sample_timer_jittered(d);
-    if (d->provider && d->provider->poll)
+    pgwt_debug_block_end(d, "sample_timer_rearm", 0, started_ns);
+    if (d->provider && d->provider->poll) {
+        started_ns = pgwt_debug_block_begin(d);
         d->provider->poll(d);
+        pgwt_debug_block_end(d, "capture_provider_poll", 0, started_ns);
+    }
 }
 
 /* CAP-12: raise RLIMIT_NOFILE to what MAX_BACKENDS needs. Full/tiered mode
@@ -316,6 +392,19 @@ static void handle_signal(struct pgwt_daemon *d)
 int pgwt_daemon_init(struct pgwt_daemon *d)
 {
     int err;
+
+    /* Cache the debug env once per daemon lifecycle. All liveness clocks and
+     * duration probes key off this bool; when unset they do no syscalls and
+     * emit nothing. Reset the per-run counters for daemon-mode re-attach. */
+    d->debug_dump_state = getenv("PGWT_DEBUG_DUMP_STATE") != NULL;
+    d->debug_loop_iterations = 0;
+    d->debug_timer_entries = 0;
+    d->debug_timer_expirations = 0;
+    d->debug_max_timer_expirations = 0;
+    d->debug_last_loop_ts_ns = 0;
+    d->debug_max_loop_gap_ns = 0;
+    d->debug_timer_settime_rc = 0;
+    d->debug_timer_epoll_rc = 0;
 
     /* CAP-12: enough fds for a full-size backend registry, before anything
      * starts opening watchpoints. */
@@ -466,10 +555,10 @@ int pgwt_daemon_init(struct pgwt_daemon *d)
      * final state_map is dumped to stderr at shutdown for the reopened
      * straddle live-CPU investigation. Announced here so the hook can never
      * be active silently, same discipline as the PGWT_TEST_* hooks above. */
-    if (getenv("PGWT_DEBUG_DUMP_STATE")) {
-        fprintf(stderr, "WARN: PGWT_DEBUG_DUMP_STATE — final state_map will be "
-                "dumped to stderr at shutdown (STATEDUMP lines; DEBUG ONLY, "
-                "never set in production)\n");
+    if (d->debug_dump_state) {
+        fprintf(stderr, "WARN: PGWT_DEBUG_DUMP_STATE — state, timer, and "
+                "main-loop liveness will be dumped to stderr (STATEDUMP lines; "
+                "DEBUG ONLY, never set in production)\n");
     }
     if (!d->cpu_accounting) {
         /* No BTF → tp_btf/sched_switch can't load: don't try, and fall back
@@ -821,7 +910,9 @@ int pgwt_daemon_init(struct pgwt_daemon *d)
         .it_interval = { .tv_sec = d->interval },
         .it_value    = { .tv_sec = d->interval },
     };
-    timerfd_settime(d->timer_fd, 0, &its, NULL);
+    int timer_settime_rc = timerfd_settime(d->timer_fd, 0, &its, NULL);
+    if (d->debug_dump_state && timer_settime_rc != 0)
+        d->debug_timer_settime_rc = -errno;
 
     /* High-rate sampler timer (sampled/tiered tiers): fires at sample_rate_hz
      * independently of the per-second display interval. Armed ONE-SHOT with
@@ -875,7 +966,9 @@ int pgwt_daemon_init(struct pgwt_daemon *d)
     /* Add timer fd */
     ev.events = EPOLLIN;
     ev.data.fd = d->timer_fd;
-    epoll_ctl(d->epoll_fd, EPOLL_CTL_ADD, d->timer_fd, &ev);
+    int timer_epoll_rc = epoll_ctl(d->epoll_fd, EPOLL_CTL_ADD, d->timer_fd, &ev);
+    if (d->debug_dump_state && timer_epoll_rc != 0)
+        d->debug_timer_epoll_rc = -errno;
 
     /* Add sampler timer fd (sampled/tiered tiers) */
     if (d->sample_timer_fd >= 0) {
@@ -995,6 +1088,11 @@ int pgwt_daemon_run(struct pgwt_daemon *d)
      * eventfd_signal overhead. We poll the ringbuf at 10ms intervals. */
     int poll_ms = d->event_rb ? 10 : -1;
 
+    /* Baseline for the first completed-pass gap. Subsequent timestamps are
+     * updated exactly once at the end of each main-loop pass. */
+    if (d->debug_dump_state)
+        d->debug_last_loop_ts_ns = pgwt_debug_monotonic_ns();
+
     while (d->running) {
         int timeout_ms = poll_ms;
         if (deadline > 0) {
@@ -1006,41 +1104,85 @@ int pgwt_daemon_run(struct pgwt_daemon *d)
                 timeout_ms = remaining;
         }
 
+        uint64_t started_ns = pgwt_debug_block_begin(d);
         int n = epoll_wait(d->epoll_fd, events, 8, timeout_ms);
+        pgwt_debug_block_end(d, "epoll_wait", 0, started_ns);
         if (n < 0) {
-            if (errno == EINTR) continue;
+            if (errno == EINTR) {
+                if (d->debug_dump_state) {
+                    uint64_t now = pgwt_debug_monotonic_ns();
+                    uint64_t gap = now - d->debug_last_loop_ts_ns;
+                    if (gap > d->debug_max_loop_gap_ns)
+                        d->debug_max_loop_gap_ns = gap;
+                    d->debug_last_loop_ts_ns = now;
+                    d->debug_loop_iterations++;
+                }
+                continue;
+            }
             perror("epoll_wait");
             break;
         }
 
         for (int i = 0; i < n; i++) {
             if (events[i].data.fd == d->timer_fd) {
+                started_ns = pgwt_debug_block_begin(d);
                 handle_timer(d);
+                pgwt_debug_block_end(d, "timer_handler", 0, started_ns);
             } else if (d->sample_timer_fd >= 0
                        && events[i].data.fd == d->sample_timer_fd) {
+                started_ns = pgwt_debug_block_begin(d);
                 handle_sample_timer(d);
+                pgwt_debug_block_end(d, "sample_timer_handler", 0, started_ns);
             } else if (events[i].data.fd == rb_fd) {
+                started_ns = pgwt_debug_block_begin(d);
                 ring_buffer__consume(d->rb);
+                pgwt_debug_block_end(d, "lifecycle_ring_consume", 0, started_ns);
             } else if (events[i].data.fd == event_rb_fd) {
+                started_ns = pgwt_debug_block_begin(d);
                 ring_buffer__consume(d->event_rb);
+                pgwt_debug_block_end(d, "event_ring_consume", 0, started_ns);
             } else if (events[i].data.fd == d->signal_fd) {
+                started_ns = pgwt_debug_block_begin(d);
                 handle_signal(d);
+                pgwt_debug_block_end(d, "signal_handler", 0, started_ns);
             } else if (pgwt_escalation_is_timer_fd(d, events[i].data.fd)) {
+                started_ns = pgwt_debug_block_begin(d);
                 pgwt_escalation_on_timer(d);
+                pgwt_debug_block_end(d, "escalation_timer_handler", 0,
+                                     started_ns);
             } else if (d->control) {
+                started_ns = pgwt_debug_block_begin(d);
                 pgwt_control_handle_fd(d->control, events[i].data.fd);
+                pgwt_debug_block_end(d, "control_handler", 0, started_ns);
             }
         }
 
         /* Drain event ringbuf on every iteration (poll-based with NO_WAKEUP) */
-        if (d->event_rb)
+        if (d->event_rb) {
+            started_ns = pgwt_debug_block_begin(d);
             ring_buffer__consume(d->event_rb);
+            pgwt_debug_block_end(d, "event_ring_drain", 0, started_ns);
+        }
+
+        if (d->debug_dump_state) {
+            uint64_t now = pgwt_debug_monotonic_ns();
+            uint64_t gap = now - d->debug_last_loop_ts_ns;
+            if (gap > d->debug_max_loop_gap_ns)
+                d->debug_max_loop_gap_ns = gap;
+            d->debug_last_loop_ts_ns = now;
+            d->debug_loop_iterations++;
+        }
     }
 
     /* Drain remaining events before cleanup */
-    if (d->event_rb)
+    if (d->event_rb) {
+        uint64_t started_ns = pgwt_debug_block_begin(d);
         ring_buffer__consume(d->event_rb);
+        pgwt_debug_block_end(d, "event_ring_final_drain", 0, started_ns);
+    }
+    uint64_t started_ns = pgwt_debug_block_begin(d);
     ring_buffer__consume(d->rb);
+    pgwt_debug_block_end(d, "lifecycle_ring_final_drain", 0, started_ns);
 
     if (d->exit_reason != PGWT_EXIT_PG_DEAD)
         fprintf(stderr, "\npg_wait_tracer: shutting down\n");
@@ -1060,12 +1202,13 @@ int pgwt_daemon_run(struct pgwt_daemon *d)
  * (control.c names) that discriminate between the known modes. Capped at
  * PGWT_STATEDUMP_MAX entries: the flaky phase tracks a handful of backends,
  * and a capped dump on a big map says so loudly instead of flooding.
- * Zero cost when the env is unset (one getenv per shutdown). */
+ * With the env unset, the cached gate skips the clock reads and emits no
+ * diagnostic output. */
 #define PGWT_STATEDUMP_MAX 64
 
 static void pgwt_debug_dump_state_map(struct pgwt_daemon *d)
 {
-    if (!getenv("PGWT_DEBUG_DUMP_STATE") || !d->skel)
+    if (!d->debug_dump_state || !d->skel)
         return;
     int state_fd = bpf_map__fd(d->skel->maps.state_map);
     if (state_fd < 0)
@@ -1082,14 +1225,30 @@ static void pgwt_debug_dump_state_map(struct pgwt_daemon *d)
         if (d->backends.entries[i].is_alive)
             backends_tracked++;
 
+    double last_loop_age_ms = d->debug_last_loop_ts_ns
+        ? ((double)now - (double)d->debug_last_loop_ts_ns) / 1e6 : -1.0;
+
     /* META first so a truncated/partial log still carries the counters. */
     fprintf(stderr,
             "STATEDUMP-META: cpu_accounting=%d backends_tracked=%d "
+            "loop_iterations=%llu timer_ticks=%llu completed_ticks=%d "
+            "timer_expirations=%llu max_timer_expirations=%llu "
+            "max_loop_gap_ms=%.3f last_loop_age_ms=%.3f "
+            "timer_settime_rc=%d timer_epoll_rc=%d "
             "state_reseeds_total=%llu invalid_wait_reads_total=%llu "
             "wp_attach_failures_total=%llu state_map_full_total=%llu "
             "cpu_ns_total=%llu offcpu_ns_total=%llu "
             "cpu_clamped_ns_total=%llu wait_gap_cpu_ns_total=%llu\n",
             d->cpu_accounting ? 1 : 0, backends_tracked,
+            (unsigned long long)d->debug_loop_iterations,
+            (unsigned long long)d->debug_timer_entries,
+            d->tick,
+            (unsigned long long)d->debug_timer_expirations,
+            (unsigned long long)d->debug_max_timer_expirations,
+            (double)d->debug_max_loop_gap_ns / 1e6,
+            last_loop_age_ms,
+            d->debug_timer_settime_rc,
+            d->debug_timer_epoll_rc,
             (unsigned long long)d->counters.state_reseeds_total,
             (unsigned long long)d->counters.invalid_wait_reads_total,
             (unsigned long long)d->counters.wp_attach_failures_total,

--- a/src/daemon.h
+++ b/src/daemon.h
@@ -241,9 +241,45 @@ struct pgwt_daemon {
     volatile bool running;
     uint64_t start_ts;
 
+    /* PGWT_DEBUG_DUMP_STATE main-loop liveness probe. These fields are read
+     * and updated only when the debug env is set; production takes no clocks
+     * and emits no diagnostics. debug_timer_entries is deliberately separate
+     * from tick: tick advances only after handle_timer completes, so it cannot
+     * tell "never entered" from "entered and stalled before completion". */
+    bool        debug_dump_state;
+    uint64_t    debug_loop_iterations;
+    uint64_t    debug_timer_entries;
+    uint64_t    debug_timer_expirations;
+    uint64_t    debug_max_timer_expirations;
+    uint64_t    debug_last_loop_ts_ns;
+    uint64_t    debug_max_loop_gap_ns;
+    int         debug_timer_settime_rc;   /* 0 or saved -errno */
+    int         debug_timer_epoll_rc;     /* 0 or saved -errno */
+
     /* Placed at end of struct to survive field overflow corruption */
     char       *pg_binary_saved;        /* heap-allocated postgres binary path for USDT */
 };
+
+/* PGWT_DEBUG_DUMP_STATE duration probe shared by the daemon loop and the
+ * synchronous backend/watchpoint paths it dispatches. The env-off case is
+ * inline: no helper call and, critically, no clock syscall. Durations above
+ * 50ms emit one STATEDUMP-BLOCK line. */
+uint64_t pgwt_debug_monotonic_ns(void);
+void pgwt_debug_block_report(const char *op, pid_t pid, uint64_t started_ns);
+
+static inline uint64_t pgwt_debug_block_begin(const struct pgwt_daemon *d)
+{
+    return d->debug_dump_state ? pgwt_debug_monotonic_ns() : 0;
+}
+
+static inline void pgwt_debug_block_end(const struct pgwt_daemon *d,
+                                        const char *op, pid_t pid,
+                                        uint64_t started_ns)
+{
+    (void)d;
+    if (started_ns)
+        pgwt_debug_block_report(op, pid, started_ns);
+}
 
 /* True when watchpoints should be attached RIGHT NOW.
  *   FULL    — always (the original watchpoint behavior).


### PR DESCRIPTION
## Scope

This is a diagnostic-only probe for the FOURTH straddle live-CPU mode. It does not change tracing, recovery, timer, or watchpoint behavior, and it does not add a test hook or root-cause fix.

All new timing/counter/output work is gated by the existing `PGWT_DEBUG_DUMP_STATE` flag. With the flag unset there are no new clock reads or diagnostic writes. No BPF source, existing test, or fixed-mode implementation (#52/#56/#63) is changed.

## What the next strike records

- A completed-main-loop-pass counter, last-pass timestamp, and maximum completion-to-completion gap.
- Separate timer-handler entry and completion counts. `d->tick` advances only at the end of `handle_timer`, so `timer_ticks` now records entries while `completed_ticks` preserves the existing counter.
- Timerfd expiration totals/max coalescing and saved `timerfd_settime` / timer `epoll_ctl` errors.
- `STATEDUMP-TIMER` at the first non-PostgreSQL-death point in `handle_timer`, before recovery, sweeping, and map reads.
- `STATEDUMP-BLOCK` for operations exceeding 50 ms, including epoll wait/dispatch, ring consumption, lifecycle callbacks, backend recovery, proc reads, watchpoint open/preseed/enable/close, map reads, output/writer maintenance, control/escalation, and sampler work.
- Shutdown `STATEDUMP-META` fields:
  `loop_iterations`, `timer_ticks`, `completed_ticks`,
  `timer_expirations`, `max_timer_expirations`,
  `max_loop_gap_ms`, `last_loop_age_ms`,
  `timer_settime_rc`, and `timer_epoll_rc`.

Key implementation points are `src/daemon.c:87-293`, `src/daemon.c:903-971`,
`src/daemon.c:1074-1185`, `src/daemon.c:1228-1259`, and
`src/backend.c:84-94,288-329,545-602,818-978`.

## Static trace and ranked mechanism diagnosis

1. **Synchronous watchpoint install/enable remains the leading hypothesis, but is not pinned.** A lifecycle ring callback runs inline on the main-loop thread (`src/daemon.c:48-84,1136-1139`). FORK/INIT then reaches `pgwt_handle_fork` / `pgwt_handle_init`, which synchronously calls `pgwt_open_watchpoint*`, preseed, and `PERF_EVENT_IOC_ENABLE` (`src/backend.c:288-329,818-978`; `src/perf_event.c:13-94`). The open path includes `perf_event_open` and `PERF_EVENT_IOC_SET_BPF`; bootstrap open also enables immediately. Current Linux perf installation and enable paths use synchronous task-context calls and retry around task migration/context races ([task_function_call](https://github.com/torvalds/linux/blob/master/kernel/events/core.c#L94-L128), [perf_install_in_context](https://github.com/torvalds/linux/blob/master/kernel/events/core.c#L2927-L3032), [_perf_event_enable](https://github.com/torvalds/linux/blob/master/kernel/events/core.c#L3080-L3108)). It is therefore plausible—not proven—that a target migration/exit race plus two-CPU starvation stretches one operation to seconds. The captured `wp_attach_failures_total=1` is correlation only; a failed attach can also return quickly.

2. **Daemon scheduling starvation or an overlong epoll wait.** The full-mode loop calls `epoll_wait` synchronously; when the event ring exists it uses a 10 ms timeout (`src/daemon.c:1087-1109`). A two-hog/two-vCPU run can delay the daemon after wakeup. The main display timer is statically periodic, not one-shot: both `it_value` and `it_interval` are set to `d->interval` (`src/daemon.c:903-915`). Only the separate sampler timer is one-shot (`src/daemon.c:917-927`). Thus “main timer failed to re-arm” is refuted.

3. **Synchronous ring backlog/callback work.** Both lifecycle and event ring consumers run inline, including the unconditional event drain (`src/daemon.c:1126-1164`). A lifecycle callback may perform the entire attach path; event/query callbacks may synchronously append to trace, summary, or query-text storage. A sufficiently large backlog or slow filesystem can delay the next timer dispatch.

4. **Timer-prefix recovery/sweep or other timer-body work.** Before the old TIMER print, `handle_timer` synchronously scanned `/proc` for unattached children and could enter INIT/attach (`src/daemon.c:127-155`; `src/backend.c:545-602`). The scan is unbounded in host process count. The stale sweep is registry-bounded but can execute a 2 ms settle sleep per candidate. Downstream map iteration/BPF syscalls, live schedstat reads, stdout flush, writer rotation/flush/cleanup, and backend GC are also synchronous (`src/daemon.c:158-293`). The moved early TIMER line plus nested block names now distinguishes this from “handler never entered.”

5. **Timer wiring/delivery failure.** `timer_settime_rc` or `timer_epoll_rc` will identify setup failure without changing the existing error behavior. If both remain zero, loop iterations remain healthy, and timer entries remain zero, the residue is timerfd/epoll delivery rather than a loop stall.

6. **Runtime ELF symbol resolution / exec handling is not a candidate.** There is no exec lifecycle event: BPF emits FORK, bootstrap INIT, and EXIT (`src/bpf/pg_wait_tracer.bpf.c:445-501`). Runtime “address resolution” is synchronous `/proc/<pid>/mem` pointer reading plus `/proc/<pid>/maps` validation, now separately timed (`src/backend.c:84-94`; `src/discovery.c:335-385,499-540`). ELF `debug_query_string` symbol resolution happens during daemon initialization, before timer creation and the main loop (`src/daemon.c:506-531`), so it cannot explain an in-window blackout.

Other synchronous main-loop branches are covered by outer timers: sampler provider polling, signal handling, control requests, and escalation timer work. Control-triggered escalation walks the registry and attaches synchronously; de-escalation drains the event ring, flushes intervals, detaches, and writes markers (`src/escalation.c:94-125,313-407`). Control sockets are nonblocking and bounded, so their socket I/O itself is not a likely seconds-long block.

## Decisive next-strike interpretation

The watchpoint hypothesis is confirmed if a strike contains a multi-second
`STATEDUMP-BLOCK: op=watchpoint_open[_failed]` or
`watchpoint_enable[_failed]` (or the bootstrap equivalent) for the new backend,
nested within a similarly long `lifecycle_fork`, `lifecycle_init`, or
`backend_recovery_scan`, with `max_loop_gap_ms` covering the blackout.

- Attach before the first timer dispatch: `timer_ticks=0 completed_ticks=0`.
- Attach from first-tick recovery: an early TIMER line, `timer_ticks>=1`, and
  `completed_ticks=0` until the handler returns.
- Scheduler/epoll alternative: no attach leaf, but a blackout-sized
  `op=epoll_wait`, large `max_loop_gap_ms`, setup rc values of zero, and
  possibly coalesced `max_timer_expirations>1`.
- Timer setup alternative: normal loop iterations/small gaps, zero timer entries,
  and a negative setup rc.
- A different named block rejects the attach hypothesis and names the actual
  synchronous path.

The two-vCPU/intermittent pattern follows naturally from the leading mechanism:
the target backend and CPU hogs occupy/migrate across the only two CPUs while the
daemon waits for synchronous perf task-context installation. The exact race and
scheduler timing need to align, so most runs remain healthy.

## Validation

- `make BPFTOOL=/tmp/bpftool/src/bpftool` — pass (userspace-only rebuild; no skeleton regeneration needed)
- `make -C tests check` — pass, all suites
- `git diff --check` — pass
- Disposable PostgreSQL 18 full-mode smoke:
  - env unset: `rc=0`, `STATEDUMP` line count = 0
  - env set: `rc=0`, TIMER line count = 1, BLOCK line count = 0
  - meta included `loop_iterations=165 timer_ticks=1 completed_ticks=1 timer_expirations=1 max_timer_expirations=1 max_loop_gap_ms=20.850 last_loop_age_ms=0.010 timer_settime_rc=0 timer_epoll_rc=0`

## Deterministic hook / fix

Not pinned. Per the gate, this PR deliberately stops at Parts 1–2: no
`PGWT_TEST_*` hook and no proposed/product fix are included. The next
`mode4-hunt` strike should select or reject the leading mechanism using the
signals above.
