### PR TITLE
Fix sampled AAS command-gate build invalidation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,8 @@ INC_DIR    = include
 BUILD_DIR  = build
 TARGET     = pg_wait_tracer
 
+.DEFAULT_GOAL := all
+
 ARCH       := $(shell uname -m | sed 's/x86_64/x86/' | sed 's/aarch64/arm64/')
 
 # ---------------------------------------------------------------------------
@@ -116,6 +118,7 @@ USER_SRCS  = $(SRC_DIR)/pg_wait_tracer.c \
              $(SRC_DIR)/cJSON.c
 
 USER_OBJS  = $(patsubst $(SRC_DIR)/%.c,$(BUILD_DIR)/%.o,$(USER_SRCS))
+USER_DEPS  = $(USER_OBJS:.o=.d)
 
 # pgwt-server: lightweight replay server (no BPF dependencies)
 SERVER_SRCS = $(SRC_DIR)/server.c \
@@ -130,7 +133,16 @@ SERVER_SRCS = $(SRC_DIR)/server.c \
               $(SRC_DIR)/backend_meta.c \
               $(SRC_DIR)/cJSON.c
 SERVER_OBJS = $(patsubst $(SRC_DIR)/%.c,$(BUILD_DIR)/server_%.o,$(SERVER_SRCS))
+SERVER_DEPS = $(SERVER_OBJS:.o=.d)
 SERVER_LDFLAGS = -lz -llz4 -lm
+
+# Compiler-generated header dependencies are correctness-critical here: most
+# daemon translation units share struct pgwt_daemon across file boundaries.
+# A stale object built against an older daemon.h is an ABI mismatch even when
+# the final link succeeds. -MMD/-MP below writes these files beside each object;
+# the explicit Makefile prerequisite forces one migration rebuild for old trees
+# that do not have dependency files yet.
+-include $(USER_DEPS) $(SERVER_DEPS)
 
 .PHONY: all clean test-asan test-valgrind bench pgwt-client
 
@@ -209,11 +221,11 @@ $(INC_DIR)/pg_wait_tracer.skel.h: $(BUILD_DIR)/pg_wait_tracer.bpf.o
 	@$(BPFTOOL) gen skeleton $< > $@
 
 # Step 4: Compile userspace C (all depend on skeleton + shared header)
-$(BUILD_DIR)/%.o: $(SRC_DIR)/%.c $(INC_DIR)/pg_wait_tracer.skel.h \
+$(BUILD_DIR)/%.o: $(SRC_DIR)/%.c Makefile $(INC_DIR)/pg_wait_tracer.skel.h \
                   $(LIBBPF_DEP) \
                   $(SRC_DIR)/pg_wait_tracer.h | $(BUILD_DIR)
 	@echo "  CC       $@"
-	@$(CC) $(CFLAGS) -c $< -o $@
+	@$(CC) $(CFLAGS) -MMD -MP -c $< -o $@
 
 # Step 5: Link
 $(TARGET): $(USER_OBJS)
@@ -222,9 +234,9 @@ $(TARGET): $(USER_OBJS)
 	@echo "  DONE     $@"
 
 # pgwt-server: compile WITHOUT skeleton dependency, with -DPGWT_SERVER
-$(BUILD_DIR)/server_%.o: $(SRC_DIR)/%.c $(SRC_DIR)/pg_wait_tracer.h | $(BUILD_DIR)
+$(BUILD_DIR)/server_%.o: $(SRC_DIR)/%.c Makefile $(SRC_DIR)/pg_wait_tracer.h | $(BUILD_DIR)
 	@echo "  CC       $@ (server)"
-	@$(CC) $(CFLAGS) -DPGWT_SERVER -c $< -o $@
+	@$(CC) $(CFLAGS) -DPGWT_SERVER -MMD -MP -c $< -o $@
 
 pgwt-server: $(SERVER_OBJS)
 	@echo "  LINK     $@"

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -18,10 +18,11 @@ TESTS     = test_wait_event test_cmdline test_event_writer test_event_reader \
             test_golden_fixture \
             gen_test_traces gen_bench_traces test_concurrent_rw cross_validate \
             dump_markers
+CHECKS    = $(TESTS) test_build_dependencies.sh
 
 .PHONY: all clean check
 
-all: $(TESTS)
+all: $(CHECKS)
 
 # Run the full C unit suite. The list of tests lives in unit_tests.list —
 # the SINGLE source of truth shared by CI (ci.yml) and tests/run_all.sh

