### PR TITLE
Prevent failed sampler reads from fabricating CPU

### DIFF
--- a/src/control.c
+++ b/src/control.c
@@ -153,6 +153,10 @@ static cJSON *build_status(const struct pgwt_daemon *d)
 static cJSON *build_metrics(const struct pgwt_daemon *d)
 {
     const struct pgwt_counters *ctr = &d->counters;
+    struct pgwt_metrics pm;
+    memset(&pm, 0, sizeof(pm));
+    if (d->provider && d->provider->self_metrics)
+        d->provider->self_metrics((struct pgwt_daemon *)d, &pm);
 
     cJSON *root = cJSON_CreateObject();
     cJSON_AddBoolToObject(root, "ok", 1);
@@ -176,6 +180,19 @@ static cJSON *build_metrics(const struct pgwt_daemon *d)
     cJSON_AddNumberToObject(root, "samples_per_sec", ctr->samples_per_sec);
     cjson_add_uint64(root, "sample_read_faults_total",
                      ctr->sample_read_faults_total);
+    cjson_add_uint64(root, "sample_read_failures_total",
+                     pm.sample_read_failures_total);
+    cJSON_AddNumberToObject(root, "sample_read_targets",
+                            pm.sample_read_targets);
+    cJSON_AddNumberToObject(root, "sample_read_valid",
+                            pm.sample_read_valid);
+    cJSON_AddNumberToObject(root, "sample_read_invalid",
+                            pm.sample_read_invalid);
+    cJSON_AddNumberToObject(root, "sample_read_coverage_pct",
+                            pm.sample_read_targets > 0
+                                ? 100.0 * (double)pm.sample_read_valid
+                                  / (double)pm.sample_read_targets
+                                : 0.0);
     cjson_add_uint64(root, "sampler_ticks_missed_total",
                      ctr->sampler_ticks_missed_total);
 
@@ -230,10 +247,6 @@ static cJSON *build_metrics(const struct pgwt_daemon *d)
 
     /* Provider self-metrics. ringbuf_drops_total is the full tier's BPF-side
      * event_ringbuf drop count (A2 wired this; A0 deliberately omitted it). */
-    struct pgwt_metrics pm;
-    memset(&pm, 0, sizeof(pm));
-    if (d->provider && d->provider->self_metrics)
-        d->provider->self_metrics((struct pgwt_daemon *)d, &pm);
     cjson_add_uint64(root, "ringbuf_drops_total", pm.ringbuf_drops_total);
 
     /* Trace writer stats (0 when recording is disabled) */

--- a/src/provider.h
+++ b/src/provider.h
@@ -47,6 +47,10 @@ struct pgwt_metrics {
     uint64_t samples_total;       /* SAMPLES records written (sampled tier) */
     double   samples_per_sec;     /* recent sample rate */
     uint64_t sample_read_faults;  /* process_vm_readv partial/EFAULT fallbacks */
+    uint64_t sample_read_failures_total; /* targets with no successful read */
+    uint32_t sample_read_targets; /* targets attempted on the latest tick */
+    uint32_t sample_read_valid;   /* successful target reads on latest tick */
+    uint32_t sample_read_invalid; /* failed target reads on latest tick */
     uint64_t ringbuf_drops_total; /* event_ringbuf drops (full tier, BPF-side) */
 };
 

--- a/src/sampler.c
+++ b/src/sampler.c
@@ -31,6 +31,10 @@
 static int read_target_own_pid(const struct pgwt_sample_target *t,
                                uint32_t *val)
 {
+    if (t->pid <= 0 || t->wait_event_addr == 0) {
+        errno = EINVAL;
+        return 0;
+    }
     char path[64];
     snprintf(path, sizeof(path), "/proc/%d/mem", t->pid);
     int fd = open(path, O_RDONLY | O_CLOEXEC);
@@ -107,10 +111,14 @@ void pgwt_read_cmd_gate(pid_t pid, uint64_t dqs_addr, uint64_t be_entry_addr,
 }
 
 int pgwt_sampler_read_targets(const struct pgwt_sample_target *targets, int n,
-                              uint32_t *out_vals, uint64_t *read_faults)
+                              uint32_t *out_vals, uint8_t *out_valid,
+                              uint64_t *read_faults)
 {
-    if (n <= 0)
+    if (n <= 0 || !targets || !out_vals || !out_valid)
         return 0;
+
+    memset(out_vals, 0, (size_t)n * sizeof(*out_vals));
+    memset(out_valid, 0, (size_t)n * sizeof(*out_valid));
 
     struct iovec *liov = calloc(n, sizeof(*liov));
     struct iovec *riov = calloc(n, sizeof(*riov));
@@ -125,7 +133,6 @@ int pgwt_sampler_read_targets(const struct pgwt_sample_target *targets, int n,
     int got = 0;
     int nb = 0;   /* number of batchable (shared-memory) targets */
     for (int i = 0; i < n; i++) {
-        out_vals[i] = 0;
         /* SMP-2: only targets whose address is verified to live in a
          * MAP_SHARED mapping may be read through another pid. A private
          * address mapped at the same VA in every child reads SUCCESSFULLY
@@ -154,6 +161,8 @@ int pgwt_sampler_read_targets(const struct pgwt_sample_target *targets, int n,
         ssize_t r = process_vm_readv(reader_pid, liov + base, rem,
                                      riov + base, rem, 0);
         int done = (r > 0) ? (int)(r / sizeof(uint32_t)) : 0;
+        for (int j = 0; j < done; j++)
+            out_valid[idx[base + j]] = 1;
         got  += done;
         base += done;
         if (base >= nb)
@@ -164,6 +173,7 @@ int pgwt_sampler_read_targets(const struct pgwt_sample_target *targets, int n,
         uint32_t val = 0;
         if (read_target_own_pid(&targets[idx[base]], &val)) {
             out_vals[idx[base]] = val;
+            out_valid[idx[base]] = 1;
             got++;
         }
         if (read_faults)
@@ -178,6 +188,7 @@ int pgwt_sampler_read_targets(const struct pgwt_sample_target *targets, int n,
         uint32_t val = 0;
         if (read_target_own_pid(&targets[i], &val)) {
             out_vals[i] = val;
+            out_valid[i] = 1;
             got++;
         }
     }
@@ -230,13 +241,20 @@ int pgwt_cpu_sample_recordable(enum pgwt_backend_type bt, int cmd_open)
 }
 
 int pgwt_sampler_build_batch(const struct pgwt_sample_target *targets,
-                             const uint32_t *vals, int n, uint64_t tick_ts,
+                             const uint32_t *vals, const uint8_t *valid,
+                             int n, uint64_t tick_ts,
                              struct pgwt_trace_event *out,
                              uint64_t *invalid_reads,
                              uint64_t *noncmd_cpu_skipped)
 {
     int count = 0;
     for (int i = 0; i < n; i++) {
+        /* A failed read leaves vals[i] == 0, but that is not an on-CPU
+         * observation. Exclude it before the we==0 policy or any other
+         * classification so read failures cannot fabricate active demand. */
+        if (!valid || !valid[i])
+            continue;
+
         uint32_t we = vals[i];
 
         /* event 0 == on CPU. T2 (AAS-1): a session on CPU IS an active
@@ -274,6 +292,23 @@ int pgwt_sampler_build_batch(const struct pgwt_sample_target *targets,
         e->query_id     = targets[i].query_id;
     }
     return count;
+}
+
+void pgwt_sampler_note_coverage(struct pgwt_sampler *s, int targets, int valid)
+{
+    if (!s)
+        return;
+    if (targets < 0)
+        targets = 0;
+    if (valid < 0)
+        valid = 0;
+    if (valid > targets)
+        valid = targets;
+
+    s->read_targets_last = (uint32_t)targets;
+    s->read_valid_last = (uint32_t)valid;
+    s->read_invalid_last = (uint32_t)(targets - valid);
+    s->read_failures_total += s->read_invalid_last;
 }
 
 uint64_t pgwt_sampler_effective_period(uint64_t nominal_ns,
@@ -514,11 +549,14 @@ int pgwt_sampler_start(struct pgwt_daemon *d)
     }
 
     s->read_vals = calloc(MAX_BACKENDS, sizeof(*s->read_vals));
+    s->read_valid = calloc(MAX_BACKENDS, sizeof(*s->read_valid));
     s->samples   = calloc(MAX_BACKENDS, sizeof(*s->samples));
     s->qid_keys  = calloc(s->qid_cap, sizeof(*s->qid_keys));
     s->qid_vals  = calloc(s->qid_cap, sizeof(*s->qid_vals));
-    if (!s->read_vals || !s->samples || !s->qid_keys || !s->qid_vals) {
+    if (!s->read_vals || !s->read_valid || !s->samples || !s->qid_keys
+        || !s->qid_vals) {
         free(s->read_vals);
+        free(s->read_valid);
         free(s->samples);
         free(s->qid_keys);
         free(s->qid_vals);
@@ -540,6 +578,7 @@ int pgwt_sampler_stop(struct pgwt_daemon *d)
     if (!s)
         return 0;
     free(s->read_vals);
+    free(s->read_valid);
     free(s->samples);
     free(s->qid_keys);
     free(s->qid_vals);
@@ -750,14 +789,18 @@ int pgwt_sampler_poll(struct pgwt_daemon *d)
         }
         n++;
     }
-    if (n == 0)
+    if (n == 0) {
+        pgwt_sampler_note_coverage(s, 0, 0);
         return 0;
+    }
 
     uint64_t faults_before = s->read_faults_total;
     errno = 0;
     int got = pgwt_sampler_read_targets(targets, n, s->read_vals,
+                                        s->read_valid,
                                         &s->read_faults_total);
     int read_errno = errno;
+    pgwt_sampler_note_coverage(s, n, got);
     d->counters.sample_read_faults_total +=
         (s->read_faults_total - faults_before);
 
@@ -790,7 +833,8 @@ int pgwt_sampler_poll(struct pgwt_daemon *d)
      * is not an instrumented idle wait (IoWorkerMain) — i.e. on-CPU or a
      * real wait like IO:DataFileRead. */
     for (int i = 0; i < n; i++) {
-        if (targets[i].backend_type != PGWT_BT_IO_WORKER)
+        if (!s->read_valid[i]
+            || targets[i].backend_type != PGWT_BT_IO_WORKER)
             continue;
         d->counters.io_worker_samples_total++;
         uint32_t we = s->read_vals[i];
@@ -811,7 +855,8 @@ int pgwt_sampler_poll(struct pgwt_daemon *d)
      * query_id the edge-uprobe likewise missed. */
     if (d->debug_query_string_addr) {
         for (int i = 0; i < n; i++) {
-            if (s->read_vals[i] != 0 || targets[i].cmd_open)
+            if (!s->read_valid[i] || s->read_vals[i] != 0
+                || targets[i].cmd_open)
                 continue;   /* not on-CPU, or the edge already caught it */
             if (targets[i].backend_type != PGWT_BT_CLIENT
                 && targets[i].backend_type != PGWT_BT_UNKNOWN)
@@ -830,8 +875,8 @@ int pgwt_sampler_poll(struct pgwt_daemon *d)
     }
 
     uint64_t invalid_before = d->counters.invalid_wait_reads_total;
-    int count = pgwt_sampler_build_batch(targets, s->read_vals, n, tick_ts,
-                                         s->samples,
+    int count = pgwt_sampler_build_batch(targets, s->read_vals, s->read_valid,
+                                         n, tick_ts, s->samples,
                                          &d->counters.invalid_wait_reads_total,
                                          &d->counters.noncmd_cpu_samples_total);
     if (d->counters.invalid_wait_reads_total != invalid_before
@@ -872,6 +917,10 @@ void pgwt_sampler_metrics(struct pgwt_daemon *d, struct pgwt_metrics *m)
     if (d->sampler) {
         m->samples_total      = d->sampler->samples_total;
         m->sample_read_faults = d->sampler->read_faults_total;
+        m->sample_read_failures_total = d->sampler->read_failures_total;
+        m->sample_read_targets = d->sampler->read_targets_last;
+        m->sample_read_valid = d->sampler->read_valid_last;
+        m->sample_read_invalid = d->sampler->read_invalid_last;
     }
 }
 

--- a/src/sampler.h
+++ b/src/sampler.h
@@ -90,6 +90,7 @@ struct pgwt_sampler {
 
     /* Scratch buffers sized for MAX_BACKENDS, allocated once. */
     uint32_t     *read_vals;     /* MAX_BACKENDS — wait_event_info per target */
+    uint8_t      *read_valid;    /* MAX_BACKENDS — 1 only after a successful read */
     struct pgwt_trace_event *samples; /* MAX_BACKENDS — encoded batch */
 
     /* Batched pid->query_id join scratch (SMP-4). qid_cap entries. */
@@ -100,8 +101,16 @@ struct pgwt_sampler {
 
     struct pgwt_sampler_health health;   /* SMP-1 */
 
+    /* Per-tick read coverage. Stage 3 consumes this to decide whether a tick
+     * has enough sampler coverage to advance its detector; this stage only
+     * produces and exposes it. */
+    uint32_t read_targets_last;
+    uint32_t read_valid_last;
+    uint32_t read_invalid_last;
+
     uint64_t samples_total;       /* cumulative SAMPLES records written */
     uint64_t read_faults_total;   /* per-pid pread fallbacks taken */
+    uint64_t read_failures_total; /* targets with no successful read */
 };
 
 /* Provider hooks (see provider.h). Exposed for the vtable in sampler.c. */
@@ -116,13 +125,15 @@ void pgwt_sampler_metrics(struct pgwt_daemon *d, struct pgwt_metrics *m);
  * is_shared are read in one batched process_vm_readv() sweep (per-pid pread
  * fallback for entries that fault); all other targets are read individually
  * via pread(/proc/<pid>/mem) — NEVER through another pid (SMP-2). Writes
- * results into out_vals[i] (0 left in place for entries that could not be
- * read). read_faults (may be NULL) is incremented once per pread fallback
- * taken in the batched sweep. Returns the number of entries successfully
- * read; errno is left at the last failing syscall's value when the return
- * is short. */
+ * results into out_vals[i] and sets out_valid[i] to 1 only when that target
+ * was read successfully. A successful value of 0 is therefore distinct from
+ * an unread target, whose value remains 0 and validity remains 0. read_faults
+ * (may be NULL) is incremented once per pread fallback taken in the batched
+ * sweep. Returns the number of entries successfully read; errno is left at
+ * the last failing syscall's value when the return is short. */
 int pgwt_sampler_read_targets(const struct pgwt_sample_target *targets, int n,
-                              uint32_t *out_vals, uint64_t *read_faults);
+                              uint32_t *out_vals, uint8_t *out_valid,
+                              uint64_t *read_faults);
 
 /* Build the SAMPLES batch from targets + their freshly-read values.
  *
@@ -143,15 +154,22 @@ int pgwt_sampler_read_targets(const struct pgwt_sample_target *targets, int n,
  * — the anomaly engine and the live accumulator consume them (io_worker
  * records must not enter AAS/DB Time).
  *
- * A value with an INVALID class byte (CAP-2/5: garbage from a wrong offset)
- * is skipped and counted in *invalid_reads (may be NULL) — garbage must
- * never be recorded as data. `tick_ts` is the sample timestamp stamped on
- * every record. Returns the number of sample records written into out. */
+ * A target whose valid[i] is 0 is skipped before any CPU/wait classification.
+ * A valid value with an INVALID class byte (CAP-2/5: garbage from a wrong
+ * offset) is skipped and counted in *invalid_reads (may be NULL) — garbage
+ * must never be recorded as data. `tick_ts` is the sample timestamp stamped
+ * on every record. Returns the number of sample records written into out. */
 int pgwt_sampler_build_batch(const struct pgwt_sample_target *targets,
-                             const uint32_t *vals, int n, uint64_t tick_ts,
+                             const uint32_t *vals, const uint8_t *valid,
+                             int n, uint64_t tick_ts,
                              struct pgwt_trace_event *out,
                              uint64_t *invalid_reads,
                              uint64_t *noncmd_cpu_skipped);
+
+/* Record one tick's target-level read coverage. Counts are clamped to a
+ * coherent 0 <= valid <= targets range; each invalid target contributes once
+ * to read_failures_total. Pure and exposed for the sampler unit harness. */
+void pgwt_sampler_note_coverage(struct pgwt_sampler *s, int targets, int valid);
 
 /* T2: category flag (PGWT_EVENT_FLAG_*) for a backend type, and the we==0
  * recording policy. Pure helpers shared by the sampler and the server-side

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -90,7 +90,7 @@ test_trace_v2: test_trace_v2.c $(BUILD)/server_event_writer.o \
 # test_sampler: sampler core (process_vm_readv read + batch encode + per-pid
 # fallback). Compiles sampler.c with -DPGWT_SERVER so only the BPF-free core
 # is built — no skeleton, no bpftool, runnable in CI's server-only jobs.
-test_sampler: test_sampler.c ../src/sampler.c
+test_sampler: test_sampler.c ../src/sampler.c ../src/anomaly.c
 	$(CC) $(CFLAGS) -DPGWT_SERVER -o $@ $^
 
 # test_anomaly: anomaly rule engine (AAS-vs-baseline, lock-fraction,

--- a/tests/test_sampler.c
+++ b/tests/test_sampler.c
@@ -19,6 +19,7 @@
  */
 #define _GNU_SOURCE
 #include "sampler.h"
+#include "anomaly.h"
 #include "pg_wait_tracer.h"
 
 #include <stdio.h>
@@ -59,13 +60,16 @@ static void test_self_read(void)
     };
 
     uint32_t vals[3] = { 0xdead, 0xdead, 0xdead };
+    uint8_t valid[3] = { 0, 0, 0 };
     uint64_t faults = 0;
-    int got = pgwt_sampler_read_targets(targets, 3, vals, &faults);
+    int got = pgwt_sampler_read_targets(targets, 3, vals, valid, &faults);
 
     CHECK(got == 3, "expected 3 reads, got %d", got);
     CHECK(vals[0] == v0, "vals[0]=0x%x expected 0x%x", vals[0], v0);
     CHECK(vals[1] == 0,  "vals[1]=0x%x expected 0", vals[1]);
     CHECK(vals[2] == v2, "vals[2]=0x%x expected 0x%x", vals[2], v2);
+    CHECK(valid[0] && valid[1] && valid[2],
+          "all three successful reads are marked valid");
     CHECK(faults == 0, "expected no fallback faults, got %llu",
           (unsigned long long)faults);
 }
@@ -91,12 +95,14 @@ static void test_build_batch(void)
         0,                       /* on CPU, no command — skipped + counted */
         WEI(PG_WAIT_LWLOCK, 0x07),
     };
+    uint8_t valid[3] = { 1, 1, 1 };
 
     struct pgwt_trace_event out[3];
     memset(out, 0xAA, sizeof(out));
     uint64_t ts = 0x123456789ABCULL;
     uint64_t noncmd = 0;
-    int n = pgwt_sampler_build_batch(targets, vals, 3, ts, out, NULL, &noncmd);
+    int n = pgwt_sampler_build_batch(targets, vals, valid, 3, ts, out,
+                                     NULL, &noncmd);
 
     CHECK(n == 2, "expected 2 records (1 non-command on-CPU skipped), got %d", n);
     CHECK(noncmd == 1, "expected 1 non-command CPU skip counted, got %llu",
@@ -143,10 +149,12 @@ static void test_build_batch_cpu_policy(void)
         { .pid = 6, .backend_type = PGWT_BT_PARALLEL_WORKER },
     };
     uint32_t vals[6] = { 0, 0, 0, 0, 0, 0 };
+    uint8_t valid[6] = { 1, 1, 1, 1, 1, 1 };
 
     struct pgwt_trace_event out[6];
     uint64_t noncmd = 0;
-    int n = pgwt_sampler_build_batch(targets, vals, 6, 7, out, NULL, &noncmd);
+    int n = pgwt_sampler_build_batch(targets, vals, valid, 6, 7, out,
+                                     NULL, &noncmd);
 
     CHECK(n == 5, "expected 5 CPU records (1 gated out), got %d", n);
     CHECK(noncmd == 1, "expected 1 gated skip, got %llu",
@@ -171,7 +179,8 @@ static void test_build_batch_cpu_policy(void)
     uint32_t wvals[6] = { WEI(PG_WAIT_IO, 1), WEI(PG_WAIT_IO, 1),
                           WEI(PG_WAIT_IO, 1), WEI(PG_WAIT_IO, 1),
                           WEI(PG_WAIT_IO, 1), WEI(PG_WAIT_IO, 1) };
-    n = pgwt_sampler_build_batch(targets, wvals, 6, 8, out, NULL, NULL);
+    n = pgwt_sampler_build_batch(targets, wvals, valid, 6, 8, out,
+                                 NULL, NULL);
     CHECK(n == 6, "all wait readings recorded, got %d", n);
     CHECK(out[4].flags == PGWT_EVENT_FLAG_IO_WORKER,
           "io_worker WAIT sample flagged IO_WORKER");
@@ -182,10 +191,13 @@ static void test_build_batch_cpu_policy(void)
     struct pgwt_sample_target unk = { .pid = 9,
                                       .backend_type = PGWT_BT_UNKNOWN };
     uint32_t zero = 0;
-    n = pgwt_sampler_build_batch(&unk, &zero, 1, 9, out, NULL, NULL);
+    uint8_t valid_one = 1;
+    n = pgwt_sampler_build_batch(&unk, &zero, &valid_one, 1, 9, out,
+                                 NULL, NULL);
     CHECK(n == 0, "UNKNOWN type we==0 is gated (command closed)");
     unk.cmd_open = 1;
-    n = pgwt_sampler_build_batch(&unk, &zero, 1, 9, out, NULL, NULL);
+    n = pgwt_sampler_build_batch(&unk, &zero, &valid_one, 1, 9, out,
+                                 NULL, NULL);
     CHECK(n == 1, "UNKNOWN type we==0 records when command open");
 }
 
@@ -205,10 +217,12 @@ static void test_build_batch_garbage(void)
         0xDEADBEEFu,              /* garbage class 0xDE — dropped + counted */
         0x7F000001u,              /* garbage class 0x7F — dropped + counted */
     };
+    uint8_t valid[3] = { 1, 1, 1 };
 
     struct pgwt_trace_event out[3];
     uint64_t invalid = 0;
-    int n = pgwt_sampler_build_batch(targets, vals, 3, 1, out, &invalid, NULL);
+    int n = pgwt_sampler_build_batch(targets, vals, valid, 3, 1, out,
+                                     &invalid, NULL);
 
     CHECK(n == 1, "expected 1 record (2 garbage dropped), got %d", n);
     CHECK(out[0].pid == 2001, "the valid record survived");
@@ -216,7 +230,7 @@ static void test_build_batch_garbage(void)
           (unsigned long long)invalid);
 
     /* NULL counter must not crash and must still drop garbage. */
-    n = pgwt_sampler_build_batch(targets, vals, 3, 1, out, NULL, NULL);
+    n = pgwt_sampler_build_batch(targets, vals, valid, 3, 1, out, NULL, NULL);
     CHECK(n == 1, "NULL invalid counter: still 1 record, got %d", n);
 }
 
@@ -243,14 +257,95 @@ static void test_fallback(void)
     };
 
     uint32_t vals[2] = { 0xdead, 0xdead };
