### PR TITLE
AAS-1: confirm sampler and fix busy-baseline anomaly detection

### DIFF
--- a/.github/scripts/aas1_confirm.py
+++ b/.github/scripts/aas1_confirm.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3
+"""Reproduce the AAS-1 anomaly-escalation miss on the 2-vCPU CI runner."""
+
+import argparse
+from contextlib import redirect_stderr, redirect_stdout
+import io
+import os
+from pathlib import Path
+import subprocess
+import sys
+import traceback
+
+
+REPO = Path(__file__).resolve().parents[2]
+TESTS = REPO / "tests"
+sys.path.insert(0, str(TESTS))
+
+import test_capture_smoke as t  # noqa: E402
+
+
+CI_SMOKE = TESTS / "ci_smoke.sh"
+STRIKE_LOG = REPO / "aas1-strike.log"
+SUMMARY_LOG = REPO / "aas1-confirm-summary.txt"
+FULL_STDERR = REPO / ".aas1-storm-stderr.tmp"
+STRIKE_PREFIX = "CPU storm triggered anomaly escalation"
+STRAY_PROCESSES = ("pg_wait_tracer", "pgwt-server")
+
+
+def checks_contain_strike(checks):
+    """True only for the AAS-1 miss, not for another phase assertion."""
+    return any(
+        not passed
+        and message.startswith(STRIKE_PREFIX)
+        and "anomaly_fires_total=0" in message
+        for passed, message in checks
+    )
+
+
+def output_contains_strike(output):
+    """Recognize the same failed check in a full ci_smoke.sh transcript."""
+    for raw_line in output.splitlines():
+        line = raw_line.decode("utf-8", errors="replace")
+        if ("FAIL: " + STRIKE_PREFIX) in line \
+                and "anomaly_fires_total=0" in line:
+            return True
+    return False
+
+
+def first_failed_check(checks):
+    for passed, message in checks:
+        if not passed:
+            return message
+    return "driver error before any check"
+
+
+def first_fail_line(output):
+    for raw_line in output.splitlines():
+        line = raw_line.decode("utf-8", errors="replace").strip()
+        if "FAIL" in line:
+            return line
+    return "no FAIL line found"
+
+
+def write_strike(stderr, verdict):
+    """Persist and print the first strike's complete tracer stderr."""
+    if isinstance(stderr, str):
+        stderr = stderr.encode("utf-8", errors="replace")
+    STRIKE_LOG.write_bytes(stderr)
+    SUMMARY_LOG.write_text(verdict + "\n", encoding="utf-8")
+    print(verdict, flush=True)
+    print("=== complete tracer stderr ===", flush=True)
+    sys.stdout.buffer.write(stderr)
+    if stderr and not stderr.endswith(b"\n"):
+        sys.stdout.buffer.write(b"\n")
+    sys.stdout.buffer.flush()
+
+
+def write_not_reproduced(iterations):
+    verdict = f"not reproduced in {iterations}"
+    detail = (
+        f"{verdict}\n"
+        f"standalone phase: {iterations} iterations, no strike\n"
+        f"full ci_smoke.sh fallback: {iterations} iterations, no strike\n"
+    )
+    STRIKE_LOG.write_text(detail, encoding="utf-8")
+    SUMMARY_LOG.write_text(detail, encoding="utf-8")
+    print(detail, end="")
+
+
+def kill_stray_processes():
+    """Remove test helpers without disturbing the PostgreSQL cluster."""
+    for signal in ("-TERM", "-KILL"):
+        for process_name in STRAY_PROCESSES:
+            result = subprocess.run(
+                ["sudo", "pkill", signal, "-x", process_name],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                check=False,
+            )
+            # pkill returns 1 when no matching process exists.
+            if result.returncode not in (0, 1):
+                raise RuntimeError(
+                    f"could not clean up stray {process_name} process "
+                    f"(pkill rc={result.returncode})")
+
+
+def run_standalone(pm_pid):
+    """Run one imported storm phase and capture its checks + tracer stderr."""
+    captured = {"stderr": b""}
+    checks = []
+    output = io.StringIO()
+    original_popen = subprocess.Popen
+    original_check = t.check
+
+    class CapturingPopen(original_popen):
+        def __init__(self, *popen_args, **popen_kwargs):
+            command = (popen_args[0] if popen_args
+                       else popen_kwargs.get("args", []))
+            executable = (command[0]
+                          if isinstance(command, (list, tuple)) and command
+                          else command)
+            self._aas1_tracer = (
+                executable is not None
+                and os.path.abspath(os.fspath(executable)) == t.TRACER)
+            super().__init__(*popen_args, **popen_kwargs)
+
+        def communicate(self, *comm_args, **comm_kwargs):
+            stdout, stderr = super().communicate(*comm_args, **comm_kwargs)
+            if self._aas1_tracer:
+                captured["stderr"] = stderr or b""
+            return stdout, stderr
+
+    def capture_check(condition, message):
+        checks.append((bool(condition), str(message)))
+        original_check(condition, message)
+
+    t.subprocess.Popen = CapturingPopen
+    t.check = capture_check
+    error = None
+    try:
+        with redirect_stdout(output), redirect_stderr(output):
+            t.phase_cpu_storm_escalation(pm_pid)
+    except Exception:
+        error = traceback.format_exc()
+    finally:
+        t.subprocess.Popen = original_popen
+        t.check = original_check
+
+    return checks, captured["stderr"], output.getvalue(), error
+
+
+def sudo_env(stderr_path):
+    assignments = [
+        f"PATH={os.environ.get('PATH', '')}",
+        "PGWT_DEBUG_SAMPLER_TRACE=1",
+        f"PGWT_AAS1_CAPTURE_STDERR={stderr_path}",
+    ]
+    for name in ("BPFTOOL", "GITHUB_STEP_SUMMARY"):
+        value = os.environ.get(name)
+        if value:
+            assignments.append(f"{name}={value}")
+    return assignments
+
+
+def run_full_sequence(pg_version):
+    command = [
+        "sudo", "env", *sudo_env(FULL_STDERR), str(CI_SMOKE),
+        "--pg-version", pg_version,
+    ]
+    return subprocess.run(
+        command,
+        cwd=REPO,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        check=False,
+    )
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--iterations", type=int, required=True)
+    parser.add_argument("--pg-version", required=True)
+    args = parser.parse_args(argv)
+    if args.iterations <= 0:
+        parser.error("--iterations must be positive")
+
+    t.TRACER = str(REPO / "pg_wait_tracer")
+    t.SERVER = str(REPO / "pgwt-server")
+    os.environ["PGWT_DEBUG_SAMPLER_TRACE"] = "1"
+    pm_pid = t.find_postmaster(pg_version=int(args.pg_version))
+    if not pm_pid:
+        parser.error(
+            f"cannot find PostgreSQL {args.pg_version} postmaster PID")
+
+    print(f"method: standalone phase (postmaster PID {pm_pid})", flush=True)
+    for iteration in range(1, args.iterations + 1):
+        checks, stderr, _output, error = run_standalone(pm_pid)
+        if checks_contain_strike(checks):
+            verdict = (
+                f"method=standalone iteration {iteration}/{args.iterations}: "
+                "STRIKE (anomaly_fires_total=0)")
+            write_strike(stderr, verdict)
+            return 1
+
+        if error or any(not passed for passed, _ in checks):
+            detail = error.splitlines()[-1] if error else first_failed_check(checks)
+            print(
+                f"standalone iteration {iteration}/{args.iterations}: "
+                f"other ({detail})",
+                flush=True,
+            )
+        else:
+            print(
+                f"standalone iteration {iteration}/{args.iterations}: pass",
+                flush=True,
+            )
+        kill_stray_processes()
+
+    print(
+        f"standalone did not reproduce in {args.iterations}; "
+        "method: full ci_smoke.sh fallback",
+        flush=True,
+    )
+    for iteration in range(1, args.iterations + 1):
+        FULL_STDERR.unlink(missing_ok=True)
+        result = run_full_sequence(args.pg_version)
+        output = result.stdout or b""
+        if output_contains_strike(output):
+            if FULL_STDERR.exists():
+                stderr = FULL_STDERR.read_bytes()
+            else:
+                stderr = (
+                    b"AAS-1 strike detected, but the complete tracer stderr "
+                    b"capture is missing. Full ci_smoke.sh output follows:\n" + output)
+            verdict = (
+                f"method=full-ci-smoke iteration "
+                f"{iteration}/{args.iterations}: STRIKE "
+                "(anomaly_fires_total=0)")
+            write_strike(stderr, verdict)
+            FULL_STDERR.unlink(missing_ok=True)
+            return 1
+
+        if result.returncode:
+            print(
+                f"full iteration {iteration}/{args.iterations}: "
+                f"other ({first_fail_line(output)})",
+                flush=True,
+            )
+        else:
+            print(
+                f"full iteration {iteration}/{args.iterations}: pass",
+                flush=True,
+            )
+        FULL_STDERR.unlink(missing_ok=True)
+        kill_stray_processes()
+
+    write_not_reproduced(args.iterations)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,11 +26,11 @@ on:
         type: boolean
         default: false
       iterations:
-        description: "Number of full ci_smoke.sh sequence runs"
+        description: "Number of iterations for manual confirmation/hunt jobs"
         type: string
         default: "25"
       pg:
-        description: "PostgreSQL major version for the mode-4 hunt"
+        description: "PostgreSQL major version for manual confirmation/hunt jobs"
         type: string
         default: "17"
 
@@ -320,6 +320,115 @@ jobs:
           path: |
             mode4-strike.log
             mode4-hunt-summary.txt
+          if-no-files-found: error
+
+  aas1-confirm:
+    name: aas1-confirm
+    if: ${{ github.event_name == 'workflow_dispatch' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Initialize AAS-1 confirmation artifacts
+        run: |
+          printf '%s\n' 'confirmation did not start' > aas1-strike.log
+          printf '%s\n' 'confirmation did not start' > aas1-confirm-summary.txt
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang llvm libbpf-dev libelf-dev \
+            zlib1g-dev liblz4-dev linux-tools-common
+          # Same bpftool fallback as capture-smoke: the runner's HWE azure
+          # kernel may ship linux-tools without a bpftool binary.
+          if bpftool version >/dev/null 2>&1; then
+            BPFTOOL=$(command -v bpftool)
+          else
+            git clone --depth 1 --branch v7.5.0 --recurse-submodules \
+              https://github.com/libbpf/bpftool.git /tmp/bpftool
+            make -C /tmp/bpftool/src -j"$(nproc)"
+            BPFTOOL=/tmp/bpftool/src/bpftool
+          fi
+          "$BPFTOOL" version
+          echo "BPFTOOL=$BPFTOOL" >> "$GITHUB_ENV"
+          test -r /sys/kernel/btf/vmlinux
+
+      - name: Install PostgreSQL ${{ inputs.pg }} (PGDG apt)
+        env:
+          PG_MAJOR: ${{ inputs.pg }}
+        run: |
+          set -x
+          V="$PG_MAJOR"
+          sudo systemctl stop postgresql || true
+          sudo apt-get install -y postgresql-common
+          pg_lsclusters -h | awk '{print $1, $2}' | while read -r ver name; do
+            sudo pg_dropcluster --stop "$ver" "$name" || true
+          done
+          sudo /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -y
+          if ! apt-cache show "postgresql-$V" >/dev/null 2>&1; then
+            echo "postgresql-$V not in the live PGDG repo — adding apt-archive"
+            echo "deb https://apt-archive.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" \
+              | sudo tee /etc/apt/sources.list.d/pgdg-archive.list
+            sudo apt-get update
+          fi
+          sudo apt-get install -y "postgresql-$V" "postgresql-contrib-$V"
+
+      - name: Configure + start PostgreSQL ${{ inputs.pg }}
+        env:
+          PG_MAJOR: ${{ inputs.pg }}
+        run: |
+          set -ex
+          V="$PG_MAJOR"
+          if ! pg_lsclusters -h | awk -v v="$V" '$1 == v && $2 == "main"' | grep -q .; then
+            sudo pg_createcluster "$V" main
+          fi
+          sudo pg_conftool "$V" main set port 5432
+          sudo pg_conftool "$V" main set shared_preload_libraries pg_stat_statements
+          if [ "$V" -ge 14 ]; then
+            sudo pg_conftool "$V" main set compute_query_id on
+          fi
+          sudo sed -i -E 's/(peer|scram-sha-256|md5)$/trust/' \
+            "/etc/postgresql/$V/main/pg_hba.conf"
+          sudo pg_ctlcluster "$V" main start
+          psql -U postgres -d postgres -c "CREATE EXTENSION IF NOT EXISTS pg_stat_statements"
+          psql -U postgres -d postgres -tAc "SELECT version()"
+
+      - name: Build (BPF tracer + pgwt-server)
+        run: make
+
+      - name: Confirm AAS-1 sampler phase-locking
+        env:
+          AAS1_ITERATIONS: ${{ inputs.iterations }}
+          PG_MAJOR: ${{ inputs.pg }}
+        run: |
+          set -euo pipefail
+          taskset -c 0,1 bash -c 'while :; do :; done' &
+          BURNER_ONE=$!
+          taskset -c 0,1 bash -c 'while :; do :; done' &
+          BURNER_TWO=$!
+          cleanup_burners() {
+            kill "$BURNER_ONE" "$BURNER_TWO" 2>/dev/null || true
+            wait "$BURNER_ONE" "$BURNER_TWO" 2>/dev/null || true
+          }
+          trap cleanup_burners EXIT
+
+          sudo env \
+            "PATH=/usr/lib/postgresql/$PG_MAJOR/bin:$PATH" \
+            "BPFTOOL=$BPFTOOL" \
+            "GITHUB_STEP_SUMMARY=$GITHUB_STEP_SUMMARY" \
+            "PGWT_DEBUG_SAMPLER_TRACE=1" \
+            python3 .github/scripts/aas1_confirm.py \
+              --iterations "$AAS1_ITERATIONS" \
+              --pg-version "$PG_MAJOR"
+
+      - name: Upload AAS-1 confirmation artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: aas1-confirm-${{ inputs.pg }}-${{ github.run_attempt }}
+          path: |
+            aas1-strike.log
+            aas1-confirm-summary.txt
           if-no-files-found: error
 
   web-ui:

--- a/README.md
+++ b/README.md
@@ -170,8 +170,13 @@ A full-fidelity window can be opened two ways:
 - **Manually** — the web UI's "Escalate" button, or the control socket
   (`{"cmd":"escalate","duration_s":N}`). `{"cmd":"deescalate"}` closes it early.
 - **Automatically** — anomaly rules evaluated on the sampled stream:
-  AAS exceeding a multiple of its rolling baseline (`--anomaly-aas-factor`,
-  default 3.0× sustained `--anomaly-aas-ticks` ticks, default 3), or the
+  AAS exceeding either its strict primary multiple of the rolling baseline
+  (`--anomaly-aas-factor`, default 3.0×) or all three secondary guards:
+  absolute AAS at least `--anomaly-aas-abs-floor` (default 2.0), an increase
+  of at least `--anomaly-aas-abs-delta` over baseline (default 1.5), and at
+  least `--anomaly-aas-secondary-factor` times baseline (default 1.5×). Both
+  paths must sustain `--anomaly-aas-ticks` ticks (default 3). Setting
+  `--anomaly-aas-factor` to 1000000 or higher disables both AAS paths. Or the
   Lock-class share of active samples exceeding `--anomaly-lock-fraction`
   (default 0.30) **and** the absolute Lock-class AAS exceeding
   `--anomaly-lock-min-aas` (default 2.0). The lock floor stops a single
@@ -487,7 +492,10 @@ Auto-escalation rules evaluated on the sampled stream. Ignored outside
 
 | Flag | Short | Default | Description |
 |------|-------|---------|-------------|
-| `--anomaly-aas-factor <K>` | — | `3.0` | Fire when AAS > K × rolling baseline |
+| `--anomaly-aas-factor <K>` | — | `3.0` | Primary: fire when AAS > K × rolling baseline; K ≥ 1000000 disables both AAS paths |
+| `--anomaly-aas-abs-floor <A>` | — | `2.0` | Secondary: require meaningful absolute AAS ≥ A |
+| `--anomaly-aas-abs-delta <D>` | — | `1.5` | Secondary: require AAS ≥ rolling baseline + D |
+| `--anomaly-aas-secondary-factor <K>` | — | `1.5` | Secondary: require AAS ≥ K × rolling baseline |
 | `--anomaly-aas-ticks <N>` | — | `3` | ...sustained for N consecutive ticks |
 | `--anomaly-lock-fraction <F>` | — | `0.30` | Fire when Lock-class share of active samples > F (sustained N ticks) |
 | `--anomaly-lock-min-aas <A>` | — | `2.0` | ...**and** absolute Lock-class AAS ≥ A (min-activity floor: a lone lock waiter can't escalate) |

--- a/src/anomaly.c
+++ b/src/anomaly.c
@@ -61,14 +61,17 @@ void pgwt_anomaly_init(struct pgwt_anomaly *a, bool enabled,
                        int sample_rate_hz)
 {
     memset(a, 0, sizeof(*a));
-    a->enabled       = enabled;
-    a->aas_factor    = PGWT_ANOMALY_DEF_AAS_FACTOR;
-    a->aas_ticks     = PGWT_ANOMALY_DEF_AAS_TICKS;
-    a->lock_fraction = PGWT_ANOMALY_DEF_LOCK_FRAC;
-    a->lock_min_aas  = PGWT_ANOMALY_DEF_LOCK_MIN_AAS;
-    a->lock_ticks    = PGWT_ANOMALY_DEF_LOCK_TICKS;
-    a->cooldown_ns   = (uint64_t)PGWT_ANOMALY_DEF_COOLDOWN_S * 1000000000ULL;
-    a->escalation_s  = PGWT_ANOMALY_DEF_ESCALATE_S;
+    a->enabled              = enabled;
+    a->aas_factor           = PGWT_ANOMALY_DEF_AAS_FACTOR;
+    a->aas_abs_floor        = PGWT_ANOMALY_DEF_AAS_ABS_FLOOR;
+    a->aas_abs_delta        = PGWT_ANOMALY_DEF_AAS_ABS_DELTA;
+    a->aas_secondary_factor = PGWT_ANOMALY_DEF_AAS_SECONDARY_FACTOR;
+    a->aas_ticks            = PGWT_ANOMALY_DEF_AAS_TICKS;
+    a->lock_fraction        = PGWT_ANOMALY_DEF_LOCK_FRAC;
+    a->lock_min_aas         = PGWT_ANOMALY_DEF_LOCK_MIN_AAS;
+    a->lock_ticks           = PGWT_ANOMALY_DEF_LOCK_TICKS;
+    a->cooldown_ns = (uint64_t)PGWT_ANOMALY_DEF_COOLDOWN_S * 1000000000ULL;
+    a->escalation_s         = PGWT_ANOMALY_DEF_ESCALATE_S;
     a->slow_release_div = PGWT_ANOMALY_DEF_SLOW_RELEASE_DIV;
 
     /* Baseline EWMA: pick alpha so the baseline has roughly a 60-second
@@ -109,12 +112,27 @@ pgwt_anomaly_eval(struct pgwt_anomaly *a, double aas, double lock_fraction,
     /* ── AAS-vs-baseline rule ──────────────────────────────────────────── */
     bool baseline_warm = a->baseline_warmup >= a->warmup_needed;
     bool aas_over = false;
-    if (baseline_warm && a->aas_factor > 0.0) {
+    bool aas_rule_enabled = a->aas_factor > 0.0
+                         && a->aas_factor < PGWT_ANOMALY_AAS_DISABLE_FACTOR;
+    if (baseline_warm && aas_rule_enabled) {
         double threshold = a->aas_factor * a->baseline_aas;
         /* Guard against a near-zero baseline: a tiny absolute AAS over a
          * 0-ish baseline is noise, not an incident. Require at least 2 active
          * sessions before the multiplicative rule can fire. */
-        aas_over = (aas >= 2.0) && (aas > threshold);
+        bool primary_over = (aas >= 2.0) && (aas > threshold);
+
+        /* The primary 3x rule misses a meaningful load increase when normal
+         * activity has already raised the baseline (for example 2 -> 4 AAS).
+         * Require all three secondary guards: meaningful absolute load, a
+         * substantial additive jump, and a relative increase that scales on
+         * busy systems. The shared streak below keeps this path sustained. */
+        bool secondary_over = a->aas_abs_floor > 0.0
+                           && a->aas_abs_delta > 0.0
+                           && a->aas_secondary_factor > 0.0
+                           && aas >= a->aas_abs_floor
+                           && aas >= a->baseline_aas + a->aas_abs_delta
+                           && aas >= a->aas_secondary_factor * a->baseline_aas;
+        aas_over = primary_over || secondary_over;
     }
     if (aas_over)
         a->aas_over_streak++;
@@ -142,7 +160,7 @@ pgwt_anomaly_eval(struct pgwt_anomaly *a, double aas, double lock_fraction,
     /* Only learn from NORMAL ticks: do not fold an anomalous AAS back into the
      * baseline (that would let a sustained incident silently raise the bar
      * until the rule stops firing). A tick is "normal" for baseline purposes
-     * when AAS is not currently over the multiplicative threshold. While
+     * when AAS is not currently over either AAS threshold. While
      * warming up we always learn (there is no baseline to protect yet). */
     if (!baseline_warm) {
         /* Simple running mean during warmup so the EWMA starts sane. */

--- a/src/anomaly.h
+++ b/src/anomaly.h
@@ -9,9 +9,11 @@
  * tick's sample batch (no re-reading the trace):
  *
  *   1. AAS-vs-baseline — maintain a rolling baseline of AAS (active sessions,
- *      idle-excluded per pgwt_is_idle_event). Fire when
- *      `aas > k * rolling_baseline` is sustained for N consecutive ticks.
- *      Config: --anomaly-aas-factor k, --anomaly-aas-ticks N.
+ *      idle-excluded per pgwt_is_idle_event). Fire when either the primary
+ *      multiplicative threshold or the secondary absolute+relative threshold
+ *      is sustained for N consecutive ticks. Config: --anomaly-aas-factor,
+ *      --anomaly-aas-abs-floor, --anomaly-aas-abs-delta,
+ *      --anomaly-aas-secondary-factor, and --anomaly-aas-ticks.
  *   2. Lock-class fraction — fire when the Lock-class share of the tick's
  *      ACTIVE (non-idle) samples exceeds a threshold, sustained for N ticks.
  *      Config: --anomaly-lock-fraction.
@@ -83,7 +85,10 @@ struct pgwt_anomaly {
     bool   enabled;           /* armed only in --mode tiered */
 
     /* Config (thresholds). Conservative defaults; all overridable. */
-    double aas_factor;        /* fire when aas > factor * baseline */
+    double aas_factor;        /* primary: aas > factor * baseline */
+    double aas_abs_floor;     /* secondary: minimum meaningful absolute AAS */
+    double aas_abs_delta;     /* secondary: minimum AAS increase over baseline */
+    double aas_secondary_factor; /* secondary: relative floor vs baseline */
     int    aas_ticks;         /* consecutive ticks the AAS rule must hold */
     double lock_fraction;     /* fire when lock share > this */
     double lock_min_aas;      /* ESC-4: AND lock-class AAS >= this (min-activity floor) */
@@ -92,7 +97,7 @@ struct pgwt_anomaly {
     int    escalation_s;      /* duration requested per auto-escalation */
 
     /* ESC-7 baseline slow learn-through: after the AAS metric has been
-     * continuously over the multiplicative threshold for learn_through_ticks,
+     * continuously over either AAS threshold for learn_through_ticks,
      * the baseline resumes EWMA at 1/slow_release_div the normal rate, so a
      * sustained legitimate regime change is eventually adopted (the rule stops
      * re-firing forever) while a short incident (streak < learn_through_ticks)
@@ -129,8 +134,14 @@ struct pgwt_anomaly {
 };
 
 /* Default thresholds (conservative). */
-#define PGWT_ANOMALY_DEF_AAS_FACTOR   3.0
-#define PGWT_ANOMALY_DEF_AAS_TICKS    3
+#define PGWT_ANOMALY_DEF_AAS_FACTOR           3.0
+#define PGWT_ANOMALY_DEF_AAS_ABS_FLOOR        2.0
+#define PGWT_ANOMALY_DEF_AAS_ABS_DELTA        1.5
+#define PGWT_ANOMALY_DEF_AAS_SECONDARY_FACTOR 1.5
+#define PGWT_ANOMALY_DEF_AAS_TICKS            3
+/* Historical pure-sampling sentinel used by capture-smoke tests. At or above
+ * this value BOTH AAS paths are disabled; the independent lock rule remains. */
+#define PGWT_ANOMALY_AAS_DISABLE_FACTOR 1000000.0
 #define PGWT_ANOMALY_DEF_LOCK_FRAC    0.30
 #define PGWT_ANOMALY_DEF_LOCK_MIN_AAS 2.0   /* ESC-4: min lock-class AAS to fire */
 #define PGWT_ANOMALY_DEF_LOCK_TICKS   3

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -1031,6 +1031,13 @@ int pgwt_daemon_init(struct pgwt_daemon *d)
     if (d->anomaly.enabled) {
         if (d->anomaly_aas_factor > 0.0)
             d->anomaly.aas_factor = d->anomaly_aas_factor;
+        if (d->anomaly_aas_abs_floor > 0.0)
+            d->anomaly.aas_abs_floor = d->anomaly_aas_abs_floor;
+        if (d->anomaly_aas_abs_delta > 0.0)
+            d->anomaly.aas_abs_delta = d->anomaly_aas_abs_delta;
+        if (d->anomaly_aas_secondary_factor > 1.0)
+            d->anomaly.aas_secondary_factor =
+                d->anomaly_aas_secondary_factor;
         if (d->anomaly_aas_ticks > 0)
             d->anomaly.aas_ticks = d->anomaly_aas_ticks;
         if (d->anomaly_lock_fraction >= 0.0)
@@ -1044,10 +1051,13 @@ int pgwt_daemon_init(struct pgwt_daemon *d)
             d->anomaly.escalation_s = d->anomaly_window_s;
         if (d->verbose)
             fprintf(stderr,
-                    "INFO: anomaly triggers armed: aas>%.1f*baseline for %d "
-                    "ticks, lock_frac>%.2f for %d ticks, cooldown %llus, "
+                    "INFO: anomaly triggers armed: aas primary>%.1f*baseline; "
+                    "secondary>=%.1f, baseline+%.1f, and %.1f*baseline for %d "
+                    "ticks; lock_frac>%.2f for %d ticks, cooldown %llus, "
                     "window %ds\n",
-                    d->anomaly.aas_factor, d->anomaly.aas_ticks,
+                    d->anomaly.aas_factor, d->anomaly.aas_abs_floor,
+                    d->anomaly.aas_abs_delta,
+                    d->anomaly.aas_secondary_factor, d->anomaly.aas_ticks,
                     d->anomaly.lock_fraction, d->anomaly.lock_ticks,
                     (unsigned long long)(d->anomaly.cooldown_ns / 1000000000ULL),
                     d->anomaly.escalation_s);

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -405,6 +405,7 @@ int pgwt_daemon_init(struct pgwt_daemon *d)
     d->debug_max_loop_gap_ns = 0;
     d->debug_timer_settime_rc = 0;
     d->debug_timer_epoll_rc = 0;
+    d->debug_sampler_trace = getenv("PGWT_DEBUG_SAMPLER_TRACE") != NULL;
 
     /* CAP-12: enough fds for a full-size backend registry, before anything
      * starts opening watchpoints. */
@@ -559,6 +560,11 @@ int pgwt_daemon_init(struct pgwt_daemon *d)
         fprintf(stderr, "WARN: PGWT_DEBUG_DUMP_STATE — state, timer, and "
                 "main-loop liveness will be dumped to stderr (STATEDUMP lines; "
                 "DEBUG ONLY, never set in production)\n");
+    }
+    if (d->debug_sampler_trace) {
+        fprintf(stderr, "WARN: PGWT_DEBUG_SAMPLER_TRACE — per-observation "
+                "sampler decisions will be dumped to stderr "
+                "(STATEDUMP-SAMP lines; DEBUG ONLY, never set in production)\n");
     }
     if (!d->cpu_accounting) {
         /* No BTF → tp_btf/sched_switch can't load: don't try, and fall back

--- a/src/daemon.h
+++ b/src/daemon.h
@@ -180,6 +180,9 @@ struct pgwt_daemon {
     /* Anomaly config (parsed flags; copied into anomaly state after init so
      * --anomaly-* overrides apply on top of the rate-derived defaults). */
     double      anomaly_aas_factor;      /* --anomaly-aas-factor (<=0 = default) */
+    double      anomaly_aas_abs_floor;   /* --anomaly-aas-abs-floor (<=0 = default) */
+    double      anomaly_aas_abs_delta;   /* --anomaly-aas-abs-delta (<=0 = default) */
+    double      anomaly_aas_secondary_factor; /* --anomaly-aas-secondary-factor */
     int         anomaly_aas_ticks;       /* --anomaly-aas-ticks (<=0 = default) */
     double      anomaly_lock_fraction;   /* --anomaly-lock-fraction (<0 = default) */
     double      anomaly_lock_min_aas;    /* --anomaly-lock-min-aas (<0 = default, ESC-4) */

--- a/src/daemon.h
+++ b/src/daemon.h
@@ -256,6 +256,11 @@ struct pgwt_daemon {
     int         debug_timer_settime_rc;   /* 0 or saved -errno */
     int         debug_timer_epoll_rc;     /* 0 or saved -errno */
 
+    /* PGWT_DEBUG_SAMPLER_TRACE per-observation AAS-1 diagnostic. Cached once
+     * per daemon lifecycle; when false the sampler takes no diagnostic clocks
+     * and emits no STATEDUMP-SAMP lines. */
+    bool        debug_sampler_trace;
+
     /* Placed at end of struct to survive field overflow corruption */
     char       *pg_binary_saved;        /* heap-allocated postgres binary path for USDT */
 };

--- a/src/pg_wait_tracer.c
+++ b/src/pg_wait_tracer.c
@@ -73,6 +73,11 @@ static void usage(const char *prog)
         "\n"
         "Anomaly triggers (tiered mode — auto-escalate on the sampled stream):\n"
         "      --anomaly-aas-factor <K>   Fire when AAS > K*rolling_baseline (default 3.0)\n"
+        "                             K >= 1000000 disables both AAS trigger paths\n"
+        "      --anomaly-aas-abs-floor <A>  Secondary: require AAS >= A (default 2.0)\n"
+        "      --anomaly-aas-abs-delta <D>  Secondary: require AAS >= baseline+D (default 1.5)\n"
+        "      --anomaly-aas-secondary-factor <K>\n"
+        "                             Secondary: require AAS >= K*baseline (default 1.5)\n"
         "      --anomaly-aas-ticks <N>    ...sustained for N consecutive ticks (default 3)\n"
         "      --anomaly-lock-fraction <F>  Fire when Lock-class share of active\n"
         "                             samples > F (default 0.30), sustained N ticks\n"
@@ -219,6 +224,9 @@ static enum pgwt_mode parse_mode(const char *s)
 #define OPT_ANOM_WINDOW     271
 #define OPT_RETENTION_GB    272
 #define OPT_ANOM_LOCK_MIN_AAS 273
+#define OPT_ANOM_AAS_ABS_FLOOR 274
+#define OPT_ANOM_AAS_ABS_DELTA 275
+#define OPT_ANOM_AAS_SECONDARY_FACTOR 276
 
 static struct option long_opts[] = {
     {"pid",        required_argument, NULL, 'p'},
@@ -248,6 +256,10 @@ static struct option long_opts[] = {
     {"sample-rate",     required_argument, NULL, OPT_SAMPLE_RATE},
     {"escalation-budget", required_argument, NULL, OPT_ESC_BUDGET},
     {"anomaly-aas-factor",  required_argument, NULL, OPT_ANOM_AAS_FACTOR},
+    {"anomaly-aas-abs-floor", required_argument, NULL, OPT_ANOM_AAS_ABS_FLOOR},
+    {"anomaly-aas-abs-delta", required_argument, NULL, OPT_ANOM_AAS_ABS_DELTA},
+    {"anomaly-aas-secondary-factor", required_argument, NULL,
+                                      OPT_ANOM_AAS_SECONDARY_FACTOR},
     {"anomaly-aas-ticks",   required_argument, NULL, OPT_ANOM_AAS_TICKS},
     {"anomaly-lock-fraction", required_argument, NULL, OPT_ANOM_LOCK_FRAC},
     {"anomaly-lock-min-aas", required_argument, NULL, OPT_ANOM_LOCK_MIN_AAS},
@@ -282,6 +294,9 @@ int main(int argc, char **argv)
     /* Anomaly triggers (A5): negative sentinels = "use the built-in default"
      * (pgwt_anomaly_init derives them); only an explicit flag overrides. */
     d->anomaly_aas_factor    = -1.0;
+    d->anomaly_aas_abs_floor = -1.0;
+    d->anomaly_aas_abs_delta = -1.0;
+    d->anomaly_aas_secondary_factor = -1.0;
     d->anomaly_aas_ticks     = -1;
     d->anomaly_lock_fraction = -1.0;
     d->anomaly_lock_min_aas  = -1.0;
@@ -338,6 +353,11 @@ int main(int argc, char **argv)
                 d->escalation_budget_s = atoi(optarg);
             break;
         case OPT_ANOM_AAS_FACTOR: d->anomaly_aas_factor = atof(optarg); break;
+        case OPT_ANOM_AAS_ABS_FLOOR: d->anomaly_aas_abs_floor = atof(optarg); break;
+        case OPT_ANOM_AAS_ABS_DELTA: d->anomaly_aas_abs_delta = atof(optarg); break;
+        case OPT_ANOM_AAS_SECONDARY_FACTOR:
+            d->anomaly_aas_secondary_factor = atof(optarg);
+            break;
         case OPT_ANOM_AAS_TICKS:  d->anomaly_aas_ticks = atoi(optarg); break;
         case OPT_ANOM_LOCK_FRAC:  d->anomaly_lock_fraction = atof(optarg); break;
         case OPT_ANOM_LOCK_MIN_AAS: d->anomaly_lock_min_aas = atof(optarg); break;
@@ -433,6 +453,23 @@ int main(int argc, char **argv)
      * "unset, use default", so only reject out-of-range explicit values. */
     if (d->anomaly_aas_factor == 0.0) {
         fprintf(stderr, "FATAL: --anomaly-aas-factor must be > 0\n");
+        free(d);
+        return 1;
+    }
+    if (d->anomaly_aas_abs_floor == 0.0) {
+        fprintf(stderr, "FATAL: --anomaly-aas-abs-floor must be > 0\n");
+        free(d);
+        return 1;
+    }
+    if (d->anomaly_aas_abs_delta == 0.0) {
+        fprintf(stderr, "FATAL: --anomaly-aas-abs-delta must be > 0\n");
+        free(d);
+        return 1;
+    }
+    if (d->anomaly_aas_secondary_factor >= 0.0
+        && d->anomaly_aas_secondary_factor <= 1.0) {
+        fprintf(stderr,
+                "FATAL: --anomaly-aas-secondary-factor must be > 1\n");
         free(d);
         return 1;
     }

--- a/src/sampler.c
+++ b/src/sampler.c
@@ -74,19 +74,25 @@ static int read_target_own_pid(const struct pgwt_sample_target *t,
  * foreign-pid read would return the reader's copy (SMP-2). *cmd_open /
  * *query_id are left untouched on any read failure, so the caller keeps its
  * edge-maintained fallback — this path never fabricates. */
-void pgwt_read_cmd_gate(pid_t pid, uint64_t dqs_addr, uint64_t be_entry_addr,
-                        int st_query_id_off, int *cmd_open, uint64_t *query_id)
+/* Return 1 when debug_query_string was read successfully. qstr_nonnull is an
+ * optional diagnostic output; it never participates in the gate decision. */
+static int read_cmd_gate_level(pid_t pid, uint64_t dqs_addr,
+                               uint64_t be_entry_addr, int st_query_id_off,
+                               int *cmd_open, uint64_t *query_id,
+                               int *qstr_nonnull)
 {
     if (dqs_addr == 0)
-        return;   /* symbol unresolved — keep the edge-maintained fallback */
+        return 0;   /* symbol unresolved — keep the edge-maintained fallback */
 
     uint64_t dqs = 0;
     struct iovec ld = { &dqs, sizeof(dqs) };
     struct iovec rd = { (void *)(uintptr_t)dqs_addr, sizeof(dqs) };
     if (process_vm_readv(pid, &ld, 1, &rd, 1, 0) != (ssize_t)sizeof(dqs))
-        return;   /* read failed — do not disturb the fallback */
+        return 0;   /* read failed — do not disturb the fallback */
 
     int open_now = (dqs != 0) ? 1 : 0;
+    if (qstr_nonnull)
+        *qstr_nonnull = open_now;
     if (cmd_open)
         *cmd_open = open_now;
 
@@ -104,6 +110,14 @@ void pgwt_read_cmd_gate(pid_t pid, uint64_t dqs_addr, uint64_t be_entry_addr,
                 *query_id = qid;
         }
     }
+    return 1;
+}
+
+void pgwt_read_cmd_gate(pid_t pid, uint64_t dqs_addr, uint64_t be_entry_addr,
+                        int st_query_id_off, int *cmd_open, uint64_t *query_id)
+{
+    (void)read_cmd_gate_level(pid, dqs_addr, be_entry_addr,
+                              st_query_id_off, cmd_open, query_id, NULL);
 }
 
 int pgwt_sampler_read_targets(const struct pgwt_sample_target *targets, int n,
@@ -809,7 +823,9 @@ int pgwt_sampler_poll(struct pgwt_daemon *d)
      * the common steady state (edge already open, or not on CPU) does zero
      * extra reads. When ground truth says "in a command", also refresh the
      * query_id the edge-uprobe likewise missed. */
-    if (d->debug_query_string_addr) {
+    if (d->debug_query_string_addr && !d->debug_sampler_trace) {
+        /* Production path: preserve the existing gate/drop behavior and avoid
+         * all per-target diagnostic bookkeeping when tracing is disabled. */
         for (int i = 0; i < n; i++) {
             if (s->read_vals[i] != 0 || targets[i].cmd_open)
                 continue;   /* not on-CPU, or the edge already caught it */
@@ -827,8 +843,57 @@ int pgwt_sampler_poll(struct pgwt_daemon *d)
                 d->counters.cmd_gate_recovered_total++;
             }
         }
+    } else if (d->debug_sampler_trace) {
+        for (int i = 0; i < n; i++) {
+            int edge = targets[i].cmd_open ? 1 : 0;
+            int level_checked = 0;
+            int level_ok = 0;
+            int qstr_nonnull = 0;
+            bool gated_client = targets[i].backend_type == PGWT_BT_CLIENT
+                             || targets[i].backend_type == PGWT_BT_UNKNOWN;
+
+            if (d->debug_query_string_addr && s->read_vals[i] == 0
+                && !targets[i].cmd_open && gated_client) {
+                int cg = 0;
+                uint64_t qg = targets[i].query_id;
+                level_checked = 1;
+                level_ok = read_cmd_gate_level(
+                    targets[i].pid, d->debug_query_string_addr,
+                    d->my_be_entry_addr, d->st_query_id_offset,
+                    &cg, &qg, &qstr_nonnull);
+                if (cg) {
+                    targets[i].cmd_open = 1;
+                    targets[i].query_id = qg;
+                    d->counters.cmd_gate_recovered_total++;
+                }
+            }
+
+            if (gated_client) {
+                uint32_t we = s->read_vals[i];
+                bool active_observation = we == 0
+                    || (pgwt_classify_wei(we) != PGWT_WEI_GARBAGE
+                        && !pgwt_is_idle_event(we));
+                if (active_observation) {
+                    bool recordable = we == 0
+                        ? pgwt_cpu_sample_recordable(targets[i].backend_type,
+                                                     targets[i].cmd_open)
+                        : pgwt_classify_wei(we) != PGWT_WEI_GARBAGE;
+                    fprintf(stderr,
+                            "STATEDUMP-SAMP: t=%llu pid=%d we=0x%08x "
+                            "edge=%d level_checked=%d level_ok=%d "
+                            "qstr=%s final=%s\n",
+                            (unsigned long long)tick_ts, targets[i].pid, we,
+                            edge, level_checked, level_ok,
+                            qstr_nonnull ? "nonNULL" : "NULL",
+                            recordable ? "COUNT" : "DROP");
+                }
+            }
+        }
     }
 
+    uint64_t noncmd_before = 0;
+    if (d->debug_sampler_trace)
+        noncmd_before = d->counters.noncmd_cpu_samples_total;
     uint64_t invalid_before = d->counters.invalid_wait_reads_total;
     int count = pgwt_sampler_build_batch(targets, s->read_vals, n, tick_ts,
                                          s->samples,
@@ -853,7 +918,37 @@ int pgwt_sampler_poll(struct pgwt_daemon *d)
      * tiered mode they may AUTO-escalate to full fidelity. Evaluated even when
      * count == 0 (an all-idle / all-CPU tick is a legitimate low-AAS reading
      * that the rolling baseline must learn from). No-op outside tiered mode. */
+    double trace_aas = 0.0;
+    double trace_baseline = 0.0;
+    double trace_threshold = 0.0;
+    bool trace_over = false;
+    if (d->debug_sampler_trace) {
+        double lock_fraction = 0.0;
+        pgwt_anomaly_metrics_from_batch(s->samples, count, &trace_aas,
+                                        &lock_fraction);
+        trace_baseline = d->anomaly.baseline_aas;
+        trace_threshold = d->anomaly.aas_factor * trace_baseline;
+        bool baseline_warm = d->anomaly.baseline_warmup
+                          >= d->anomaly.warmup_needed;
+        trace_over = d->anomaly.enabled && baseline_warm
+                  && d->anomaly.aas_factor > 0.0
+                  && trace_aas >= 2.0 && trace_aas > trace_threshold;
+    }
+
     pgwt_anomaly_tick(d, s->samples, count);
+
+    if (d->debug_sampler_trace) {
+        fprintf(stderr,
+                "STATEDUMP-SAMP-TICK: t=%llu period_ns=%llu aas=%.3f "
+                "baseline=%.3f threshold=%.3f over=%d streak=%d "
+                "counted=%d dropped_noncmd=%llu\n",
+                (unsigned long long)tick_ts,
+                (unsigned long long)period_ns,
+                trace_aas, trace_baseline, trace_threshold,
+                trace_over ? 1 : 0, d->anomaly.aas_over_streak, count,
+                (unsigned long long)(d->counters.noncmd_cpu_samples_total
+                                     - noncmd_before));
+    }
 
     if (count == 0)
         return 0;

--- a/tests/test_anomaly.c
+++ b/tests/test_anomaly.c
@@ -111,10 +111,13 @@ static void test_aas_sustained(void)
 /* ── Test 3: AAS within factor never fires ─────────────────────────────── */
 static void test_aas_no_fire(void)
 {
-    printf("--- AAS rule: under factor never fires ---\n");
+    printf("--- primary AAS rule: under factor never fires ---\n");
     struct pgwt_anomaly a;
     pgwt_anomaly_init(&a, true, 10);
     a.aas_factor = 3.0;
+    /* This pre-existing case isolates the primary rule. Under the new default
+     * secondary rule, 4 -> 8 is correctly considered a meaningful doubling. */
+    a.aas_secondary_factor = 0.0;
     a.aas_ticks  = 3;
     uint64_t clk = TICK_NS;
     warm_baseline(&a, 4.0, &clk);   /* baseline ~4 */
@@ -123,6 +126,134 @@ static void test_aas_no_fire(void)
     int fires = 0;
     feed(&a, 8.0, 0.0, 50, &clk, &fires);
     CHECK(fires == 0, "AAS under factor fired %d times", fires);
+}
+
+/* ── AAS-1: additive/secondary trigger and false-positive guards ───── */
+static void test_busy_baseline_secondary_fires(void)
+{
+    printf("--- AAS-1: busy baseline 2 -> 4 fires via secondary rule ---\n");
+    struct pgwt_anomaly a;
+    pgwt_anomaly_init(&a, true, 10);
+    a.aas_ticks = 3;
+    uint64_t clk = TICK_NS;
+    warm_baseline(&a, 2.0, &clk);
+
+    CHECK(a.aas_abs_floor == 2.0, "default abs floor %.2f expected 2.0",
+          a.aas_abs_floor);
+    CHECK(a.aas_abs_delta == 1.5, "default abs delta %.2f expected 1.5",
+          a.aas_abs_delta);
+    CHECK(a.aas_secondary_factor == 1.5,
+          "default secondary factor %.2f expected 1.5",
+          a.aas_secondary_factor);
+    CHECK(4.0 <= a.aas_factor * a.baseline_aas,
+          "regression pin must not clear primary threshold %.2f",
+          a.aas_factor * a.baseline_aas);
+
+    struct pgwt_anomaly_decision d =
+        feed(&a, 4.0, 0.0, a.aas_ticks, &clk, NULL);
+    CHECK(d.action == PGWT_ANOMALY_FIRE
+          && (d.fired_mask & PGWT_RULE_AAS),
+          "busy-baseline spike expected FIRE(aas), got action=%d mask=%u",
+          d.action, d.fired_mask);
+}
+
+static void test_idle_baseline_primary_still_fires(void)
+{
+    printf("--- AAS-1: idle baseline 1 -> 4 still fires via primary rule ---\n");
+    struct pgwt_anomaly a;
+    pgwt_anomaly_init(&a, true, 10);
+    a.aas_ticks = 3;
+    /* Isolate the unchanged strict-primary behavior. */
+    a.aas_secondary_factor = 0.0;
+    uint64_t clk = TICK_NS;
+    warm_baseline(&a, 1.0, &clk);
+
+    CHECK(4.0 > a.aas_factor * a.baseline_aas,
+          "idle-baseline spike must clear primary threshold %.2f",
+          a.aas_factor * a.baseline_aas);
+    struct pgwt_anomaly_decision d =
+        feed(&a, 4.0, 0.0, a.aas_ticks, &clk, NULL);
+    CHECK(d.action == PGWT_ANOMALY_FIRE
+          && (d.fired_mask & PGWT_RULE_AAS),
+          "idle-baseline spike expected FIRE(aas), got action=%d mask=%u",
+          d.action, d.fired_mask);
+}
+
+static void test_busy_baseline_jitter_does_not_fire(void)
+{
+    printf("--- AAS-1: busy-baseline jitter does not fire ---\n");
+    struct pgwt_anomaly a;
+    pgwt_anomaly_init(&a, true, 10);
+    uint64_t clk = TICK_NS;
+    warm_baseline(&a, 2.0, &clk);
+
+    const double jitter[] = {2.0, 2.3, 2.6, 2.2, 2.5, 2.1};
+    int fires = 0;
+    for (int i = 0; i < 120; i++) {
+        struct pgwt_anomaly_decision d =
+            pgwt_anomaly_eval(&a, jitter[i % 6], 0.0, clk);
+        clk += TICK_NS;
+        if (d.action == PGWT_ANOMALY_FIRE)
+            fires++;
+    }
+    CHECK(fires == 0, "busy-baseline jitter fired %d times", fires);
+    CHECK(a.aas_over_streak == 0,
+          "jitter left AAS over-streak at %d", a.aas_over_streak);
+}
+
+static void test_large_baseline_small_jump_does_not_fire(void)
+{
+    printf("--- AAS-1: large baseline 50 -> 55 does not fire ---\n");
+    struct pgwt_anomaly a;
+    pgwt_anomaly_init(&a, true, 10);
+    uint64_t clk = TICK_NS;
+    warm_baseline(&a, 50.0, &clk);
+
+    int fires = 0;
+    feed(&a, 55.0, 0.0, 120, &clk, &fires);
+    CHECK(fires == 0, "large-baseline small jump fired %d times", fires);
+    CHECK(a.aas_over_streak == 0,
+          "small relative jump left AAS over-streak at %d",
+          a.aas_over_streak);
+}
+
+static void test_large_baseline_real_spike_fires(void)
+{
+    printf("--- AAS-1: large baseline 50 -> 85 fires ---\n");
+    struct pgwt_anomaly a;
+    pgwt_anomaly_init(&a, true, 10);
+    a.aas_ticks = 3;
+    uint64_t clk = TICK_NS;
+    warm_baseline(&a, 50.0, &clk);
+
+    CHECK(85.0 <= a.aas_factor * a.baseline_aas,
+          "large spike regression must not clear primary threshold %.2f",
+          a.aas_factor * a.baseline_aas);
+    struct pgwt_anomaly_decision d =
+        feed(&a, 85.0, 0.0, a.aas_ticks, &clk, NULL);
+    CHECK(d.action == PGWT_ANOMALY_FIRE
+          && (d.fired_mask & PGWT_RULE_AAS),
+          "large-baseline real spike expected FIRE, got action=%d mask=%u",
+          d.action, d.fired_mask);
+}
+
+static void test_aas_factor_disable_contract(void)
+{
+    printf("--- AAS-1: million-factor disables both AAS paths ---\n");
+    struct pgwt_anomaly a;
+    pgwt_anomaly_init(&a, true, 10);
+    a.aas_factor = PGWT_ANOMALY_AAS_DISABLE_FACTOR;
+    uint64_t clk = TICK_NS;
+    warm_baseline(&a, 2.0, &clk);
+
+    int fires = 0;
+    struct pgwt_anomaly_decision d =
+        feed(&a, 4.0, 0.0, 20, &clk, &fires);
+    CHECK(fires == 0, "disabled AAS paths fired %d times", fires);
+    CHECK(d.action == PGWT_ANOMALY_NONE,
+          "disabled AAS paths produced action %d", d.action);
+    CHECK(a.aas_over_streak == 0,
+          "disabled AAS paths left over-streak at %d", a.aas_over_streak);
 }
 
 /* ── Test 4: lock-class fraction rule ──────────────────────────────────── */
@@ -483,6 +614,12 @@ int main(void)
     test_disabled();
     test_aas_sustained();
     test_aas_no_fire();
+    test_busy_baseline_secondary_fires();
+    test_idle_baseline_primary_still_fires();
+    test_busy_baseline_jitter_does_not_fire();
+    test_large_baseline_small_jump_does_not_fire();
+    test_large_baseline_real_spike_fires();
+    test_aas_factor_disable_contract();
     test_lock_fraction();
     test_cooldown();
     test_baseline_protected();

--- a/tests/test_capture_smoke.py
+++ b/tests/test_capture_smoke.py
@@ -1268,6 +1268,7 @@ def phase_cpu_storm_escalation(pm_pid):
     os.chmod(trace_dir, 0o755)
 
     storm = CpuStorm(3)
+    tracer_stderr = b""
     tracer = subprocess.Popen(
         [TRACER, "--mode", "tiered", "--pid", str(pm_pid),
          "-T", trace_dir, "--duration", "20", "--quiet",
@@ -1285,14 +1286,23 @@ def phase_cpu_storm_escalation(pm_pid):
             print(f"  (control socket: {e})")
         storm_active = sample_active_sessions(3.0, interval=0.5)
         storm_to = time.time_ns()
-        _, stderr = tracer.communicate(timeout=40)
-        err = stderr.decode('utf-8', errors='replace')
+        _, tracer_stderr = tracer.communicate(timeout=40)
+        err = tracer_stderr.decode('utf-8', errors='replace')
     except subprocess.TimeoutExpired:
         tracer.kill()
-        _, stderr = tracer.communicate()
-        err = stderr.decode('utf-8', errors='replace')
+        _, tracer_stderr = tracer.communicate()
+        err = tracer_stderr.decode('utf-8', errors='replace')
     finally:
         storm.stop()
+
+    # AAS-1 confirmation fallback: ci_smoke.sh runs this phase in a child
+    # process, so the driver cannot intercept Popen as it does for standalone
+    # attempts. Export this phase's raw tracer stderr only when the driver asks
+    # for it; normal smoke runs perform no extra file I/O.
+    aas1_stderr_path = os.environ.get("PGWT_AAS1_CAPTURE_STDERR")
+    if aas1_stderr_path:
+        with open(aas1_stderr_path, "wb") as aas1_stderr_file:
+            aas1_stderr_file.write(tracer_stderr)
 
     fires = metrics.get("anomaly_fires_total", 0)
     windows = metrics.get("escalation_windows_total", 0)


### PR DESCRIPTION
## Summary

- retain the env-gated `PGWT_DEBUG_SAMPLER_TRACE` diagnostics and isolated `aas1-confirm` workflow that established the sampler reports a steady AAS of 4.0
- add a secondary additive+relative AAS anomaly path for meaningful spikes above an already-active baseline
- preserve the strict primary rule, shared sustained-tick hysteresis, cooldown, and ESC-7 learn-through
- make the historical `--anomaly-aas-factor 1000000` pure-sampling sentinel disable both AAS paths
- add configurable thresholds and deterministic regression/false-positive tests

## Confirmed root cause

The CI trace showed a correctly measured `aas=4.0` against a baseline near `2.0`. The existing strict `aas > 3.0 * baseline` rule therefore remained false. This was detector blindness on a busy baseline, not sampler undercounting, phase lock, or a brittle streak.

## Detector formulation

```c
primary_over = aas >= 2.0
            && aas > aas_factor * baseline;

secondary_over = aas >= aas_abs_floor
              && aas >= baseline + aas_abs_delta
              && aas >= aas_secondary_factor * baseline;

aas_over = primary_over || secondary_over;
```

Both paths feed the same `aas_over_streak`, so `--anomaly-aas-ticks`, cooldown, baseline protection, and slow learn-through apply identically. The secondary path is gated by the same AAS-rule enable predicate as the primary path. An AAS factor at or above `1000000` suppresses both paths; the independent lock rule is unchanged.

## Defaults and false-positive rationale

- `--anomaly-aas-abs-floor 2.0`: preserves a meaningful absolute-load floor and prevents tiny near-idle changes from qualifying.
- `--anomaly-aas-abs-delta 1.5`: baseline `2.0` to AAS `4.0` clears the additive threshold `3.5` with `0.5` margin, while the specified `2.0` to `2.6` jitter remains well below it.
- `--anomaly-aas-secondary-factor 1.5`: scales the secondary rule on busy systems. Baseline `50` to AAS `55` is only `1.1x` and cannot fire; baseline `50` to AAS `85` is `1.7x` and does fire.
- `--anomaly-aas-ticks 3` remains unchanged, so one transient secondary crossing cannot escalate.

The primary keeps its existing strict comparison and its `aas >= 2.0` floor.

## Deterministic proof matrix

- busy baseline `2 -> 4`: fires after 3 ticks while the primary threshold is demonstrably not crossed
- idle baseline `1 -> 4`: still fires with the secondary path isolated off, proving the primary behavior is unchanged
- busy-baseline jitter `2.0..2.6`: no fire over 120 ticks
- large baseline `50 -> 55`: no fire over 120 ticks
- large baseline `50 -> 85`: fires after 3 ticks while the primary threshold is demonstrably not crossed
- AAS factor `1000000`, baseline `2 -> 4`: no action, no fire, and AAS streak remains zero
- all pre-existing anomaly cases remain green

## Validation

- `make BPFTOOL=/tmp/bpftool/src/bpftool`
- `make -C tests check`
- `test_anomaly`: 113/113 checks passed
- `git diff --check`

Only anomaly detector/configuration, its unit tests, CLI help, and detector documentation changed. The lock rule, sampler, idle/ClientRead gate, and env-gated sampler trap were not modified. No PostgreSQL, tracer, or live confirmation phase was run locally. The supervisor can dispatch the `aas1-confirm` CI loop after review.