--- a/tests/test_anomaly.c
+++ b/tests/test_anomaly.c
@@ -456,6 +456,71 @@ static void test_baseline_learn_through(void)
           b.baseline_aas);
 }
 
+/* ── Exploratory AAS-1 repro: one sampled dip defeats a sustained storm ── */
+static void test_cpu_storm_single_tick_dips_fail_to_fire(void)
+{
+    printf("--- exploratory AAS-1: isolated sampler dips reset storm sustain ---\n");
+
+    struct pgwt_anomaly a;
+    pgwt_anomaly_init(&a, true, 10);
+    a.aas_factor = 3.0;
+    a.aas_ticks  = 3;
+    uint64_t clk = TICK_NS;
+    warm_baseline(&a, 1.0, &clk);
+
+    /* Model a constrained runner at the real 10 Hz observe cadence. The
+     * underlying workload remains four active sessions, but an occasional
+     * sampler/gate miss reports the boundary value 3.0 for one tick. With a
+     * baseline near 1.0, 4.0 is over the 3x threshold while 3.0 is not (the
+     * rule uses strict >). Every isolated dip therefore resets the hard
+     * consecutive streak before its third tick. This is an exploratory
+     * characterization of the current bug: a later approved detector fix is
+     * expected to flip this stream from no-FIRE to FIRE and update the check. */
+    static const double storm_aas[] = {
+        4.0, 4.0, 3.0,
+        4.0, 4.0, 3.0,
+        4.0, 4.0, 3.0,
+        4.0, 4.0, 3.0,
+    };
+    int fires = 0;
+    int near = 0;
+    int max_streak = 0;
+    for (size_t i = 0; i < sizeof(storm_aas) / sizeof(storm_aas[0]); i++) {
+        double baseline = a.baseline_aas;
+        double threshold = a.aas_factor * baseline;
+        int warm = a.baseline_warmup >= a.warmup_needed;
+        int over = warm && storm_aas[i] >= 2.0
+                 && storm_aas[i] > threshold;
+        int streak_before = a.aas_over_streak;
+        struct pgwt_anomaly_decision d =
+            pgwt_anomaly_eval(&a, storm_aas[i], 0.0, clk);
+
+        printf("  obs t_ms=%llu aas=%.1f baseline=%.4f threshold=%.4f "
+               "warm=%d over=%d streak=%d->%d action=%d\n",
+               (unsigned long long)(i * TICK_NS / 1000000ULL),
+               storm_aas[i], baseline, threshold, warm, over,
+               streak_before, a.aas_over_streak, d.action);
+        if (d.action == PGWT_ANOMALY_FIRE)
+            fires++;
+        if (d.action == PGWT_ANOMALY_NEAR
+            && (d.near_mask & PGWT_NEAR_AAS_SUSTAIN))
+            near++;
+        if (a.aas_over_streak > max_streak)
+            max_streak = a.aas_over_streak;
+        clk += TICK_NS;
+    }
+
+    CHECK(fires == 0,
+          "exploratory repro: dip-interrupted storm currently must not FIRE "
+          "(got %d)", fires);
+    CHECK(near == 8,
+          "exploratory repro: both over observations in each run are NEAR "
+          "(got %d)", near);
+    CHECK(max_streak == 2 && a.aas_over_streak == 0,
+          "exploratory repro: hard resets cap streak at 2 (max=%d final=%d)",
+          max_streak, a.aas_over_streak);
+}
+
 /* ── Test 9: AAS + lock can fire together (combined fired_mask) ────────── */
 static void test_combined_fire(void)
 {
@@ -491,6 +556,7 @@ int main(void)
     test_cpu_storm_fires();
     test_lock_min_activity();
     test_baseline_learn_through();
+    test_cpu_storm_single_tick_dips_fail_to_fire();
     test_combined_fire();
 
     printf("\n%d/%d checks passed\n", tests_passed, tests_run);

--- a/tests/test_build_dependencies.sh
+++ b/tests/test_build_dependencies.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Regression for stale cross-translation-unit struct layouts. A daemon.h
+# change must invalidate discovery.o, which writes struct pgwt_daemon fields
+# later read by daemon.o/sampler.o. Missing this edge once silently disabled
+# the sampled command-active gate while the final link still succeeded.
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/.." && pwd)
+HEADER="$ROOT/src/daemon.h"
+DEPFILE="$ROOT/build/discovery.d"
+STAMP=$(mktemp)
+
+cleanup() {
+    touch -r "$STAMP" "$HEADER"
+    rm -f "$STAMP"
+}
+trap cleanup EXIT
+touch -r "$HEADER" "$STAMP"
+
+make -s -C "$ROOT" build/discovery.o
+
+if [[ ! -f "$DEPFILE" ]] || ! grep -q 'src/daemon.h' "$DEPFILE"; then
+    echo "FAIL: build/discovery.d does not track src/daemon.h"
+    exit 1
+fi
+
+touch "$HEADER"
+if make -q -C "$ROOT" build/discovery.o; then
+    echo "FAIL: touching daemon.h left discovery.o incorrectly up to date"
+    exit 1
+fi
+
+make -s -C "$ROOT" build/discovery.o
+if ! make -q -C "$ROOT" build/discovery.o; then
+    echo "FAIL: discovery.o is still stale after its header-triggered rebuild"
+    exit 1
+fi
+
+echo "PASS: daemon.h invalidates and rebuilds discovery.o"

--- a/tests/test_sampler.c
+++ b/tests/test_sampler.c
@@ -189,6 +189,61 @@ static void test_build_batch_cpu_policy(void)
     CHECK(n == 1, "UNKNOWN type we==0 records when command open");
 }
 