+    uint8_t valid[2] = { 1, 1 };
     uint64_t faults = 0;
-    int got = pgwt_sampler_read_targets(targets, 2, vals, &faults);
+    int got = pgwt_sampler_read_targets(targets, 2, vals, valid, &faults);
 
     /* The good entry must be recovered via pread even though entry 0 faulted. */
     CHECK(vals[1] == good, "fallback vals[1]=0x%x expected 0x%x", vals[1], good);
+    CHECK(valid[0] == 0, "faulting entry is marked invalid");
+    CHECK(valid[1] == 1, "recovered entry is marked valid");
     CHECK(got >= 1, "expected at least the good entry recovered, got %d", got);
     CHECK(faults >= 1, "expected >=1 fallback fault recorded, got %llu",
           (unsigned long long)faults);
+}
+
+/* ── AAS-1 Stage 1: read validity, coverage, and classification ───────── */
+
+static void test_read_validity_excludes_failures(void)
+{
+    printf("--- AAS-1: failed reads cannot fabricate CPU samples ---\n");
+
+    volatile uint32_t cpu = 0;
+    volatile uint32_t wait = WEI(PG_WAIT_IO, 0x33);
+    void *bad = mmap(NULL, 4096, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS,
+                     -1, 0);
+    CHECK(bad != MAP_FAILED, "mmap PROT_NONE failed");
+    if (bad == MAP_FAILED)
+        return;
+    munmap(bad, 4096);
+
+    struct pgwt_sample_target targets[4] = {
+        /* Failed shared-batch read. If its invalid zero reaches build_batch,
+         * this command-open client is incorrectly fabricated as CPU. */
+        { .pid = getpid(), .wait_event_addr = (uint64_t)(uintptr_t)bad,
+          .query_id = 10, .is_shared = 1, .backend_type = PGWT_BT_CLIENT,
+          .cmd_open = 1 },
+        /* A real successful zero must remain a CPU sample. */
+        { .pid = getpid(), .wait_event_addr = (uint64_t)(uintptr_t)&cpu,
+          .query_id = 20, .is_shared = 1, .backend_type = PGWT_BT_CLIENT,
+          .cmd_open = 1 },
+        /* A successful wait must retain its normal classification. */
+        { .pid = getpid(), .wait_event_addr = (uint64_t)(uintptr_t)&wait,
+          .query_id = 30, .is_shared = 1, .backend_type = PGWT_BT_CLIENT },
+        /* No address on the per-pid path is independently invalid. */
+        { .pid = getpid(), .wait_event_addr = 0, .query_id = 40,
+          .is_shared = 0, .backend_type = PGWT_BT_CLIENT, .cmd_open = 1 },
+    };
+    uint32_t vals[4] = { 0xdead, 0xdead, 0xdead, 0xdead };
+    uint8_t valid[4] = { 1, 1, 1, 1 };
+    uint64_t faults = 0;
+
+    int got = pgwt_sampler_read_targets(targets, 4, vals, valid, &faults);
+    CHECK(got == 2, "mixed read got %d valid targets, expected 2", got);
+    CHECK(valid[0] == 0 && valid[1] == 1 && valid[2] == 1
+              && valid[3] == 0,
+          "validity bitmap distinguishes failures from successful zero/wait");
+    CHECK(vals[0] == 0 && vals[1] == 0 && vals[2] == wait && vals[3] == 0,
+          "failed reads stay zero but are distinguishable by validity");
+
+    struct pgwt_sampler sampler;
+    memset(&sampler, 0, sizeof(sampler));
+    pgwt_sampler_note_coverage(&sampler, 4, got);
+    CHECK(sampler.read_targets_last == 4, "coverage targets=4");
+    CHECK(sampler.read_valid_last == 2, "coverage valid=2");
+    CHECK(sampler.read_invalid_last == 2, "coverage invalid=2");
+    CHECK(sampler.read_failures_total == 2,
+          "cumulative read failures=2 after one mixed tick");
+
+    struct pgwt_trace_event out[4];
+    memset(out, 0xAA, sizeof(out));
+    int n = pgwt_sampler_build_batch(targets, vals, valid, 4, 99, out,
+                                     NULL, NULL);
+    CHECK(n == 2, "only 2 valid targets classified, got %d", n);
+    CHECK(out[0].pid == (uint32_t)getpid() && out[0].new_event == 0
+              && out[0].query_id == 20,
+          "successful zero remains a command-open CPU sample");
+    CHECK(out[1].pid == (uint32_t)getpid() && out[1].new_event == wait
+              && out[1].query_id == 30,
+          "successful wait remains classified and attributed");
+
+    int cpu_samples = 0;
+    for (int i = 0; i < n; i++)
+        if (out[i].new_event == 0)
+            cpu_samples++;
+    CHECK(cpu_samples == 1,
+          "exactly one CPU sample: failed reads add no CPU-class demand");
+
+    double aas = -1.0, lock_fraction = -1.0;
+    pgwt_anomaly_metrics_from_batch(out, n, &aas, &lock_fraction);
+    CHECK(aas == 2.0,
+          "AAS includes only valid CPU+wait targets (%.1f expected 2.0)", aas);
 }
 
 /* ── Test 4: child process read (cross-pid, shared mapping) ───────────── */