+/* ── Test 2d: authoritative level gate repairs a missed short command ─── */
+
+static void test_authoritative_cmd_gate_cpu_policy(void)
+{
+    printf("--- authoritative command level: active CPU counted, idle CPU gated ---\n");
+
+    /* Model the sampled-tier gate input directly: the transition-edge
+     * state_map says closed, but the backend is executing a short command.
+     * debug_query_string is PostgreSQL's process-local level signal; a live
+     * query is represented by a non-NULL pointer. */
+    volatile char query[] = "SELECT 1";
+    volatile uint64_t debug_query_string =
+        (uint64_t)(uintptr_t)&query[0];
+    int cmd_open = 0;                    /* stale/missed boundary edge */
+    uint64_t query_id = 0;
+
+    pgwt_read_cmd_gate(getpid(),
+                       (uint64_t)(uintptr_t)&debug_query_string,
+                       0, 0, &cmd_open, &query_id);
+    CHECK(cmd_open == 1,
+          "live debug_query_string authoritatively opens a missed short command");
+
+    struct pgwt_sample_target target = {
+        .pid = getpid(),
+        .backend_type = PGWT_BT_CLIENT,
+        .cmd_open = cmd_open,
+    };
+    uint32_t on_cpu = 0;
+    struct pgwt_trace_event out[1];
+    uint64_t noncmd = 0;
+    int n = pgwt_sampler_build_batch(&target, &on_cpu, 1, 1, out,
+                                     NULL, &noncmd);
+    CHECK(n == 1 && out[0].new_event == 0,
+          "authoritatively active short-command CPU sample is counted");
+    CHECK(noncmd == 0,
+          "active CPU sample does not increment the non-command counter");
+
+    /* Binding over-count guard: once PostgreSQL clears the live-query level,
+     * the same ambiguous we==0 reading is between-command CPU and must stay
+     * excluded. This preserves the idle/ClientRead decision. */
+    debug_query_string = 0;
+    cmd_open = 1;                       /* stale open edge must be corrected */
+    pgwt_read_cmd_gate(getpid(),
+                       (uint64_t)(uintptr_t)&debug_query_string,
+                       0, 0, &cmd_open, &query_id);
+    CHECK(cmd_open == 0,
+          "NULL debug_query_string authoritatively closes an idle backend");
+    target.cmd_open = cmd_open;
+    noncmd = 0;
+    n = pgwt_sampler_build_batch(&target, &on_cpu, 1, 2, out,
+                                 NULL, &noncmd);
+    CHECK(n == 0 && noncmd == 1,
+          "between-command CPU remains excluded and counted as non-command");
+}
+
 /* ── Test 2b: build_batch drops + counts garbage readings (CAP-2/5) ───── */
 
 static void test_build_batch_garbage(void)
@@ -487,6 +542,7 @@ int main(void)
     test_build_batch();
     test_build_batch_garbage();
     test_build_batch_cpu_policy();
+    test_authoritative_cmd_gate_cpu_policy();
     test_fallback();
     test_child_read();
     test_local_addr_not_batched();

--- a/tests/unit_tests.list
+++ b/tests/unit_tests.list
@@ -6,7 +6,8 @@
 # run_all.sh, test_concurrent_rw built but run nowhere).
 #
 # One binary name per line; '#' starts a comment. Every binary listed here