@@ -294,10 +389,12 @@ static void test_child_read(void)
         { .pid = child, .wait_event_addr = child_addr, .query_id = 7, .is_shared = 1 },
     };
     uint32_t vals[1] = { 0xdead };
+    uint8_t valid[1] = { 0 };
     uint64_t faults = 0;
-    int got = pgwt_sampler_read_targets(targets, 1, vals, &faults);
+    int got = pgwt_sampler_read_targets(targets, 1, vals, valid, &faults);
 
     CHECK(got == 1, "expected to read child value, got %d", got);
+    CHECK(valid[0] == 1, "successful child read marked valid");
     CHECK(vals[0] == WEI(PG_WAIT_IPC, 0x42),
           "child vals[0]=0x%x expected 0x%x", vals[0], WEI(PG_WAIT_IPC, 0x42));
 
@@ -358,9 +455,12 @@ static void test_local_addr_not_batched(void)
           .wait_event_addr = (uint64_t)(uintptr_t)&smp2_local_slot },
     };
     uint32_t vals[2] = { 0xdead, 0xdead };
-    int got = pgwt_sampler_read_targets(targets, 2, vals, NULL);
+    uint8_t valid[2] = { 0, 0 };
+    int got = pgwt_sampler_read_targets(targets, 2, vals, valid, NULL);
 
     CHECK(got == 2, "expected both targets read, got %d", got);
+    CHECK(valid[0] == 1 && valid[1] == 1,
+          "both shared and per-pid reads marked valid");
     CHECK(vals[0] == parent_val, "parent slot = 0x%x expected 0x%x",
           vals[0], parent_val);
     CHECK(vals[1] == child_val,
@@ -488,6 +588,7 @@ int main(void)
     test_build_batch_garbage();
     test_build_batch_cpu_policy();
     test_fallback();
+    test_read_validity_excludes_failures();
     test_child_read();
     test_local_addr_not_batched();
     test_health();


### PR DESCRIPTION
## Summary

- thread a parallel per-target `uint8_t` validity buffer from sampler reads into batch construction
- exclude failed reads before CPU policy, wait classification, io-worker utilization, and command-gate recovery
- expose latest-tick read coverage (`targets`, `valid`, `invalid`, percentage) and cumulative target read failures while preserving the existing fallback-fault counter
- add deterministic mixed-path coverage and AAS assertions to the sampler unit harness

## Root cause

`pgwt_sampler_read_targets` initialized unread targets to zero without identifying which reads failed. `pgwt_sampler_build_batch` then interpreted those zeros as successful on-CPU observations for command-open clients and most background processes, fabricating CPU-class demand and inflating AAS.

## Impact

A target contributes a sample only after its wait-event read succeeds. A successful read of zero still follows the existing CPU policy, while all successful wait classification, garbage rejection, idle handling, query-id gating, and emitted sample encoding remain unchanged.

This PR is scoped to Stage 1 read validity. It does not add the effective-core resolver, CUSUM detector, or escalation-policy changes planned for Stages 2 and 3.

## Validation

- `make BPFTOOL=/tmp/bpftool/src/bpftool`
- `make -C tests check`
- focused `test_sampler`: 98/98 checks passed
- existing `test_anomaly`: 97/97 checks passed

No local PostgreSQL or tracer process was run.