-# must be built by `make -C tests` (tests/Makefile TESTS).
+# must be built by `make -C tests` (tests/Makefile CHECKS).
+test_build_dependencies.sh
 test_wait_event
 test_cmdline
 test_bucket


### PR DESCRIPTION
## Root cause

The sampled CPU policy itself was already the intended authoritative design:

- `src/sampler.c:739-749` snapshots `state_map.{cmd_open,last_query_id}`.
- `src/bpf/pg_wait_tracer.bpf.c:689-730` maintains `cmd_open` from PostgreSQL's `pgstat_report_activity()` active/idle boundaries.
- `src/sampler.c:801-829` level-checks an at-risk closed-gate CPU sample against that backend's live `debug_query_string` and repairs a missed edge before batching.
- `src/sampler.c:247-253` drops client `we == 0` only when the resulting command gate is still closed.

The AAS-1 run was not using a coherent build of that path. Commit `6618a01` inserted the main-loop diagnostic fields at `src/daemon.h:244-257`, immediately before `pg_binary_saved` at `src/daemon.h:259-260`. The Makefile did not track `daemon.h`, so the retained `discovery.o` still used the old struct offset when `src/discovery.c:915-917` stored `pg_binary_saved`. It wrote into the newly inserted diagnostic-field area; daemon initialization cleared that area, while the real pointer remained NULL.

That NULL has two direct sampled-tier consequences:

- `src/daemon.c:521-532` skips resolving the userspace `debug_query_string` level gate.
- `src/daemon.c:614-715` skips the query/activity uprobe attach block, so command-start/end edges never update `state_map.cmd_open`.

Every client CPU reading therefore reaches `pgwt_sampler_build_batch()` with `cmd_open == 0`, increments `noncmd_cpu_samples_total`, and is excluded from AAS. The final link succeeds because C does not validate cross-translation-unit struct offsets.

### Per-sample evidence

On the broken incremental artifact, the three short-statement hogs were reported active by `pg_stat_activity` throughout the run, while the tracer reported `samples_total=949`, `noncmd_cpu_samples_total=203`, `sample_read_faults_total=0`, and `sampler_ticks_missed_total=0`. There were no authoritative gate-recovery observations, and verbose startup had neither a `debug_query_string` resolution nor an activity-uprobe attach.

Recompiling `discovery.c` against the unchanged current source/header immediately restored both command-state sources. The same workload then reported `samples_total=1148` and only 5 non-command CPU samples, all from the short-lived observer connections rather than the three hog backends. The repository's final `phase_cpu_storm_escalation` run fired once and held all seven cross-tier AAS buckets at approximately 3.0 (`min=2.99`, `pg_stat_activity=3.0`). This rules out cadence, missed ticks, detector brittleness, and a short-statement boundary race as the mechanism in this checkout.

## Fix

- Generate and include compiler dependency files for every daemon and server object (`-MMD -MP`), so a `daemon.h` layout change rebuilds every consumer.
- Make the Makefile itself an object prerequisite to force one migration rebuild in old worktrees that do not have dependency files yet.
- Pin `all` as the default goal so included dependency files cannot change plain `make` behavior.
- Add a regression that touches `daemon.h` and proves `discovery.o` becomes stale, rebuilds, and then becomes current.
- Add a sampler-level regression proving an authoritative live-query level counts closed-edge client CPU, while a NULL level keeps between-command CPU excluded.

No detector policy changed. The Stage-1 sustained-with-dips test remains an explicit characterization; this fix repairs the signal source rather than adding dip tolerance.

## Over-count guard

The sampled accounting policy is unchanged. Client CPU remains recordable only when the authoritative command level is open. The new unit test checks both sides:

- live `debug_query_string` + `we == 0` produces one CPU sample and no non-command increment;
- NULL `debug_query_string` + `we == 0` produces no sample and increments the non-command counter.

The existing anomaly batch test also continues to prove that `Client:ClientRead` and Activity-class records produce AAS 0. There is no idle/ClientRead relaxation and no `aas_factor` change.

## Validation

- `make BPFTOOL=/tmp/bpftool/src/bpftool`
- `make -C tests check` (all listed checks green; sampler 85/85)
- `tests/test_build_dependencies.sh` (daemon.h invalidates and rebuilds discovery.o)
- live PostgreSQL 18 `phase_cpu_storm_escalation` (3/3; one fire/window; seven buckets ~3.0, min 2.99)

## BPF

No BPF source or generated skeleton changed.
