### PR TITLE
Add CPU-demand CUSUM saturation escalation

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,12 +178,18 @@ A full-fidelity window can be opened two ways:
   backend's routine row-lock wait — a lock-fraction of 1.0 over an AAS of 1 —
   from burning a whole window on OLTP noise; a genuine lock convoy still fires.
   Independently, a CPU-demand CUSUM detects sustained demand near the target
-  postmaster's effective CPU capacity: `S=max(0,S+dt*(min(cpu_AAS/C,cap)-k))`
-  fires at `S>=h` (defaults `k=0.80`, `h=1.50`, `cap=1.25`). `dt` is the
-  nominal sample period, so a delayed tick cannot fabricate evidence. Failed
-  read coverage and unknown capacity never advance it; a material capacity
-  change resets it. CPU fires have the distinct `cpu_saturation` escalation
-  reason and use the same window, cooldown, and budget path.
+  postmaster's effective CPU capacity:
+  `S=max(0,S+dt*(min(cpu_AAS/C,cap)-(k+margin)))` fires at `S>=h` only when
+  `cpu_AAS>=cpu_min_aas` (defaults `k=0.80`, affinity-only `margin=0.02`,
+  `cpu_min_aas=2.0`, `h=1.50`, `cap=1.25`). Quota and explicit override
+  capacities use zero margin. `dt` is the nominal sample period, so a delayed
+  tick cannot fabricate evidence. Failed read coverage and unknown capacity
+  never advance it; a material capacity change or return from a partial-read
+  gap resets it. Each continuous saturation episode fires once, then re-arms
+  only after a complete, capacity-known tick falls below `k`. CPU fires have
+  the distinct `cpu_saturation` escalation reason and use the same window,
+  cooldown, and budget path. If discovered capacity is known to be uncertain,
+  set the deployment's known value with `--anomaly-cpu-capacity`.
   A cooldown (`--anomaly-cooldown-s`, default 120) prevents flapping.
 
 The rolling AAS baseline is **frozen while a metric is anomalous** so a
@@ -500,7 +506,9 @@ Auto-escalation rules evaluated on the sampled stream. Ignored outside
 | `--anomaly-lock-min-aas <A>` | — | `2.0` | ...**and** absolute Lock-class AAS ≥ A (min-activity floor: a lone lock waiter can't escalate) |
 | `--anomaly-cooldown-s <S>` | — | `120` | Minimum seconds between auto-escalations |
 | `--anomaly-window-s <S>` | — | `60` | Full-fidelity window length per auto-trigger |
-| `--anomaly-cpu-capacity <C>` | — | discovered | Override target effective logical CPU capacity |
+| `--anomaly-cpu-capacity <C>` | — | discovered | Override target effective logical CPU capacity; use when discovery is known to misrepresent backend capacity |
+| `--anomaly-cpu-min-aas <A>` | — | `2.0` | Absolute CPU-class AAS required for a CPU CUSUM fire |
+| `--anomaly-cpu-margin <M>` | — | `0.02` | Extra utilization slack for affinity-only capacity; quota and override capacity use zero margin |
 | `--anomaly-cpu-cusum-k <K>` | — | `0.80` | CPU-demand CUSUM slack/reference utilization |
 | `--anomaly-cpu-cusum-h <H>` | — | `1.50` | CPU-demand CUSUM fire threshold |
 | `--anomaly-cpu-cusum-cap <U>` | — | `1.25` | Cap `cpu_AAS / effective_capacity` per tick |

--- a/README.md
+++ b/README.md
@@ -177,6 +177,13 @@ A full-fidelity window can be opened two ways:
   `--anomaly-lock-min-aas` (default 2.0). The lock floor stops a single
   backend's routine row-lock wait — a lock-fraction of 1.0 over an AAS of 1 —
   from burning a whole window on OLTP noise; a genuine lock convoy still fires.
+  Independently, a CPU-demand CUSUM detects sustained demand near the target
+  postmaster's effective CPU capacity: `S=max(0,S+dt*(min(cpu_AAS/C,cap)-k))`
+  fires at `S>=h` (defaults `k=0.80`, `h=1.50`, `cap=1.25`). `dt` is the
+  nominal sample period, so a delayed tick cannot fabricate evidence. Failed
+  read coverage and unknown capacity never advance it; a material capacity
+  change resets it. CPU fires have the distinct `cpu_saturation` escalation
+  reason and use the same window, cooldown, and budget path.
   A cooldown (`--anomaly-cooldown-s`, default 120) prevents flapping.
 
 The rolling AAS baseline is **frozen while a metric is anomalous** so a
@@ -493,6 +500,15 @@ Auto-escalation rules evaluated on the sampled stream. Ignored outside
 | `--anomaly-lock-min-aas <A>` | — | `2.0` | ...**and** absolute Lock-class AAS ≥ A (min-activity floor: a lone lock waiter can't escalate) |
 | `--anomaly-cooldown-s <S>` | — | `120` | Minimum seconds between auto-escalations |
 | `--anomaly-window-s <S>` | — | `60` | Full-fidelity window length per auto-trigger |
+| `--anomaly-cpu-capacity <C>` | — | discovered | Override target effective logical CPU capacity |
+| `--anomaly-cpu-cusum-k <K>` | — | `0.80` | CPU-demand CUSUM slack/reference utilization |
+| `--anomaly-cpu-cusum-h <H>` | — | `1.50` | CPU-demand CUSUM fire threshold |
+| `--anomaly-cpu-cusum-cap <U>` | — | `1.25` | Cap `cpu_AAS / effective_capacity` per tick |
+| `--anomaly-cpu-cusum-disable` | — | off | Disable only the CPU saturation guard |
+
+For compatibility with existing pure-sampled and manual-window deployments,
+`--anomaly-aas-factor 1000000` (or larger) disables both the multiplicative AAS
+rule and the CPU saturation guard. The lock rule retains its own configuration.
 
 ### Performance Tuning
 

--- a/src/anomaly.c
+++ b/src/anomaly.c
@@ -1,10 +1,11 @@
 /* anomaly.c — Anomaly-triggered escalation rules (Track A, D5 / Phase A5)
  *
- * See anomaly.h for the design. The pure rule core (pgwt_anomaly_eval and
- * pgwt_anomaly_metrics_from_batch) is free of BPF and the escalation engine so
- * the unit test (tests/test_anomaly.c) can drive it with scripted sample
- * streams. The daemon-side wrapper (pgwt_anomaly_tick) connects the FIRE
- * decision to A4's pgwt_escalate() and logs every near-trigger.
+ * See anomaly.h for the design. The pure rule core
+ * (pgwt_anomaly_eval_observation and pgwt_anomaly_metrics_from_batch) is free
+ * of BPF and the escalation engine so the unit test (tests/test_anomaly.c) can
+ * drive it with scripted sample streams. The daemon-side wrapper
+ * (pgwt_anomaly_tick) connects the FIRE decision to A4's pgwt_escalate() and
+ * logs every near-trigger.
  *
  * The pure core is compiled into both the daemon and (via -DPGWT_SERVER) the
  * unit test; the daemon wrapper is guarded out of the server build.
@@ -30,10 +31,12 @@ static bool sample_is_idle(uint32_t wei)
 
 void pgwt_anomaly_metrics_from_batch(const struct pgwt_trace_event *samples,
                                      int n, double *out_aas,
-                                     double *out_lock_fraction)
+                                     double *out_lock_fraction,
+                                     double *out_cpu_aas)
 {
     int active = 0;
     int locks = 0;
+    int cpu = 0;
     for (int i = 0; i < n; i++) {
         uint32_t we = samples[i].new_event;
         /* T2 (AAS-1): the decomposed model. we==0 records in the batch are
@@ -48,6 +51,8 @@ void pgwt_anomaly_metrics_from_batch(const struct pgwt_trace_event *samples,
         if (we != 0 && sample_is_idle(we))
             continue;   /* instrumented idle: not an active session */
         active++;
+        if (we == 0)
+            cpu++;
         if (WE_CLASS(we) == PG_WAIT_LOCK)
             locks++;
     }
@@ -55,6 +60,8 @@ void pgwt_anomaly_metrics_from_batch(const struct pgwt_trace_event *samples,
         *out_aas = (double)active;
     if (out_lock_fraction)
         *out_lock_fraction = active > 0 ? (double)locks / (double)active : 0.0;
+    if (out_cpu_aas)
+        *out_cpu_aas = (double)cpu;
 }
 
 void pgwt_anomaly_init(struct pgwt_anomaly *a, bool enabled,
@@ -69,6 +76,10 @@ void pgwt_anomaly_init(struct pgwt_anomaly *a, bool enabled,
     a->lock_ticks    = PGWT_ANOMALY_DEF_LOCK_TICKS;
     a->cooldown_ns   = (uint64_t)PGWT_ANOMALY_DEF_COOLDOWN_S * 1000000000ULL;
     a->escalation_s  = PGWT_ANOMALY_DEF_ESCALATE_S;
+    a->cpu_cusum_enabled = true;
+    a->cpu_cusum_k   = PGWT_ANOMALY_DEF_CPU_CUSUM_K;
+    a->cpu_cusum_h   = PGWT_ANOMALY_DEF_CPU_CUSUM_H;
+    a->cpu_cusum_cap = PGWT_ANOMALY_DEF_CPU_CUSUM_CAP;
     a->slow_release_div = PGWT_ANOMALY_DEF_SLOW_RELEASE_DIV;
 
     /* Baseline EWMA: pick alpha so the baseline has roughly a 60-second
@@ -76,6 +87,7 @@ void pgwt_anomaly_init(struct pgwt_anomaly *a, bool enabled,
      * of H ticks needs alpha = 1 - 2^(-1/H); approximate with alpha ~ 1/H for
      * the small-alpha regime. H = 60s * rate. Warm up over ~5s of ticks. */
     int hz = sample_rate_hz > 0 ? sample_rate_hz : 10;
+    a->sample_period_s = 1.0 / (double)hz;
     double half_life_ticks = 60.0 * (double)hz;
     if (half_life_ticks < 1.0)
         half_life_ticks = 1.0;
@@ -93,23 +105,65 @@ void pgwt_anomaly_init(struct pgwt_anomaly *a, bool enabled,
 }
 
 struct pgwt_anomaly_decision
-pgwt_anomaly_eval(struct pgwt_anomaly *a, double aas, double lock_fraction,
-                  uint64_t now_ns)
+pgwt_anomaly_eval_observation(struct pgwt_anomaly *a,
+                              const struct pgwt_anomaly_observation *obs,
+                              uint64_t now_ns)
 {
     struct pgwt_anomaly_decision d;
     memset(&d, 0, sizeof(d));
     d.action        = PGWT_ANOMALY_NONE;
-    d.aas           = aas;
-    d.lock_fraction = lock_fraction;
+    d.aas           = obs->aas;
+    d.lock_fraction = obs->lock_fraction;
+    d.cpu_aas       = obs->cpu_aas;
+    d.cpu_capacity  = obs->cpu_capacity;
+    d.cpu_cusum     = a->cpu_cusum;
     d.baseline      = a->baseline_aas;
 
     if (!a->enabled)
         return d;
 
+    double aas = obs->aas;
+    double lock_fraction = obs->lock_fraction;
+
+    /* Cooldown remains wall-clock based. CPU evidence does not: it uses the
+     * nominal sample period below, so one delayed sampler callback is still
+     * exactly one observation rather than several seconds of evidence. */
+    bool in_cooldown = a->last_fire_ns != 0
+                    && now_ns - a->last_fire_ns < a->cooldown_ns;
+
+    /* ── CPU-demand saturation CUSUM ───────────────────────────────────── */
+    bool cpu_rule_enabled = a->cpu_cusum_enabled
+                         && a->aas_factor < PGWT_ANOMALY_DISABLE_AAS_FACTOR;
+    bool cpu_fire = false;
+
+    /* A capacity discontinuity invalidates all evidence accumulated in the
+     * old units. An open escalation window or cooldown also clears evidence:
+     * this prevents a manual/other-rule window from banking an almost-fire
+     * that would immediately consume another budget grant when it closes. */
+    if (obs->cpu_capacity_changed || obs->cpu_guard_blocked || in_cooldown) {
+        a->cpu_cusum = 0.0;
+    } else if (!cpu_rule_enabled) {
+        a->cpu_cusum = 0.0;
+    } else if (obs->cpu_coverage_ok && obs->cpu_capacity > 0.0) {
+        double u = obs->cpu_aas / obs->cpu_capacity;
+        if (u < 0.0)
+            u = 0.0;
+        if (u > a->cpu_cusum_cap)
+            u = a->cpu_cusum_cap;
+        a->cpu_cusum += a->sample_period_s * (u - a->cpu_cusum_k);
+        if (a->cpu_cusum < 0.0)
+            a->cpu_cusum = 0.0;
+        cpu_fire = a->cpu_cusum >= a->cpu_cusum_h;
+    }
+    /* LOW coverage and UNKNOWN capacity intentionally take neither branch:
+     * S is held unchanged and cannot fire from an untrusted observation. */
+    d.cpu_cusum = a->cpu_cusum;
+
     /* ── AAS-vs-baseline rule ──────────────────────────────────────────── */
     bool baseline_warm = a->baseline_warmup >= a->warmup_needed;
     bool aas_over = false;
-    if (baseline_warm && a->aas_factor > 0.0) {
+    if (baseline_warm && a->aas_factor > 0.0
+        && a->aas_factor < PGWT_ANOMALY_DISABLE_AAS_FACTOR) {
         double threshold = a->aas_factor * a->baseline_aas;
         /* Guard against a near-zero baseline: a tiny absolute AAS over a
          * 0-ish baseline is noise, not an incident. Require at least 2 active
@@ -164,7 +218,7 @@ pgwt_anomaly_eval(struct pgwt_anomaly *a, double aas, double lock_fraction,
     d.baseline = a->baseline_aas;
 
     /* ── Decision ──────────────────────────────────────────────────────── */
-    if (!aas_fire && !lock_fire) {
+    if (!aas_fire && !lock_fire && !cpu_fire) {
         /* Surface a near-trigger if a metric crossed but did not sustain. */
         unsigned near = PGWT_NEAR_NONE;
         if (aas_over && !aas_fire)
@@ -183,9 +237,9 @@ pgwt_anomaly_eval(struct pgwt_anomaly *a, double aas, double lock_fraction,
 
     /* A rule wants to fire. Enforce cooldown (hysteresis against flapping). */
     unsigned fired = (aas_fire ? PGWT_RULE_AAS : 0)
-                   | (lock_fire ? PGWT_RULE_LOCK : 0);
-    if (a->last_fire_ns != 0 &&
-        now_ns - a->last_fire_ns < a->cooldown_ns) {
+                   | (lock_fire ? PGWT_RULE_LOCK : 0)
+                   | (cpu_fire ? PGWT_RULE_CPU_SATURATION : 0);
+    if (in_cooldown) {
         d.action = PGWT_ANOMALY_NEAR;
         d.near_mask = PGWT_NEAR_COOLDOWN;
         d.fired_mask = fired;   /* what WOULD have fired */
@@ -196,9 +250,28 @@ pgwt_anomaly_eval(struct pgwt_anomaly *a, double aas, double lock_fraction,
 
     d.action = PGWT_ANOMALY_FIRE;
     d.fired_mask = fired;
+    /* Never carry CPU evidence through any escalation, including a fire
+     * caused by another rule on the same tick. */
+    a->cpu_cusum = 0.0;
+    d.cpu_cusum = 0.0;
     a->last_fire_ns = now_ns;
     a->fires_total++;
+    if (fired & PGWT_RULE_CPU_SATURATION)
+        a->cpu_saturation_fires_total++;
     return d;
+}
+
+struct pgwt_anomaly_decision
+pgwt_anomaly_eval(struct pgwt_anomaly *a, double aas, double lock_fraction,
+                  uint64_t now_ns)
+{
+    const struct pgwt_anomaly_observation obs = {
+        .aas = aas,
+        .lock_fraction = lock_fraction,
+        .cpu_capacity = -1.0,
+        .cpu_coverage_ok = false,
+    };
+    return pgwt_anomaly_eval_observation(a, &obs, now_ns);
 }
 
 /* ── Daemon-side wrapper ──────────────────────────────────────────────── */
@@ -206,7 +279,9 @@ pgwt_anomaly_eval(struct pgwt_anomaly *a, double aas, double lock_fraction,
 #ifndef PGWT_SERVER
 
 #include "daemon.h"
+#include "effective_cores.h"
 #include "escalation.h"
+#include "sampler.h"
 
 #include <time.h>
 
@@ -224,6 +299,8 @@ static const char *rule_names(unsigned mask, char *buf, size_t len)
         snprintf(buf + strlen(buf), len - strlen(buf), "aas ");
     if (mask & PGWT_RULE_LOCK)
         snprintf(buf + strlen(buf), len - strlen(buf), "lock ");
+    if (mask & PGWT_RULE_CPU_SATURATION)
+        snprintf(buf + strlen(buf), len - strlen(buf), "cpu-saturation ");
     if (buf[0] == '\0')
         snprintf(buf, len, "(none)");
     return buf;
@@ -236,12 +313,35 @@ void pgwt_anomaly_tick(struct pgwt_daemon *d,
     if (!a->enabled)
         return;
 
-    double aas = 0.0, lock_fraction = 0.0;
-    pgwt_anomaly_metrics_from_batch(samples, n, &aas, &lock_fraction);
+    /* Stage 2 capacity is refreshed at the same cadence as CPU evidence.
+     * materially_changed is therefore consumed on the exact sampler tick that
+     * resets S, rather than being lost to the slower display timer. */
+    d->effective_cores = pgwt_effective_cores_refresh(
+        &d->cpu_capacity_resolver, d->postmaster_pid);
+
+    double aas = 0.0, lock_fraction = 0.0, cpu_aas = 0.0;
+    pgwt_anomaly_metrics_from_batch(samples, n, &aas, &lock_fraction,
+                                    &cpu_aas);
+
+    /* Complete read coverage is the conservative evidence boundary. Missing
+     * targets are omitted from the batch; holding S avoids treating that
+     * partial count as a trustworthy saturation observation. A legitimate
+     * empty registry (0 targets, 0 invalid) remains a valid zero-demand tick. */
+    bool coverage_ok = d->sampler == NULL
+                    || d->sampler->read_invalid_last == 0;
+    struct pgwt_anomaly_observation obs = {
+        .aas = aas,
+        .lock_fraction = lock_fraction,
+        .cpu_aas = cpu_aas,
+        .cpu_capacity = d->effective_cores.cores,
+        .cpu_coverage_ok = coverage_ok,
+        .cpu_capacity_changed = d->effective_cores.materially_changed,
+        .cpu_guard_blocked = d->escalation.active,
+    };
 
     uint64_t now = anomaly_mono_ns();
     struct pgwt_anomaly_decision dec =
-        pgwt_anomaly_eval(a, aas, lock_fraction, now);
+        pgwt_anomaly_eval_observation(a, &obs, now);
 
     char rb[32];
     switch (dec.action) {
@@ -269,8 +369,9 @@ void pgwt_anomaly_tick(struct pgwt_daemon *d,
                          (unsigned long long)a->near_since_log);
             fprintf(stderr,
                     "INFO: anomaly near-trigger: aas=%.1f baseline=%.2f "
-                    "lock_frac=%.2f%s%s%s%s%s\n",
+                    "lock_frac=%.2f cpu_aas=%.1f cpu_cusum=%.3f%s%s%s%s%s\n",
                     dec.aas, dec.baseline, dec.lock_fraction,
+                    dec.cpu_aas, dec.cpu_cusum,
                     (dec.near_mask & PGWT_NEAR_AAS_SUSTAIN) ? " [aas-sustain]" : "",
                     (dec.near_mask & PGWT_NEAR_LOCK_SUSTAIN) ? " [lock-sustain]" : "",
                     (dec.near_mask & PGWT_NEAR_COOLDOWN) ? " [cooldown]" : "",
@@ -289,13 +390,18 @@ void pgwt_anomaly_tick(struct pgwt_daemon *d,
         int granted = 0;
         const char *why = NULL;
         rule_names(dec.fired_mask, rb, sizeof(rb));
-        int rc = pgwt_escalate(d, a->escalation_s, PGWT_ESC_REASON_ANOMALY,
+        int reason = (dec.fired_mask & PGWT_RULE_CPU_SATURATION)
+                   ? PGWT_ESC_REASON_CPU_SATURATION
+                   : PGWT_ESC_REASON_ANOMALY;
+        int rc = pgwt_escalate(d, a->escalation_s, reason,
                                &granted, &why);
         if (rc == 0) {
             fprintf(stderr,
                     "INFO: anomaly AUTO-escalation: rule=%saas=%.1f "
-                    "baseline=%.2f lock_frac=%.2f -> full fidelity %ds\n",
-                    rb, dec.aas, dec.baseline, dec.lock_fraction, granted);
+                    "baseline=%.2f lock_frac=%.2f cpu_aas=%.1f "
+                    "capacity=%.3f -> full fidelity %ds\n",
+                    rb, dec.aas, dec.baseline, dec.lock_fraction,
+                    dec.cpu_aas, dec.cpu_capacity, granted);
         } else {
             /* Over budget: dropped SILENTLY (log only, no error to anyone) —
              * unlike a manual escalate which returns a denial to its caller. */

--- a/src/anomaly.c
+++ b/src/anomaly.c
@@ -77,9 +77,12 @@ void pgwt_anomaly_init(struct pgwt_anomaly *a, bool enabled,
     a->cooldown_ns   = (uint64_t)PGWT_ANOMALY_DEF_COOLDOWN_S * 1000000000ULL;
     a->escalation_s  = PGWT_ANOMALY_DEF_ESCALATE_S;
     a->cpu_cusum_enabled = true;
+    a->cpu_min_aas   = PGWT_ANOMALY_DEF_CPU_MIN_AAS;
+    a->cpu_margin    = PGWT_ANOMALY_DEF_CPU_MARGIN;
     a->cpu_cusum_k   = PGWT_ANOMALY_DEF_CPU_CUSUM_K;
     a->cpu_cusum_h   = PGWT_ANOMALY_DEF_CPU_CUSUM_H;
     a->cpu_cusum_cap = PGWT_ANOMALY_DEF_CPU_CUSUM_CAP;
+    a->cpu_armed     = true;
     a->slow_release_div = PGWT_ANOMALY_DEF_SLOW_RELEASE_DIV;
 
     /* Baseline EWMA: pick alpha so the baseline has roughly a 60-second
@@ -135,6 +138,17 @@ pgwt_anomaly_eval_observation(struct pgwt_anomaly *a,
     bool cpu_rule_enabled = a->cpu_cusum_enabled
                          && a->aas_factor < PGWT_ANOMALY_DISABLE_AAS_FACTOR;
     bool cpu_fire = false;
+    bool cpu_cusum_climbed = false;
+
+    /* A partial-read tick cannot establish whether demand recovered. Hold its
+     * evidence, but remember the gap so the first subsequent complete,
+     * capacity-known observation cannot fire from stale pre-gap state. */
+    if (!obs->cpu_coverage_ok)
+        a->cpu_coverage_gap = true;
+    else if (obs->cpu_capacity > 0.0 && a->cpu_coverage_gap) {
+        a->cpu_cusum = 0.0;
+        a->cpu_coverage_gap = false;
+    }
 
     /* A capacity discontinuity invalidates all evidence accumulated in the
      * old units. An open escalation window or cooldown also clears evidence:
@@ -150,10 +164,27 @@ pgwt_anomaly_eval_observation(struct pgwt_anomaly *a,
             u = 0.0;
         if (u > a->cpu_cusum_cap)
             u = a->cpu_cusum_cap;
-        a->cpu_cusum += a->sample_period_s * (u - a->cpu_cusum_k);
-        if (a->cpu_cusum < 0.0)
+
+        /* A CPU fire closes the current saturation episode. Until a trusted
+         * below-slack tick proves recovery, keep S drained and do not re-arm;
+         * continuous saturation therefore consumes at most one grant. */
+        if (!a->cpu_armed) {
             a->cpu_cusum = 0.0;
-        cpu_fire = a->cpu_cusum >= a->cpu_cusum_h;
+            if (u < a->cpu_cusum_k)
+                a->cpu_armed = true;
+        } else {
+            double reference = a->cpu_cusum_k;
+            if (obs->cpu_capacity_affinity_only)
+                reference += a->cpu_margin;
+            double before = a->cpu_cusum;
+            a->cpu_cusum += a->sample_period_s * (u - reference);
+            if (a->cpu_cusum < 0.0)
+                a->cpu_cusum = 0.0;
+            cpu_cusum_climbed = a->cpu_cusum > before;
+            cpu_fire = a->cpu_armed
+                    && obs->cpu_aas >= a->cpu_min_aas
+                    && a->cpu_cusum >= a->cpu_cusum_h;
+        }
     }
     /* LOW coverage and UNKNOWN capacity intentionally take neither branch:
      * S is held unchanged and cannot fire from an untrusted observation. */
@@ -225,6 +256,10 @@ pgwt_anomaly_eval_observation(struct pgwt_anomaly *a,
             near |= PGWT_NEAR_AAS_SUSTAIN;
         if (lock_over && !lock_fire)
             near |= PGWT_NEAR_LOCK_SUSTAIN;
+        if (cpu_cusum_climbed && a->cpu_armed
+            && obs->cpu_aas >= a->cpu_min_aas
+            && a->cpu_cusum >= 0.5 * a->cpu_cusum_h)
+            near |= PGWT_NEAR_CPU_SUSTAIN;
         if (!baseline_warm && aas >= 2.0)
             near |= PGWT_NEAR_BASELINE;
         if (near) {
@@ -256,8 +291,10 @@ pgwt_anomaly_eval_observation(struct pgwt_anomaly *a,
     d.cpu_cusum = 0.0;
     a->last_fire_ns = now_ns;
     a->fires_total++;
-    if (fired & PGWT_RULE_CPU_SATURATION)
+    if (fired & PGWT_RULE_CPU_SATURATION) {
+        a->cpu_armed = false;
         a->cpu_saturation_fires_total++;
+    }
     return d;
 }
 
@@ -334,6 +371,8 @@ void pgwt_anomaly_tick(struct pgwt_daemon *d,
         .lock_fraction = lock_fraction,
         .cpu_aas = cpu_aas,
         .cpu_capacity = d->effective_cores.cores,
+        .cpu_capacity_affinity_only =
+            d->effective_cores.source == PGWT_EFFECTIVE_CORES_AFFINITY,
         .cpu_coverage_ok = coverage_ok,
         .cpu_capacity_changed = d->effective_cores.materially_changed,
         .cpu_guard_blocked = d->escalation.active,
@@ -369,13 +408,14 @@ void pgwt_anomaly_tick(struct pgwt_daemon *d,
                          (unsigned long long)a->near_since_log);
             fprintf(stderr,
                     "INFO: anomaly near-trigger: aas=%.1f baseline=%.2f "
-                    "lock_frac=%.2f cpu_aas=%.1f cpu_cusum=%.3f%s%s%s%s%s\n",
+                    "lock_frac=%.2f cpu_aas=%.1f cpu_cusum=%.3f%s%s%s%s%s%s\n",
                     dec.aas, dec.baseline, dec.lock_fraction,
                     dec.cpu_aas, dec.cpu_cusum,
                     (dec.near_mask & PGWT_NEAR_AAS_SUSTAIN) ? " [aas-sustain]" : "",
                     (dec.near_mask & PGWT_NEAR_LOCK_SUSTAIN) ? " [lock-sustain]" : "",
                     (dec.near_mask & PGWT_NEAR_COOLDOWN) ? " [cooldown]" : "",
                     (dec.near_mask & PGWT_NEAR_BASELINE) ? " [baseline-warmup]" : "",
+                    (dec.near_mask & PGWT_NEAR_CPU_SUSTAIN) ? " [cpu-sustain]" : "",
                     since);
             a->last_near_mask = dec.near_mask;
             a->last_near_log_ns = now;

--- a/src/anomaly.h
+++ b/src/anomaly.h
@@ -5,7 +5,7 @@
  * full-fidelity capture (via the A4 escalation engine) so the full data for
  * the incident is on disk without a human reacting in time.
  *
- * Two rules, both evaluated once per sampler tick on metrics derived from that
+ * Three rules, all evaluated once per sampler tick on metrics derived from that
  * tick's sample batch (no re-reading the trace):
  *
  *   1. AAS-vs-baseline — maintain a rolling baseline of AAS (active sessions,
@@ -15,16 +15,24 @@
  *   2. Lock-class fraction — fire when the Lock-class share of the tick's
  *      ACTIVE (non-idle) samples exceeds a threshold, sustained for N ticks.
  *      Config: --anomaly-lock-fraction.
+ *   3. CPU-demand saturation — a baseline-independent, one-sided CUSUM over
+ *      CPU-class AAS divided by the postmaster's effective CPU capacity. The
+ *      CUSUM advances by nominal sample time (never a delayed wall-clock gap),
+ *      drains below its slack point, and fires at its evidence threshold.
+ *      Config: --anomaly-cpu-cusum-k/-h/-cap and
+ *      --anomaly-cpu-cusum-disable.
  *
  * Hysteresis + cooldown: once an auto-escalation fires, a minimum cooldown
  * (--anomaly-cooldown-s) must elapse before another auto-escalation can fire,
- * so a flapping metric cannot burst-burn the budget. An anomaly while already
- * escalated EXTENDS the window (pgwt_escalate's extend path), it never stacks.
+ * so a flapping metric cannot burst-burn the budget. The existing AAS/lock
+ * rules may EXTEND an active window (pgwt_escalate's extend path), never stack
+ * one; the CPU rule does not accumulate while a window or cooldown is active.
  *
- * Budget: a firing rule calls pgwt_escalate(..., PGWT_ESC_REASON_ANOMALY,...).
- * The A4 engine enforces the rolling-hour budget; an over-budget anomaly
- * trigger is dropped SILENTLY (logged, no error to anyone) — unlike a manual
- * escalate, which returns a denial to its caller.
+ * Budget: a firing baseline/lock rule uses PGWT_ESC_REASON_ANOMALY; a firing
+ * CPU rule uses the distinct PGWT_ESC_REASON_CPU_SATURATION. Both call the
+ * same pgwt_escalate path. The A4 engine enforces the rolling-hour budget; an
+ * over-budget trigger is dropped SILENTLY (logged, no error to anyone) —
+ * unlike a manual escalate, which returns a denial to its caller.
  *
  * Observability: every NEAR-trigger (a metric crossed its threshold but the
  * sustained count was not yet met, or the fire was blocked by cooldown or
@@ -68,6 +76,22 @@ enum pgwt_anomaly_rule {
     PGWT_RULE_NONE = 0,
     PGWT_RULE_AAS  = 1 << 0,
     PGWT_RULE_LOCK = 1 << 1,
+    PGWT_RULE_CPU_SATURATION = 1 << 2,
+};
+
+/* Complete input for one pure rule evaluation. CPU evidence is deliberately
+ * explicit so tests can exercise coverage/capacity/window gates without a
+ * daemon. cpu_capacity <= 0 means UNKNOWN. cpu_guard_blocked is true while a
+ * full-fidelity escalation window is already active; the core additionally
+ * derives cooldown blocking from last_fire_ns. */
+struct pgwt_anomaly_observation {
+    double aas;
+    double lock_fraction;
+    double cpu_aas;
+    double cpu_capacity;
+    bool   cpu_coverage_ok;
+    bool   cpu_capacity_changed;
+    bool   cpu_guard_blocked;
 };
 
 struct pgwt_anomaly_decision {
@@ -77,6 +101,9 @@ struct pgwt_anomaly_decision {
     double   aas;           /* metrics evaluated this tick (for logging) */
     double   baseline;      /* current rolling baseline AAS */
     double   lock_fraction; /* lock-class share of active samples this tick */
+    double   cpu_aas;       /* CPU-class AAS (we==0, excluding io_worker) */
+    double   cpu_capacity;  /* effective cores, or UNKNOWN (<=0) */
+    double   cpu_cusum;     /* CPU CUSUM after this tick */
 };
 
 struct pgwt_anomaly {
@@ -90,6 +117,16 @@ struct pgwt_anomaly {
     int    lock_ticks;        /* consecutive ticks the lock rule must hold */
     uint64_t cooldown_ns;     /* min gap between auto-escalations */
     int    escalation_s;      /* duration requested per auto-escalation */
+
+    /* CPU-demand saturation CUSUM. cpu_cusum_enabled is independently
+     * configurable. The legacy operational disable convention
+     * (aas_factor >= PGWT_ANOMALY_DISABLE_AAS_FACTOR) also disables it. */
+    bool   cpu_cusum_enabled;
+    double cpu_cusum_k;       /* utilization slack/reference point */
+    double cpu_cusum_h;       /* evidence threshold in nominal seconds */
+    double cpu_cusum_cap;     /* cap applied to cpu_aas / capacity */
+    double sample_period_s;   /* NOMINAL 1/sample_rate_hz, never wall gap */
+    double cpu_cusum;         /* O(1) accumulated saturation evidence */
 
     /* ESC-7 baseline slow learn-through: after the AAS metric has been
      * continuously over the multiplicative threshold for learn_through_ticks,
@@ -123,6 +160,7 @@ struct pgwt_anomaly {
 
     /* Lifetime stats (control-socket metrics). */
     uint64_t fires_total;       /* auto-escalations actually requested */
+    uint64_t cpu_saturation_fires_total; /* CPU-rule FIRE decisions */
     uint64_t near_total;        /* near-triggers logged */
     uint64_t dropped_budget;    /* fires the budget silently dropped */
     uint64_t dropped_cooldown;  /* fires the cooldown suppressed */
@@ -136,6 +174,12 @@ struct pgwt_anomaly {
 #define PGWT_ANOMALY_DEF_LOCK_TICKS   3
 #define PGWT_ANOMALY_DEF_COOLDOWN_S   120
 #define PGWT_ANOMALY_DEF_ESCALATE_S   60
+#define PGWT_ANOMALY_DEF_CPU_CUSUM_K   0.80
+#define PGWT_ANOMALY_DEF_CPU_CUSUM_H   1.50
+#define PGWT_ANOMALY_DEF_CPU_CUSUM_CAP 1.25
+/* Existing smoke/operational contract: this sentinel disables automatic AAS
+ * anomaly behavior. Stage 3 also disables the CPU guard at this value. */
+#define PGWT_ANOMALY_DISABLE_AAS_FACTOR 1000000.0
 /* ESC-7 baseline slow learn-through (see struct comment). */
 #define PGWT_ANOMALY_DEF_LEARN_THROUGH_MIN 15  /* minutes continuously-over before learn-through */
 #define PGWT_ANOMALY_DEF_SLOW_RELEASE_DIV  10  /* learn at 1/10 the normal EWMA rate */
@@ -148,9 +192,9 @@ void pgwt_anomaly_init(struct pgwt_anomaly *a, bool enabled,
 
 /* ── Pure rule evaluation (no BPF, no escalation, unit-testable) ────────── */
 
-/* Evaluate the rules for one tick. `aas` is the number of active (non-idle)
- * samples this tick; `lock_fraction` is the Lock-class share of those active
- * samples (0 when there are none). `now_ns` is a monotonic timestamp.
+/* Evaluate the rules for one tick. `obs` carries total AAS, lock share, and
+ * the CPU guard's coverage/capacity inputs. `now_ns` is used only for the
+ * existing cooldown; CPU evidence always advances by sample_period_s.
  *
  * Mutates only *a (baseline EWMA, streak counters, cooldown clock on a FIRE,
  * lifetime stats). Returns the decision. It does NOT call pgwt_escalate — the
@@ -162,16 +206,24 @@ void pgwt_anomaly_init(struct pgwt_anomaly *a, bool enabled,
  * modeled here (the engine owns the budget) — the daemon wrapper observes a
  * silent budget denial and records dropped_budget. */
 struct pgwt_anomaly_decision
+pgwt_anomaly_eval_observation(struct pgwt_anomaly *a,
+                              const struct pgwt_anomaly_observation *obs,
+                              uint64_t now_ns);
+
+/* Compatibility entry point for the original AAS/lock-only core. CPU
+ * capacity is UNKNOWN, so this never advances the CPU guard. */
+struct pgwt_anomaly_decision
 pgwt_anomaly_eval(struct pgwt_anomaly *a, double aas, double lock_fraction,
                   uint64_t now_ns);
 
-/* Derive (aas, lock_fraction) from a tick's encoded sample batch. `samples`
- * is the build_batch output (idle/on-CPU handling already applied by the
- * sampler for on-CPU; idle waits like ClientRead are still present and are
- * excluded here). Pure — exposed for the unit test. */
+/* Derive (aas, lock_fraction, cpu_aas) from a tick's encoded sample batch.
+ * `samples` is the build_batch output (idle/on-CPU handling already applied
+ * by the sampler for on-CPU; idle waits like ClientRead are still present and
+ * are excluded here). Pure — exposed for the unit test. */
 void pgwt_anomaly_metrics_from_batch(const struct pgwt_trace_event *samples,
                                      int n, double *out_aas,
-                                     double *out_lock_fraction);
+                                     double *out_lock_fraction,
+                                     double *out_cpu_aas);
 
 /* ── Daemon-side wrapper (links the rules to the escalation engine) ─────── */
 

--- a/src/anomaly.h
+++ b/src/anomaly.h
@@ -19,7 +19,7 @@
  *      CPU-class AAS divided by the postmaster's effective CPU capacity. The
  *      CUSUM advances by nominal sample time (never a delayed wall-clock gap),
  *      drains below its slack point, and fires at its evidence threshold.
- *      Config: --anomaly-cpu-cusum-k/-h/-cap and
+ *      Config: --anomaly-cpu-min-aas/-margin, --anomaly-cpu-cusum-k/-h/-cap and
  *      --anomaly-cpu-cusum-disable.
  *
  * Hysteresis + cooldown: once an auto-escalation fires, a minimum cooldown
@@ -69,6 +69,7 @@ enum pgwt_anomaly_near {
     PGWT_NEAR_LOCK_SUSTAIN = 1 << 1,/* lock-fraction over, sustain count not met */
     PGWT_NEAR_COOLDOWN    = 1 << 2, /* would fire but in cooldown */
     PGWT_NEAR_BASELINE    = 1 << 3, /* baseline not warm yet (no AAS rule) */
+    PGWT_NEAR_CPU_SUSTAIN = 1 << 4, /* CPU CUSUM >= half its fire threshold */
 };
 
 /* Which rule(s) triggered the fire (bitmask). Recorded for logs/diagnostics. */
@@ -89,6 +90,7 @@ struct pgwt_anomaly_observation {
     double lock_fraction;
     double cpu_aas;
     double cpu_capacity;
+    bool   cpu_capacity_affinity_only;
     bool   cpu_coverage_ok;
     bool   cpu_capacity_changed;
     bool   cpu_guard_blocked;
@@ -122,11 +124,15 @@ struct pgwt_anomaly {
      * configurable. The legacy operational disable convention
      * (aas_factor >= PGWT_ANOMALY_DISABLE_AAS_FACTOR) also disables it. */
     bool   cpu_cusum_enabled;
+    double cpu_min_aas;       /* absolute CPU AAS floor required to fire */
+    double cpu_margin;        /* extra slack for affinity-only capacity */
     double cpu_cusum_k;       /* utilization slack/reference point */
     double cpu_cusum_h;       /* evidence threshold in nominal seconds */
     double cpu_cusum_cap;     /* cap applied to cpu_aas / capacity */
     double sample_period_s;   /* NOMINAL 1/sample_rate_hz, never wall gap */
     double cpu_cusum;         /* O(1) accumulated saturation evidence */
+    bool   cpu_armed;         /* one fire until trusted below-k recovery */
+    bool   cpu_coverage_gap;  /* reset evidence when complete coverage returns */
 
     /* ESC-7 baseline slow learn-through: after the AAS metric has been
      * continuously over the multiplicative threshold for learn_through_ticks,
@@ -174,6 +180,8 @@ struct pgwt_anomaly {
 #define PGWT_ANOMALY_DEF_LOCK_TICKS   3
 #define PGWT_ANOMALY_DEF_COOLDOWN_S   120
 #define PGWT_ANOMALY_DEF_ESCALATE_S   60
+#define PGWT_ANOMALY_DEF_CPU_MIN_AAS    2.0
+#define PGWT_ANOMALY_DEF_CPU_MARGIN     0.02
 #define PGWT_ANOMALY_DEF_CPU_CUSUM_K   0.80
 #define PGWT_ANOMALY_DEF_CPU_CUSUM_H   1.50
 #define PGWT_ANOMALY_DEF_CPU_CUSUM_CAP 1.25

--- a/src/control.c
+++ b/src/control.c
@@ -49,6 +49,7 @@ static const char *esc_reason_str(int reason)
     case PGWT_ESC_REASON_REQUEST:  return "request";
     case PGWT_ESC_REASON_SHUTDOWN: return "shutdown";
     case PGWT_ESC_REASON_BUDGET:   return "budget";
+    case PGWT_ESC_REASON_CPU_SATURATION: return "cpu_saturation";
     default:                       return "unknown";
     }
 }
@@ -291,6 +292,8 @@ static cJSON *build_metrics(const struct pgwt_daemon *d)
 
     /* Anomaly-trigger accounting (A5). 0 when not in tiered mode. */
     cjson_add_uint64(root, "anomaly_fires_total", d->anomaly.fires_total);
+    cjson_add_uint64(root, "anomaly_cpu_saturation_fires_total",
+                     d->anomaly.cpu_saturation_fires_total);
     cjson_add_uint64(root, "anomaly_near_total", d->anomaly.near_total);
     cjson_add_uint64(root, "anomaly_dropped_budget_total",
                      d->anomaly.dropped_budget);
@@ -298,6 +301,13 @@ static cJSON *build_metrics(const struct pgwt_daemon *d)
                      d->anomaly.dropped_cooldown);
     cJSON_AddNumberToObject(root, "anomaly_baseline_aas",
                             d->anomaly.baseline_aas);
+    cJSON_AddBoolToObject(root, "anomaly_cpu_cusum_enabled",
+                          d->anomaly.enabled
+                          && d->anomaly.cpu_cusum_enabled
+                          && d->anomaly.aas_factor
+                             < PGWT_ANOMALY_DISABLE_AAS_FACTOR);
+    cJSON_AddNumberToObject(root, "anomaly_cpu_cusum",
+                            d->anomaly.cpu_cusum);
 
     return root;
 }

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -114,11 +114,12 @@ static void handle_timer(struct pgwt_daemon *d)
         }
     }
 
-    /* AAS-1 Stage 2: refresh target capacity for metrics and the future CPU
-     * guard. This state is deliberately not consumed by anomaly/escalation
-     * in this stage. */
-    d->effective_cores = pgwt_effective_cores_refresh(
-        &d->cpu_capacity_resolver, d->postmaster_pid);
+    /* Stage 3 refreshes capacity at sampler cadence when the anomaly engine
+     * is armed, so the CUSUM consumes every material-change signal. Other
+     * modes retain Stage 2's display-cadence refresh for observability. */
+    if (!d->anomaly.enabled)
+        d->effective_cores = pgwt_effective_cores_refresh(
+            &d->cpu_capacity_resolver, d->postmaster_pid);
 
     /* Print at the first non-PG-death point in the handler. In particular,
      * this is before recovery/sweep and every live-map read: a TIMER line with
@@ -1063,15 +1064,29 @@ int pgwt_daemon_init(struct pgwt_daemon *d)
                 (uint64_t)d->anomaly_cooldown_s * 1000000000ULL;
         if (d->anomaly_window_s > 0)
             d->anomaly.escalation_s = d->anomaly_window_s;
+        if (d->anomaly_cpu_cusum_k >= 0.0)
+            d->anomaly.cpu_cusum_k = d->anomaly_cpu_cusum_k;
+        if (d->anomaly_cpu_cusum_h > 0.0)
+            d->anomaly.cpu_cusum_h = d->anomaly_cpu_cusum_h;
+        if (d->anomaly_cpu_cusum_cap > 0.0)
+            d->anomaly.cpu_cusum_cap = d->anomaly_cpu_cusum_cap;
+        if (d->anomaly_cpu_cusum_disabled)
+            d->anomaly.cpu_cusum_enabled = false;
         if (d->verbose)
             fprintf(stderr,
                     "INFO: anomaly triggers armed: aas>%.1f*baseline for %d "
                     "ticks, lock_frac>%.2f for %d ticks, cooldown %llus, "
-                    "window %ds\n",
+                    "window %ds, cpu_cusum=%s(k=%.3f h=%.3f cap=%.3f)\n",
                     d->anomaly.aas_factor, d->anomaly.aas_ticks,
                     d->anomaly.lock_fraction, d->anomaly.lock_ticks,
                     (unsigned long long)(d->anomaly.cooldown_ns / 1000000000ULL),
-                    d->anomaly.escalation_s);
+                    d->anomaly.escalation_s,
+                    (d->anomaly.cpu_cusum_enabled
+                     && d->anomaly.aas_factor
+                        < PGWT_ANOMALY_DISABLE_AAS_FACTOR)
+                        ? "enabled" : "disabled",
+                    d->anomaly.cpu_cusum_k, d->anomaly.cpu_cusum_h,
+                    d->anomaly.cpu_cusum_cap);
     }
 
     /* Arm the active capture provider. For the full tier this is a no-op

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -1064,6 +1064,10 @@ int pgwt_daemon_init(struct pgwt_daemon *d)
                 (uint64_t)d->anomaly_cooldown_s * 1000000000ULL;
         if (d->anomaly_window_s > 0)
             d->anomaly.escalation_s = d->anomaly_window_s;
+        if (d->anomaly_cpu_min_aas > 0.0)
+            d->anomaly.cpu_min_aas = d->anomaly_cpu_min_aas;
+        if (d->anomaly_cpu_margin >= 0.0)
+            d->anomaly.cpu_margin = d->anomaly_cpu_margin;
         if (d->anomaly_cpu_cusum_k >= 0.0)
             d->anomaly.cpu_cusum_k = d->anomaly_cpu_cusum_k;
         if (d->anomaly_cpu_cusum_h > 0.0)
@@ -1076,7 +1080,8 @@ int pgwt_daemon_init(struct pgwt_daemon *d)
             fprintf(stderr,
                     "INFO: anomaly triggers armed: aas>%.1f*baseline for %d "
                     "ticks, lock_frac>%.2f for %d ticks, cooldown %llus, "
-                    "window %ds, cpu_cusum=%s(k=%.3f h=%.3f cap=%.3f)\n",
+                    "window %ds, cpu_cusum=%s(min_aas=%.3f margin=%.3f "
+                    "k=%.3f h=%.3f cap=%.3f)\n",
                     d->anomaly.aas_factor, d->anomaly.aas_ticks,
                     d->anomaly.lock_fraction, d->anomaly.lock_ticks,
                     (unsigned long long)(d->anomaly.cooldown_ns / 1000000000ULL),
@@ -1085,6 +1090,7 @@ int pgwt_daemon_init(struct pgwt_daemon *d)
                      && d->anomaly.aas_factor
                         < PGWT_ANOMALY_DISABLE_AAS_FACTOR)
                         ? "enabled" : "disabled",
+                    d->anomaly.cpu_min_aas, d->anomaly.cpu_margin,
                     d->anomaly.cpu_cusum_k, d->anomaly.cpu_cusum_h,
                     d->anomaly.cpu_cusum_cap);
     }

--- a/src/daemon.h
+++ b/src/daemon.h
@@ -188,6 +188,8 @@ struct pgwt_daemon {
     int         anomaly_window_s;        /* --anomaly-window-s: per-trigger
                                           * escalation duration (<=0 = default) */
     double      anomaly_cpu_capacity;    /* --anomaly-cpu-capacity; 0 = discover */
+    double      anomaly_cpu_min_aas;     /* --anomaly-cpu-min-aas (<0 = default) */
+    double      anomaly_cpu_margin;      /* --anomaly-cpu-margin (<0 = default) */
     double      anomaly_cpu_cusum_k;     /* --anomaly-cpu-cusum-k (<0 = default) */
     double      anomaly_cpu_cusum_h;     /* --anomaly-cpu-cusum-h (<0 = default) */
     double      anomaly_cpu_cusum_cap;   /* --anomaly-cpu-cusum-cap (<0 = default) */

--- a/src/daemon.h
+++ b/src/daemon.h
@@ -188,10 +188,14 @@ struct pgwt_daemon {
     int         anomaly_window_s;        /* --anomaly-window-s: per-trigger
                                           * escalation duration (<=0 = default) */
     double      anomaly_cpu_capacity;    /* --anomaly-cpu-capacity; 0 = discover */
+    double      anomaly_cpu_cusum_k;     /* --anomaly-cpu-cusum-k (<0 = default) */
+    double      anomaly_cpu_cusum_h;     /* --anomaly-cpu-cusum-h (<0 = default) */
+    double      anomaly_cpu_cusum_cap;   /* --anomaly-cpu-cusum-cap (<0 = default) */
+    bool        anomaly_cpu_cusum_disabled; /* independent CPU-guard switch */
 
     /* AAS-1 Stage 2: target postmaster effective logical-core capacity.
-     * Refreshed once per display tick and exported through control metrics.
-     * No detector or escalation path consumes it until Stage 3. */
+     * Stage 3 refreshes it on every anomaly/sampler tick; modes without an
+     * armed anomaly engine retain the display-tick refresh for metrics. */
     struct pgwt_effective_cores_resolver cpu_capacity_resolver;
     struct pgwt_effective_cores_result effective_cores;
     /* T2: the pgstat_report_activity uprobe attached and the BackendState

--- a/src/pg_wait_tracer.c
+++ b/src/pg_wait_tracer.c
@@ -84,6 +84,11 @@ static void usage(const char *prog)
         "      --anomaly-window-s <S>     Full-fidelity window length per auto-trigger (default 60)\n"
         "      --anomaly-cpu-capacity <C> Override target effective logical CPU cores\n"
         "                             (default: affinity/cgroup discovery)\n"
+        "      --anomaly-cpu-cusum-k <K> CPU saturation slack/reference (default 0.80)\n"
+        "      --anomaly-cpu-cusum-h <H> CPU saturation evidence threshold (default 1.50)\n"
+        "      --anomaly-cpu-cusum-cap <U> Cap CPU demand/capacity ratio (default 1.25)\n"
+        "      --anomaly-cpu-cusum-disable  Disable only the CPU saturation guard\n"
+        "                             (--anomaly-aas-factor >= 1000000 also disables it)\n"
         "\n"
         "Performance tuning:\n"
         "      --lightweight          BPF accumulator only (no per-event ringbuf).\n"
@@ -224,6 +229,10 @@ static enum pgwt_mode parse_mode(const char *s)
 #define OPT_RETENTION_GB    272
 #define OPT_ANOM_LOCK_MIN_AAS 273
 #define OPT_ANOM_CPU_CAPACITY 274
+#define OPT_ANOM_CPU_CUSUM_K 275
+#define OPT_ANOM_CPU_CUSUM_H 276
+#define OPT_ANOM_CPU_CUSUM_CAP 277
+#define OPT_ANOM_CPU_CUSUM_DISABLE 278
 
 static struct option long_opts[] = {
     {"pid",        required_argument, NULL, 'p'},
@@ -259,6 +268,10 @@ static struct option long_opts[] = {
     {"anomaly-cooldown-s",  required_argument, NULL, OPT_ANOM_COOLDOWN},
     {"anomaly-window-s",    required_argument, NULL, OPT_ANOM_WINDOW},
     {"anomaly-cpu-capacity", required_argument, NULL, OPT_ANOM_CPU_CAPACITY},
+    {"anomaly-cpu-cusum-k", required_argument, NULL, OPT_ANOM_CPU_CUSUM_K},
+    {"anomaly-cpu-cusum-h", required_argument, NULL, OPT_ANOM_CPU_CUSUM_H},
+    {"anomaly-cpu-cusum-cap", required_argument, NULL, OPT_ANOM_CPU_CUSUM_CAP},
+    {"anomaly-cpu-cusum-disable", no_argument, NULL, OPT_ANOM_CPU_CUSUM_DISABLE},
     {"quiet",           no_argument,       NULL, 'q'},
     {"verbose",         no_argument,       NULL, 'v'},
     {"help",            no_argument,       NULL, 'h'},
@@ -292,6 +305,9 @@ int main(int argc, char **argv)
     d->anomaly_lock_fraction = -1.0;
     d->anomaly_lock_min_aas  = -1.0;
     d->anomaly_cooldown_s    = -1;
+    d->anomaly_cpu_cusum_k   = -1.0;
+    d->anomaly_cpu_cusum_h   = -1.0;
+    d->anomaly_cpu_cusum_cap = -1.0;
 
     pid_t pm_pid = 0;
     const char *pgdata = NULL;
@@ -363,6 +379,51 @@ int main(int argc, char **argv)
             d->anomaly_cpu_capacity = cores;
             break;
         }
+        case OPT_ANOM_CPU_CUSUM_K: {
+            char *end = NULL;
+            errno = 0;
+            double k = strtod(optarg, &end);
+            if (errno || end == optarg || *end != '\0' ||
+                !isfinite(k) || k < 0.0) {
+                fprintf(stderr, "FATAL: --anomaly-cpu-cusum-k must be a "
+                        "finite value >= 0 (got '%s')\n", optarg);
+                free(d);
+                return 1;
+            }
+            d->anomaly_cpu_cusum_k = k;
+            break;
+        }
+        case OPT_ANOM_CPU_CUSUM_H: {
+            char *end = NULL;
+            errno = 0;
+            double h = strtod(optarg, &end);
+            if (errno || end == optarg || *end != '\0' ||
+                !isfinite(h) || h <= 0.0) {
+                fprintf(stderr, "FATAL: --anomaly-cpu-cusum-h must be a "
+                        "finite value > 0 (got '%s')\n", optarg);
+                free(d);
+                return 1;
+            }
+            d->anomaly_cpu_cusum_h = h;
+            break;
+        }
+        case OPT_ANOM_CPU_CUSUM_CAP: {
+            char *end = NULL;
+            errno = 0;
+            double cap = strtod(optarg, &end);
+            if (errno || end == optarg || *end != '\0' ||
+                !isfinite(cap) || cap <= 0.0) {
+                fprintf(stderr, "FATAL: --anomaly-cpu-cusum-cap must be a "
+                        "finite value > 0 (got '%s')\n", optarg);
+                free(d);
+                return 1;
+            }
+            d->anomaly_cpu_cusum_cap = cap;
+            break;
+        }
+        case OPT_ANOM_CPU_CUSUM_DISABLE:
+            d->anomaly_cpu_cusum_disabled = true;
+            break;
         case 'q': d->quiet = true; break;
         case 'v': d->verbose = true; break;
         case 'h': usage(argv[0]); free(d); return 0;
@@ -469,6 +530,19 @@ int main(int argc, char **argv)
     if (d->anomaly_lock_min_aas == 0.0) {
         fprintf(stderr, "FATAL: --anomaly-lock-min-aas must be > 0 "
                 "(use --anomaly-lock-fraction alone to disable the floor)\n");
+        free(d);
+        return 1;
+    }
+    double cpu_cusum_k = d->anomaly_cpu_cusum_k >= 0.0
+                       ? d->anomaly_cpu_cusum_k
+                       : PGWT_ANOMALY_DEF_CPU_CUSUM_K;
+    double cpu_cusum_cap = d->anomaly_cpu_cusum_cap > 0.0
+                         ? d->anomaly_cpu_cusum_cap
+                         : PGWT_ANOMALY_DEF_CPU_CUSUM_CAP;
+    if (cpu_cusum_k >= cpu_cusum_cap) {
+        fprintf(stderr, "FATAL: --anomaly-cpu-cusum-k must be less than "
+                "--anomaly-cpu-cusum-cap (got k=%.6g cap=%.6g)\n",
+                cpu_cusum_k, cpu_cusum_cap);
         free(d);
         return 1;
     }

--- a/src/pg_wait_tracer.c
+++ b/src/pg_wait_tracer.c
@@ -83,7 +83,11 @@ static void usage(const char *prog)
         "      --anomaly-cooldown-s <S>   Min seconds between auto-escalations (default 120)\n"
         "      --anomaly-window-s <S>     Full-fidelity window length per auto-trigger (default 60)\n"
         "      --anomaly-cpu-capacity <C> Override target effective logical CPU cores\n"
-        "                             (default: affinity/cgroup discovery)\n"
+        "                             (default: affinity/cgroup discovery; use when\n"
+        "                             discovered capacity is known to be uncertain)\n"
+        "      --anomaly-cpu-min-aas <A> Absolute CPU AAS required to fire (default 2.0)\n"
+        "      --anomaly-cpu-margin <M>  Extra utilization slack for affinity-only\n"
+        "                             capacity (default 0.02; zero for quota/override)\n"
         "      --anomaly-cpu-cusum-k <K> CPU saturation slack/reference (default 0.80)\n"
         "      --anomaly-cpu-cusum-h <H> CPU saturation evidence threshold (default 1.50)\n"
         "      --anomaly-cpu-cusum-cap <U> Cap CPU demand/capacity ratio (default 1.25)\n"
@@ -233,6 +237,8 @@ static enum pgwt_mode parse_mode(const char *s)
 #define OPT_ANOM_CPU_CUSUM_H 276
 #define OPT_ANOM_CPU_CUSUM_CAP 277
 #define OPT_ANOM_CPU_CUSUM_DISABLE 278
+#define OPT_ANOM_CPU_MIN_AAS 279
+#define OPT_ANOM_CPU_MARGIN 280
 
 static struct option long_opts[] = {
     {"pid",        required_argument, NULL, 'p'},
@@ -268,6 +274,8 @@ static struct option long_opts[] = {
     {"anomaly-cooldown-s",  required_argument, NULL, OPT_ANOM_COOLDOWN},
     {"anomaly-window-s",    required_argument, NULL, OPT_ANOM_WINDOW},
     {"anomaly-cpu-capacity", required_argument, NULL, OPT_ANOM_CPU_CAPACITY},
+    {"anomaly-cpu-min-aas", required_argument, NULL, OPT_ANOM_CPU_MIN_AAS},
+    {"anomaly-cpu-margin", required_argument, NULL, OPT_ANOM_CPU_MARGIN},
     {"anomaly-cpu-cusum-k", required_argument, NULL, OPT_ANOM_CPU_CUSUM_K},
     {"anomaly-cpu-cusum-h", required_argument, NULL, OPT_ANOM_CPU_CUSUM_H},
     {"anomaly-cpu-cusum-cap", required_argument, NULL, OPT_ANOM_CPU_CUSUM_CAP},
@@ -305,6 +313,8 @@ int main(int argc, char **argv)
     d->anomaly_lock_fraction = -1.0;
     d->anomaly_lock_min_aas  = -1.0;
     d->anomaly_cooldown_s    = -1;
+    d->anomaly_cpu_min_aas   = -1.0;
+    d->anomaly_cpu_margin    = -1.0;
     d->anomaly_cpu_cusum_k   = -1.0;
     d->anomaly_cpu_cusum_h   = -1.0;
     d->anomaly_cpu_cusum_cap = -1.0;
@@ -377,6 +387,34 @@ int main(int argc, char **argv)
                 return 1;
             }
             d->anomaly_cpu_capacity = cores;
+            break;
+        }
+        case OPT_ANOM_CPU_MIN_AAS: {
+            char *end = NULL;
+            errno = 0;
+            double floor = strtod(optarg, &end);
+            if (errno || end == optarg || *end != '\0' ||
+                !isfinite(floor) || floor <= 0.0) {
+                fprintf(stderr, "FATAL: --anomaly-cpu-min-aas must be a "
+                        "finite value > 0 (got '%s')\n", optarg);
+                free(d);
+                return 1;
+            }
+            d->anomaly_cpu_min_aas = floor;
+            break;
+        }
+        case OPT_ANOM_CPU_MARGIN: {
+            char *end = NULL;
+            errno = 0;
+            double margin = strtod(optarg, &end);
+            if (errno || end == optarg || *end != '\0' ||
+                !isfinite(margin) || margin < 0.0) {
+                fprintf(stderr, "FATAL: --anomaly-cpu-margin must be a "
+                        "finite value >= 0 (got '%s')\n", optarg);
+                free(d);
+                return 1;
+            }
+            d->anomaly_cpu_margin = margin;
             break;
         }
         case OPT_ANOM_CPU_CUSUM_K: {

--- a/src/pg_wait_tracer.h
+++ b/src/pg_wait_tracer.h
@@ -202,6 +202,7 @@ enum pgwt_escalation_reason {
     PGWT_ESC_REASON_REQUEST  = 3,  /* explicit deescalate request (close) */
     PGWT_ESC_REASON_SHUTDOWN = 4,  /* daemon stopping (close) */
     PGWT_ESC_REASON_BUDGET   = 5,  /* rolling-hour budget reached (mid-window close, ESC-1) */
+    PGWT_ESC_REASON_CPU_SATURATION = 6, /* CPU-demand CUSUM trigger (AAS-1 Stage 3) */
 };
 
 /* ── Query Text Event (lifecycle ringbuf) ─────────────────── */

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -95,9 +95,10 @@ test_sampler: test_sampler.c ../src/sampler.c ../src/anomaly.c
 	$(CC) $(CFLAGS) -DPGWT_SERVER -o $@ $^
 
 # test_anomaly: anomaly rule engine (AAS-vs-baseline, lock-fraction,
-# hysteresis/cooldown, baseline protection, metrics derivation). Compiles
-# anomaly.c with -DPGWT_SERVER so only the pure rule core is built — no
-# skeleton, no escalation engine, runnable in CI's server-only jobs.
+# CPU-demand CUSUM, hysteresis/cooldown, baseline protection, metrics
+# derivation). Compiles anomaly.c with -DPGWT_SERVER so only the pure rule core
+# is built — no skeleton, no escalation engine, runnable in CI's server-only
+# jobs.
 test_anomaly: test_anomaly.c ../src/anomaly.c
 	$(CC) $(CFLAGS) -DPGWT_SERVER -o $@ $^
 

--- a/tests/dump_markers.c
+++ b/tests/dump_markers.c
@@ -31,6 +31,7 @@ static const char *reason_name(unsigned r)
     case PGWT_ESC_REASON_EXPIRED:  return "expired";
     case PGWT_ESC_REASON_REQUEST:  return "request";
     case PGWT_ESC_REASON_SHUTDOWN: return "shutdown";
+    case PGWT_ESC_REASON_CPU_SATURATION: return "cpu_saturation";
     default:                       return "unknown";
     }
 }

--- a/tests/test_anomaly.c
+++ b/tests/test_anomaly.c
@@ -63,15 +63,16 @@ static void warm_baseline(struct pgwt_anomaly *a, double level,
  * exactly one nominal 10 Hz tick. Wall-clock jumps are made explicitly by the
  * few tests that prove delayed callbacks do not add extra CPU evidence. */
 static struct pgwt_anomaly_decision
-cpu_tick(struct pgwt_anomaly *a, double aas, double cpu_aas, double capacity,
-         bool coverage_ok, bool capacity_changed, bool guard_blocked,
-         uint64_t *clock)
+cpu_tick_source(struct pgwt_anomaly *a, double aas, double cpu_aas,
+                double capacity, bool affinity_only, bool coverage_ok,
+                bool capacity_changed, bool guard_blocked, uint64_t *clock)
 {
     const struct pgwt_anomaly_observation obs = {
         .aas = aas,
         .lock_fraction = 0.0,
         .cpu_aas = cpu_aas,
         .cpu_capacity = capacity,
+        .cpu_capacity_affinity_only = affinity_only,
         .cpu_coverage_ok = coverage_ok,
         .cpu_capacity_changed = capacity_changed,
         .cpu_guard_blocked = guard_blocked,
@@ -80,6 +81,15 @@ cpu_tick(struct pgwt_anomaly *a, double aas, double cpu_aas, double capacity,
         pgwt_anomaly_eval_observation(a, &obs, *clock);
     *clock += TICK_NS;
     return d;
+}
+
+static struct pgwt_anomaly_decision
+cpu_tick(struct pgwt_anomaly *a, double aas, double cpu_aas, double capacity,
+         bool coverage_ok, bool capacity_changed, bool guard_blocked,
+         uint64_t *clock)
+{
+    return cpu_tick_source(a, aas, cpu_aas, capacity, false, coverage_ok,
+                           capacity_changed, guard_blocked, clock);
 }
 
 static void isolate_cpu_rule(struct pgwt_anomaly *a)
@@ -565,7 +575,8 @@ static void test_cpu_cusum_incidents(void)
         if (cpu >= 2 && (double)cpu > threshold)
             primary_crossed = true;
         struct pgwt_anomaly_decision d =
-            cpu_tick(&a, cpu, cpu, 4.0, true, false, false, &clk);
+            cpu_tick_source(&a, cpu, cpu, 4.0, true,
+                            true, false, false, &clk);
         if (d.action == PGWT_ANOMALY_FIRE) {
             fire_tick = t + 1;
             fire_mask = d.fired_mask;
@@ -583,6 +594,7 @@ static void test_cpu_cusum_incidents(void)
     CHECK(a.cpu_saturation_fires_total == 1,
           "C=4 cpu_saturation_fires_total=%llu expected 1",
           (unsigned long long)a.cpu_saturation_fires_total);
+    int c4_fire_tick = fire_tick;
 
     /* Same prelude and stream on C=2: ratio capping makes the expected
      * evidence rate ~0.445/s, so it should fire in roughly 3.4 seconds. */
@@ -596,7 +608,8 @@ static void test_cpu_cusum_incidents(void)
     for (int t = 0; t < 40; t++) {
         int cpu = jittery_storm_cpu(t);
         struct pgwt_anomaly_decision d =
-            cpu_tick(&b, cpu, cpu, 2.0, true, false, false, &clk);
+            cpu_tick_source(&b, cpu, cpu, 2.0, true,
+                            true, false, false, &clk);
         if (d.action == PGWT_ANOMALY_FIRE) {
             fire_tick = t + 1;
             CHECK(d.fired_mask & PGWT_RULE_CPU_SATURATION,
@@ -606,6 +619,7 @@ static void test_cpu_cusum_incidents(void)
     }
     CHECK(fire_tick >= 30 && fire_tick <= 40,
           "C=2 noisy storm fire tick=%d expected about 4s", fire_tick);
+    int c2_fire_tick = fire_tick;
 
     /* No baseline warmup: the baseline-independent guard still fires. */
     struct pgwt_anomaly c;
@@ -615,7 +629,8 @@ static void test_cpu_cusum_incidents(void)
     for (int t = 0; t < 90; t++) {
         int cpu = jittery_storm_cpu(t);
         struct pgwt_anomaly_decision d =
-            cpu_tick(&c, cpu, cpu, 4.0, true, false, false, &clk);
+            cpu_tick_source(&c, cpu, cpu, 4.0, true,
+                            true, false, false, &clk);
         if (d.action == PGWT_ANOMALY_FIRE) {
             fire_tick = t + 1;
             CHECK(d.fired_mask & PGWT_RULE_CPU_SATURATION,
@@ -636,7 +651,8 @@ static void test_cpu_cusum_incidents(void)
     for (int t = 0; t < 60 * 10; t++) {
         int cpu = jittery_storm_cpu(t);
         struct pgwt_anomaly_decision d =
-            cpu_tick(&wide, cpu, cpu, 16.0, true, false, false, &clk);
+            cpu_tick_source(&wide, cpu, cpu, 16.0, true,
+                            true, false, false, &clk);
         grants += d.action == PGWT_ANOMALY_FIRE;
     }
     CHECK(grants == 0 && wide.fires_total == 0,
@@ -657,6 +673,9 @@ static void test_cpu_cusum_incidents(void)
           "one cpu_aas=100 tick bypassed the utilization cap");
     CHECK(capped.cpu_cusum > 0.044 && capped.cpu_cusum < 0.046,
           "one capped tick produced S=%.6f expected 0.045", capped.cpu_cusum);
+
+    printf("  storm matrix: C=4 %.1fs, C=2 %.1fs, C=16 grants=%d\n",
+           c4_fire_tick / 10.0, c2_fire_tick / 10.0, grants);
 }
 
 /* ── AAS-1 Stage 3: evidence-quality and no-banking gates ────────────── */
@@ -759,6 +778,205 @@ static void test_cpu_cusum_gates(void)
           "cooldown banked/refired CPU evidence (S=%.6f fires=%llu)",
           cooldown.cpu_cusum,
           (unsigned long long)cooldown.cpu_saturation_fires_total);
+}
+
+/* ── AAS-1 Stage 3 fix: one grant per saturation episode ─────────────── */
+static void test_cpu_cusum_episode_latch(void)
+{
+    printf("--- CPU CUSUM: one fire per saturation episode ---\n");
+
+    struct pgwt_anomaly chronic;
+    pgwt_anomaly_init(&chronic, true, 10);
+    isolate_cpu_rule(&chronic);
+    uint64_t clk = TICK_NS;
+    int grants = 0;
+    for (int t = 0; t < 60 * 60 * 10; t++) {
+        struct pgwt_anomaly_decision d =
+            cpu_tick(&chronic, 4.0, 4.0, 4.0,
+                     true, false, false, &clk);
+        grants += d.action == PGWT_ANOMALY_FIRE;
+    }
+    CHECK(grants <= 1 && chronic.fires_total <= 1,
+          "chronic saturation consumed %d grants / %llu fires in one hour",
+          grants, (unsigned long long)chronic.fires_total);
+    CHECK(grants == 1 && !chronic.cpu_armed,
+          "chronic saturation expected one fire and disarmed state "
+          "(grants=%d armed=%d)", grants, chronic.cpu_armed);
+    CHECK(chronic.dropped_budget == 0,
+          "chronic saturation touched budget-drop accounting");
+
+    /* Neither a held partial-read observation nor UNKNOWN capacity proves
+     * recovery. A complete known u<k tick does, after which a new sustained
+     * saturation episode may fire once more. */
+    cpu_tick(&chronic, 0.0, 0.0, 4.0,
+             false, false, false, &clk);
+    CHECK(!chronic.cpu_armed, "low-coverage tick re-armed CPU episode");
+    cpu_tick(&chronic, 0.0, 0.0, -1.0,
+             true, false, false, &clk);
+    CHECK(!chronic.cpu_armed, "UNKNOWN-capacity tick re-armed CPU episode");
+    cpu_tick(&chronic, 3.0, 3.0, 4.0,
+             true, false, false, &clk);
+    CHECK(chronic.cpu_armed && chronic.cpu_cusum == 0.0,
+          "trusted below-k recovery did not re-arm drained CPU episode");
+
+    int second_episode_ticks = 0;
+    for (int t = 0; t < 100; t++) {
+        struct pgwt_anomaly_decision d =
+            cpu_tick(&chronic, 4.0, 4.0, 4.0,
+                     true, false, false, &clk);
+        if (d.action == PGWT_ANOMALY_FIRE) {
+            second_episode_ticks = t + 1;
+            break;
+        }
+    }
+    CHECK(second_episode_ticks > 0 && chronic.fires_total == 2,
+          "recover/resaturate did not produce exactly two episode fires "
+          "(tick=%d fires=%llu)", second_episode_ticks,
+          (unsigned long long)chronic.fires_total);
+
+    printf("  chronic busy: grants/hour=%d; recover/resaturate fires=%llu\n",
+           grants, (unsigned long long)chronic.fires_total);
+}
+
+/* ── AAS-1 Stage 3 fix: activity floor + affinity-only margin ────────── */
+static void test_cpu_cusum_floor_and_margin(void)
+{
+    printf("--- CPU CUSUM: absolute floor and affinity capacity margin ---\n");
+
+    /* Even a severe capacity underestimate cannot turn one CPU-active
+     * backend into an escalation: the absolute activity floor is mandatory. */
+    struct pgwt_anomaly floor;
+    pgwt_anomaly_init(&floor, true, 10);
+    isolate_cpu_rule(&floor);
+    CHECK(floor.cpu_min_aas == 2.0 && floor.cpu_margin == 0.02,
+          "CPU floor/margin defaults are %.3f/%.3f, expected 2.0/.02",
+          floor.cpu_min_aas, floor.cpu_margin);
+    uint64_t floor_clk = TICK_NS;
+    int floor_grants = 0;
+    for (int t = 0; t < 60 * 60 * 10; t++) {
+        struct pgwt_anomaly_decision d =
+            cpu_tick(&floor, 1.0, 1.0, 0.5,
+                     true, false, false, &floor_clk);
+        floor_grants += d.action == PGWT_ANOMALY_FIRE;
+    }
+    CHECK(floor_grants == 0 && floor.fires_total == 0,
+          "cpu_aas below floor fired on underestimated C "
+          "(%d grants / %llu fires)", floor_grants,
+          (unsigned long long)floor.fires_total);
+
+    /* Noisy integer demand has mean 3.24 on C=4 (u=.81): it eventually fires
+     * with the base k=.80, but affinity-only provenance adds the default .02
+     * margin and makes the same benign stream drain instead. */
+    struct pgwt_anomaly affinity;
+    struct pgwt_anomaly no_margin;
+    pgwt_anomaly_init(&affinity, true, 10);
+    pgwt_anomaly_init(&no_margin, true, 10);
+    isolate_cpu_rule(&affinity);
+    isolate_cpu_rule(&no_margin);
+    uint64_t affinity_clk = TICK_NS;
+    uint64_t no_margin_clk = TICK_NS;
+    int affinity_grants = 0;
+    int no_margin_grants = 0;
+    for (int t = 0; t < 60 * 60 * 10; t++) {
+        int q = (t * 37 + 11) % 100;
+        int cpu = q < 76 ? 3 : 4;
+        struct pgwt_anomaly_decision with =
+            cpu_tick_source(&affinity, cpu, cpu, 4.0, true,
+                            true, false, false, &affinity_clk);
+        struct pgwt_anomaly_decision without =
+            cpu_tick_source(&no_margin, cpu, cpu, 4.0, false,
+                            true, false, false, &no_margin_clk);
+        affinity_grants += with.action == PGWT_ANOMALY_FIRE;
+        no_margin_grants += without.action == PGWT_ANOMALY_FIRE;
+    }
+    CHECK(affinity_grants == 0 && affinity.fires_total == 0,
+          "affinity margin did not suppress benign u=.81 load "
+          "(%d grants / %llu fires)", affinity_grants,
+          (unsigned long long)affinity.fires_total);
+    CHECK(no_margin_grants > 0,
+          "margin pinning stream without affinity margin never fired");
+
+    printf("  underestimated floor grants=%d; affinity u=.81 grants=%d "
+           "(zero-margin control=%d)\n",
+           floor_grants, affinity_grants, no_margin_grants);
+}
+
+/* ── AAS-1 Stage 3 fix: discard evidence across partial-read gaps ────── */
+static void test_cpu_cusum_coverage_return(void)
+{
+    printf("--- CPU CUSUM: coverage return resets stale evidence ---\n");
+
+    struct pgwt_anomaly idle_return;
+    pgwt_anomaly_init(&idle_return, true, 10);
+    isolate_cpu_rule(&idle_return);
+    uint64_t clk = TICK_NS;
+    for (int t = 0; t < 33; t++)
+        cpu_tick(&idle_return, 5.0, 5.0, 4.0,
+                 true, false, false, &clk);
+    CHECK(idle_return.cpu_cusum > 1.48 && idle_return.cpu_cusum < 1.49,
+          "coverage-gap setup S=%.6f expected just below h",
+          idle_return.cpu_cusum);
+    for (int t = 0; t < 100; t++)
+        cpu_tick(&idle_return, 0.0, 0.0, 4.0,
+                 false, false, false, &clk);
+    struct pgwt_anomaly_decision idle =
+        cpu_tick(&idle_return, 0.0, 0.0, 4.0,
+                 true, false, false, &clk);
+    CHECK(idle.action != PGWT_ANOMALY_FIRE && idle_return.cpu_cusum == 0.0,
+          "idle coverage return fired stale evidence (action=%d S=%.6f)",
+          idle.action, idle_return.cpu_cusum);
+
+    struct pgwt_anomaly busy_return;
+    pgwt_anomaly_init(&busy_return, true, 10);
+    isolate_cpu_rule(&busy_return);
+    clk = TICK_NS;
+    for (int t = 0; t < 33; t++)
+        cpu_tick(&busy_return, 5.0, 5.0, 4.0,
+                 true, false, false, &clk);
+    for (int t = 0; t < 100; t++)
+        cpu_tick(&busy_return, 0.0, 0.0, 4.0,
+                 false, false, false, &clk);
+    struct pgwt_anomaly_decision busy =
+        cpu_tick(&busy_return, 5.0, 5.0, 4.0,
+                 true, false, false, &clk);
+    CHECK(busy.action != PGWT_ANOMALY_FIRE
+          && busy_return.cpu_cusum > 0.044
+          && busy_return.cpu_cusum < 0.046,
+          "busy coverage return retained stale S (action=%d S=%.6f)",
+          busy.action, busy_return.cpu_cusum);
+    int clean_ticks = 1;
+    while (busy.action != PGWT_ANOMALY_FIRE && clean_ticks < 100) {
+        busy = cpu_tick(&busy_return, 5.0, 5.0, 4.0,
+                        true, false, false, &clk);
+        clean_ticks++;
+    }
+    CHECK(busy.action == PGWT_ANOMALY_FIRE
+          && (busy.fired_mask & PGWT_RULE_CPU_SATURATION),
+          "continued saturation after coverage return did not fire "
+          "(ticks=%d action=%d)", clean_ticks, busy.action);
+
+    printf("  stale idle return grants=0; sustained return fire=%.1fs\n",
+           clean_ticks / 10.0);
+}
+
+/* ── AAS-1 Stage 3 fix: surface a climbing half-threshold CUSUM ──────── */
+static void test_cpu_cusum_near_flag(void)
+{
+    printf("--- CPU CUSUM: near flag while evidence climbs ---\n");
+    struct pgwt_anomaly a;
+    pgwt_anomaly_init(&a, true, 10);
+    isolate_cpu_rule(&a);
+    uint64_t clk = TICK_NS;
+    struct pgwt_anomaly_decision d = {0};
+    for (int t = 0; t < 17; t++)
+        d = cpu_tick(&a, 5.0, 5.0, 4.0,
+                     true, false, false, &clk);
+    CHECK(d.action == PGWT_ANOMALY_NEAR
+          && (d.near_mask & PGWT_NEAR_CPU_SUSTAIN),
+          "S=%.6f expected NEAR(cpu-sustain), action=%d mask=%u",
+          d.cpu_cusum, d.action, d.near_mask);
+    CHECK(!(d.fired_mask & PGWT_RULE_CPU_SATURATION),
+          "CPU near tick also reported a fire mask=%u", d.fired_mask);
 }
 
 /* ── AAS-1 Stage 3: explicit and legacy disable contracts ────────────── */
@@ -864,6 +1082,9 @@ static void run_quiet_hour(int scenario, const char *name)
     CHECK(a.dropped_budget == 0,
           "%s: %llu budget drops in one hour", name,
           (unsigned long long)a.dropped_budget);
+    printf("  normal[%s]: grants=%d fires=%llu drops=%llu\n",
+           name, grants, (unsigned long long)a.fires_total,
+           (unsigned long long)a.dropped_budget);
 }
 
 /* ── AAS-1 Stage 3: long false-positive matrix + boundaries ──────────── */
@@ -971,6 +1192,10 @@ int main(void)
     test_combined_fire();
     test_cpu_cusum_incidents();
     test_cpu_cusum_gates();
+    test_cpu_cusum_episode_latch();
+    test_cpu_cusum_floor_and_margin();
+    test_cpu_cusum_coverage_return();
+    test_cpu_cusum_near_flag();
     test_cpu_cusum_disable_contract();
     test_cpu_cusum_false_positive_matrix();
 

--- a/tests/test_anomaly.c
+++ b/tests/test_anomaly.c
@@ -5,6 +5,8 @@
  *   - AAS-vs-baseline (factor, sustained N ticks, baseline warmup)
  *   - lock-class fraction (threshold, sustained N ticks)
  *   - hysteresis / cooldown (a flapping metric cannot re-fire inside cooldown)
+ *   - baseline-independent CPU-demand CUSUM with realistic noisy integer
+ *     incidents, one-hour false-positive streams, and evidence-quality gates
  *   - budget-blocked-silent (modeled at the daemon layer — here we assert the
  *     pure core still FIREs, since the budget lives in the escalation engine)
  *
@@ -55,6 +57,63 @@ static void warm_baseline(struct pgwt_anomaly *a, double level,
                           uint64_t *clock)
 {
     feed(a, level, 0.0, a->warmup_needed + 5, clock, NULL);
+}
+
+/* Evaluate one complete Stage-3 observation and advance the scripted clock by
+ * exactly one nominal 10 Hz tick. Wall-clock jumps are made explicitly by the
+ * few tests that prove delayed callbacks do not add extra CPU evidence. */
+static struct pgwt_anomaly_decision
+cpu_tick(struct pgwt_anomaly *a, double aas, double cpu_aas, double capacity,
+         bool coverage_ok, bool capacity_changed, bool guard_blocked,
+         uint64_t *clock)
+{
+    const struct pgwt_anomaly_observation obs = {
+        .aas = aas,
+        .lock_fraction = 0.0,
+        .cpu_aas = cpu_aas,
+        .cpu_capacity = capacity,
+        .cpu_coverage_ok = coverage_ok,
+        .cpu_capacity_changed = capacity_changed,
+        .cpu_guard_blocked = guard_blocked,
+    };
+    struct pgwt_anomaly_decision d =
+        pgwt_anomaly_eval_observation(a, &obs, *clock);
+    *clock += TICK_NS;
+    return d;
+}
+
+static void isolate_cpu_rule(struct pgwt_anomaly *a)
+{
+    a->aas_factor = 0.0;
+    a->lock_fraction = 0.0;
+}
+
+/* Exact discrete distribution from the realistic-noise contract. Multiplying
+ * by 37 permutes [0,99], so every 100 ticks contain counts 2,23,50,23,2 of
+ * CPU AAS 2,3,4,5,6 respectively (mean 4), without constant plateaus. */
+static int jittery_storm_cpu(int tick)
+{
+    int q = (tick * 37 + 11) % 100;
+    if (q < 2)  return 2;
+    if (q < 25) return 3;
+    if (q < 75) return 4;
+    if (q < 98) return 5;
+    return 6;
+}
+
+/* Drifted total-AAS baseline P(1,2,3)=.10,.60,.30 (mean 2.2). */
+static int drifted_baseline_aas(int tick)
+{
+    int q = (tick * 7 + 3) % 10;
+    if (q < 1) return 1;
+    if (q < 7) return 2;
+    return 3;
+}
+
+/* Noisy integer CPU baseline with mean 0.8 AAS. */
+static int baseline_cpu_demand(int tick)
+{
+    return ((tick * 3 + 1) % 5) == 0 ? 0 : 1;
 }
 
 /* ── Test 1: disabled engine never fires ──────────────────────────────── */
@@ -274,21 +333,23 @@ static void test_metrics_from_batch(void)
     batch[7].new_event = WEI(PG_WAIT_IO, 0x10);       /* io_worker: excluded */
     batch[7].flags     = PGWT_EVENT_FLAG_IO_WORKER;
 
-    double aas = -1, frac = -1;
-    pgwt_anomaly_metrics_from_batch(batch, 8, &aas, &frac);
+    double aas = -1, frac = -1, cpu = -1;
+    pgwt_anomaly_metrics_from_batch(batch, 8, &aas, &frac, &cpu);
     /* Active = 5 (two idle + the io_worker excluded, the CPU sample
      * included); locks = 2 → fraction 0.4. */
     CHECK(aas == 5.0, "aas=%.1f expected 5", aas);
     CHECK(frac == 0.4, "lock_fraction=%.2f expected 0.40", frac);
+    CHECK(cpu == 1.0, "cpu_aas=%.1f expected 1", cpu);
 
     /* All-idle batch → AAS 0, fraction 0 (no divide-by-zero). */
     struct pgwt_trace_event idle[2];
     memset(idle, 0, sizeof(idle));
     idle[0].new_event = WEI(PG_WAIT_CLIENT, 0);
     idle[1].new_event = WEI(PG_WAIT_ACTIVITY, 0x01);
-    pgwt_anomaly_metrics_from_batch(idle, 2, &aas, &frac);
+    pgwt_anomaly_metrics_from_batch(idle, 2, &aas, &frac, &cpu);
     CHECK(aas == 0.0, "all-idle aas=%.1f expected 0", aas);
     CHECK(frac == 0.0, "all-idle frac=%.2f expected 0", frac);
+    CHECK(cpu == 0.0, "all-idle cpu_aas=%.1f expected 0", cpu);
 }
 
 /* ── Test 8b: a pure CPU storm must be able to trip the AAS rule (AAS-1) ─ */
@@ -312,9 +373,10 @@ static void test_cpu_storm_fires(void)
 
     int fired = 0;
     for (int t = 0; t < 5; t++) {
-        double aas = -1, frac = -1;
-        pgwt_anomaly_metrics_from_batch(storm, 8, &aas, &frac);
+        double aas = -1, frac = -1, cpu = -1;
+        pgwt_anomaly_metrics_from_batch(storm, 8, &aas, &frac, &cpu);
         CHECK(aas == 8.0, "storm tick aas=%.1f expected 8", aas);
+        CHECK(cpu == 8.0, "storm tick cpu_aas=%.1f expected 8", cpu);
         struct pgwt_anomaly_decision d = pgwt_anomaly_eval(&a, aas, frac, clk);
         clk += TICK_NS;
         if (d.action == PGWT_ANOMALY_FIRE) {
@@ -341,9 +403,10 @@ static void test_cpu_storm_fires(void)
         iostorm[i].flags = PGWT_EVENT_FLAG_IO_WORKER;
     }
     for (int t = 0; t < 5; t++) {
-        double aas = -1, frac = -1;
-        pgwt_anomaly_metrics_from_batch(iostorm, 8, &aas, &frac);
+        double aas = -1, frac = -1, cpu = -1;
+        pgwt_anomaly_metrics_from_batch(iostorm, 8, &aas, &frac, &cpu);
         CHECK(aas == 0.0, "io_worker-only batch aas=%.1f expected 0", aas);
+        CHECK(cpu == 0.0, "io_worker-only cpu_aas=%.1f expected 0", cpu);
         struct pgwt_anomaly_decision d = pgwt_anomaly_eval(&b, aas, frac, clk);
         clk += TICK_NS;
         CHECK(d.action != PGWT_ANOMALY_FIRE,
@@ -478,6 +541,420 @@ static void test_combined_fire(void)
           "combined fired_mask=%u expected both AAS+LOCK", d.fired_mask);
 }
 
+/* ── AAS-1 Stage 3: realistic noisy CPU-saturation incidents ─────────── */
+static void test_cpu_cusum_incidents(void)
+{
+    printf("--- CPU CUSUM: noisy saturation incidents fire on capacity ---\n");
+
+    /* Five-minute drifted prelude, then the exact jittery storm on C=4. The
+     * baseline converges to 2.2, so storm max AAS 6 never exceeds 3x baseline;
+     * the distinct CPU rule must be the sole cause of escalation. */
+    struct pgwt_anomaly a;
+    pgwt_anomaly_init(&a, true, 10);
+    uint64_t clk = TICK_NS;
+    for (int t = 0; t < 5 * 60 * 10; t++)
+        cpu_tick(&a, drifted_baseline_aas(t), baseline_cpu_demand(t),
+                 4.0, true, false, false, &clk);
+
+    bool primary_crossed = false;
+    int fire_tick = 0;
+    unsigned fire_mask = 0;
+    for (int t = 0; t < 90; t++) {
+        int cpu = jittery_storm_cpu(t);
+        double threshold = a.aas_factor * a.baseline_aas;
+        if (cpu >= 2 && (double)cpu > threshold)
+            primary_crossed = true;
+        struct pgwt_anomaly_decision d =
+            cpu_tick(&a, cpu, cpu, 4.0, true, false, false, &clk);
+        if (d.action == PGWT_ANOMALY_FIRE) {
+            fire_tick = t + 1;
+            fire_mask = d.fired_mask;
+            break;
+        }
+    }
+    CHECK(!primary_crossed,
+          "3x total-AAS predicate crossed during C=4 storm (baseline %.2f)",
+          a.baseline_aas);
+    CHECK(fire_tick > 0 && fire_tick <= 90,
+          "C=4 noisy storm fire tick=%d expected within 9s", fire_tick);
+    CHECK((fire_mask & PGWT_RULE_CPU_SATURATION)
+          && !(fire_mask & PGWT_RULE_AAS),
+          "C=4 fire mask=%u expected CPU saturation only", fire_mask);
+    CHECK(a.cpu_saturation_fires_total == 1,
+          "C=4 cpu_saturation_fires_total=%llu expected 1",
+          (unsigned long long)a.cpu_saturation_fires_total);
+
+    /* Same prelude and stream on C=2: ratio capping makes the expected
+     * evidence rate ~0.445/s, so it should fire in roughly 3.4 seconds. */
+    struct pgwt_anomaly b;
+    pgwt_anomaly_init(&b, true, 10);
+    clk = TICK_NS;
+    for (int t = 0; t < 5 * 60 * 10; t++)
+        cpu_tick(&b, drifted_baseline_aas(t), baseline_cpu_demand(t),
+                 2.0, true, false, false, &clk);
+    fire_tick = 0;
+    for (int t = 0; t < 40; t++) {
+        int cpu = jittery_storm_cpu(t);
+        struct pgwt_anomaly_decision d =
+            cpu_tick(&b, cpu, cpu, 2.0, true, false, false, &clk);
+        if (d.action == PGWT_ANOMALY_FIRE) {
+            fire_tick = t + 1;
+            CHECK(d.fired_mask & PGWT_RULE_CPU_SATURATION,
+                  "C=2 storm fired non-CPU mask=%u", d.fired_mask);
+            break;
+        }
+    }
+    CHECK(fire_tick >= 30 && fire_tick <= 40,
+          "C=2 noisy storm fire tick=%d expected about 4s", fire_tick);
+
+    /* No baseline warmup: the baseline-independent guard still fires. */
+    struct pgwt_anomaly c;
+    pgwt_anomaly_init(&c, true, 10);
+    clk = TICK_NS;
+    fire_tick = 0;
+    for (int t = 0; t < 90; t++) {
+        int cpu = jittery_storm_cpu(t);
+        struct pgwt_anomaly_decision d =
+            cpu_tick(&c, cpu, cpu, 4.0, true, false, false, &clk);
+        if (d.action == PGWT_ANOMALY_FIRE) {
+            fire_tick = t + 1;
+            CHECK(d.fired_mask & PGWT_RULE_CPU_SATURATION,
+                  "cold-start storm fired non-CPU mask=%u", d.fired_mask);
+            break;
+        }
+    }
+    CHECK(fire_tick > 0 && fire_tick <= 90,
+          "cold-start C=4 noisy storm fire tick=%d expected within 9s",
+          fire_tick);
+
+    /* The identical four-session-mean stream is nowhere near C=16. */
+    struct pgwt_anomaly wide;
+    pgwt_anomaly_init(&wide, true, 10);
+    isolate_cpu_rule(&wide);
+    clk = TICK_NS;
+    int grants = 0;
+    for (int t = 0; t < 60 * 10; t++) {
+        int cpu = jittery_storm_cpu(t);
+        struct pgwt_anomaly_decision d =
+            cpu_tick(&wide, cpu, cpu, 16.0, true, false, false, &clk);
+        grants += d.action == PGWT_ANOMALY_FIRE;
+    }
+    CHECK(grants == 0 && wide.fires_total == 0,
+          "C=16 storm consumed %d grants / %llu fires",
+          grants, (unsigned long long)wide.fires_total);
+    CHECK(wide.dropped_budget == 0,
+          "C=16 storm recorded %llu budget drops",
+          (unsigned long long)wide.dropped_budget);
+
+    /* One arbitrarily large sample contributes only cap-k = .45 for .1s. */
+    struct pgwt_anomaly capped;
+    pgwt_anomaly_init(&capped, true, 10);
+    isolate_cpu_rule(&capped);
+    clk = TICK_NS;
+    struct pgwt_anomaly_decision one =
+        cpu_tick(&capped, 100.0, 100.0, 4.0, true, false, false, &clk);
+    CHECK(one.action != PGWT_ANOMALY_FIRE,
+          "one cpu_aas=100 tick bypassed the utilization cap");
+    CHECK(capped.cpu_cusum > 0.044 && capped.cpu_cusum < 0.046,
+          "one capped tick produced S=%.6f expected 0.045", capped.cpu_cusum);
+}
+
+/* ── AAS-1 Stage 3: evidence-quality and no-banking gates ────────────── */
+static void test_cpu_cusum_gates(void)
+{
+    printf("--- CPU CUSUM: coverage/capacity/change/cooldown gates ---\n");
+
+    struct pgwt_anomaly a;
+    pgwt_anomaly_init(&a, true, 10);
+    isolate_cpu_rule(&a);
+    uint64_t clk = TICK_NS;
+    for (int t = 0; t < 10; t++)
+        cpu_tick(&a, 5.0, 5.0, 4.0, true, false, false, &clk);
+    double before = a.cpu_cusum;
+    struct pgwt_anomaly_decision low_coverage =
+        cpu_tick(&a, 100.0, 100.0, 4.0, false, false, false, &clk);
+    CHECK(low_coverage.action != PGWT_ANOMALY_FIRE,
+          "low-coverage tick fired the CPU guard");
+    CHECK(a.cpu_cusum == before,
+          "low-coverage tick changed S %.6f -> %.6f", before, a.cpu_cusum);
+
+    /* UNKNOWN is a stable disabled state, even under impossible demand. */
+    struct pgwt_anomaly unknown;
+    pgwt_anomaly_init(&unknown, true, 10);
+    isolate_cpu_rule(&unknown);
+    clk = TICK_NS;
+    int grants = 0;
+    for (int t = 0; t < 60 * 60 * 10; t++) {
+        struct pgwt_anomaly_decision d =
+            cpu_tick(&unknown, 100.0, 100.0, -1.0,
+                     true, false, false, &clk);
+        grants += d.action == PGWT_ANOMALY_FIRE;
+    }
+    CHECK(grants == 0 && unknown.cpu_cusum == 0.0,
+          "UNKNOWN capacity produced %d grants, S=%.6f",
+          grants, unknown.cpu_cusum);
+    CHECK(unknown.fires_total == 0 && unknown.dropped_budget == 0,
+          "UNKNOWN capacity consumed fire/budget accounting");
+
+    /* A material C change invalidates evidence in the old units and skips the
+     * change tick; stable observations may start accumulating only afterward. */
+    struct pgwt_anomaly changed;
+    pgwt_anomaly_init(&changed, true, 10);
+    isolate_cpu_rule(&changed);
+    clk = TICK_NS;
+    for (int t = 0; t < 10; t++)
+        cpu_tick(&changed, 5.0, 5.0, 4.0, true, false, false, &clk);
+    CHECK(changed.cpu_cusum > 0.4, "change setup S=%.3f expected >0.4",
+          changed.cpu_cusum);
+    cpu_tick(&changed, 5.0, 5.0, 2.0, true, true, false, &clk);
+    CHECK(changed.cpu_cusum == 0.0,
+          "material capacity change did not reset S (%.6f)",
+          changed.cpu_cusum);
+    cpu_tick(&changed, 5.0, 5.0, 2.0, true, false, false, &clk);
+    CHECK(changed.cpu_cusum > 0.044 && changed.cpu_cusum < 0.046,
+          "post-change stable tick did not restart at one nominal step: %.6f",
+          changed.cpu_cusum);
+
+    /* Active windows clear evidence rather than banking an almost-fire. */
+    cpu_tick(&changed, 5.0, 5.0, 2.0, true, false, true, &clk);
+    CHECK(changed.cpu_cusum == 0.0,
+          "active escalation window banked CPU evidence %.6f",
+          changed.cpu_cusum);
+
+    /* A delayed callback still adds one nominal .1s step, not the gap. */
+    struct pgwt_anomaly delayed;
+    pgwt_anomaly_init(&delayed, true, 10);
+    isolate_cpu_rule(&delayed);
+    clk = TICK_NS;
+    cpu_tick(&delayed, 5.0, 5.0, 4.0, true, false, false, &clk);
+    clk += 30ULL * 1000000000ULL;
+    cpu_tick(&delayed, 5.0, 5.0, 4.0, true, false, false, &clk);
+    CHECK(delayed.cpu_cusum > 0.089 && delayed.cpu_cusum < 0.091,
+          "30s delayed tick produced S=%.6f expected two nominal steps",
+          delayed.cpu_cusum);
+
+    /* A fire resets S, and the subsequent cooldown cannot accumulate it. */
+    struct pgwt_anomaly cooldown;
+    pgwt_anomaly_init(&cooldown, true, 10);
+    isolate_cpu_rule(&cooldown);
+    clk = TICK_NS;
+    bool fired = false;
+    for (int t = 0; t < 100; t++) {
+        struct pgwt_anomaly_decision d =
+            cpu_tick(&cooldown, 5.0, 5.0, 4.0,
+                     true, false, false, &clk);
+        if (d.action == PGWT_ANOMALY_FIRE) {
+            fired = true;
+            break;
+        }
+    }
+    CHECK(fired && cooldown.cpu_cusum == 0.0,
+          "CPU fire did not reset S (fired=%d S=%.6f)",
+          fired, cooldown.cpu_cusum);
+    for (int t = 0; t < 100; t++)
+        cpu_tick(&cooldown, 100.0, 100.0, 4.0,
+                 true, false, false, &clk);
+    CHECK(cooldown.cpu_cusum == 0.0
+          && cooldown.cpu_saturation_fires_total == 1,
+          "cooldown banked/refired CPU evidence (S=%.6f fires=%llu)",
+          cooldown.cpu_cusum,
+          (unsigned long long)cooldown.cpu_saturation_fires_total);
+}
+
+/* ── AAS-1 Stage 3: explicit and legacy disable contracts ────────────── */
+static void test_cpu_cusum_disable_contract(void)
+{
+    printf("--- CPU CUSUM: independent + legacy disable contracts ---\n");
+    uint64_t clk = TICK_NS;
+
+    struct pgwt_anomaly independent;
+    pgwt_anomaly_init(&independent, true, 10);
+    isolate_cpu_rule(&independent);
+    independent.cpu_cusum_enabled = false;
+    int grants = 0;
+    for (int t = 0; t < 1000; t++) {
+        struct pgwt_anomaly_decision d =
+            cpu_tick(&independent, 100.0, 100.0, 4.0,
+                     true, false, false, &clk);
+        grants += d.action == PGWT_ANOMALY_FIRE;
+    }
+    CHECK(grants == 0 && independent.cpu_cusum == 0.0,
+          "independent disable produced %d grants / S %.3f",
+          grants, independent.cpu_cusum);
+
+    struct pgwt_anomaly legacy;
+    pgwt_anomaly_init(&legacy, true, 10);
+    legacy.aas_factor = PGWT_ANOMALY_DISABLE_AAS_FACTOR;
+    legacy.lock_fraction = 0.0;
+    clk = TICK_NS;
+    grants = 0;
+    for (int t = 0; t < 1000; t++) {
+        struct pgwt_anomaly_decision d =
+            cpu_tick(&legacy, 100.0, 100.0, 4.0,
+                     true, false, false, &clk);
+        grants += d.action == PGWT_ANOMALY_FIRE;
+    }
+    CHECK(grants == 0 && legacy.fires_total == 0 && legacy.cpu_cusum == 0.0,
+          "aas-factor disable produced %d grants / %llu fires / S %.3f",
+          grants, (unsigned long long)legacy.fires_total, legacy.cpu_cusum);
+}
+
+/* Drive one of the required hour-long false-positive workloads. All values
+ * presented to the detector are integers; fractional labels below are the
+ * means of their deterministic jitter patterns. */
+static void run_quiet_hour(int scenario, const char *name)
+{
+    struct pgwt_anomaly a;
+    pgwt_anomaly_init(&a, true, 10);
+    isolate_cpu_rule(&a);
+    uint64_t clk = TICK_NS;
+    int grants = 0;
+
+    for (int t = 0; t < 60 * 60 * 10; t++) {
+        int aas = 0;
+        int cpu = 0;
+        switch (scenario) {
+        case 0: { /* total AAS 1.5 <-> 3.5; CPU demand 0.4 <-> 1 */
+            bool high = ((t / 10) & 1) != 0;
+            aas = high ? 3 + (t & 1) : 1 + (t & 1);
+            int q = t % 5;
+            cpu = high ? (q == 0 ? 0 : (q == 4 ? 2 : 1))
+                       : (q < 2 ? 1 : 0);
+            break;
+        }
+        case 1: { /* adversarial CPU demand 1.5 <-> 3.5 */
+            bool high = ((t / 10) & 1) != 0;
+            cpu = high ? 3 + (t & 1) : 1 + (t & 1);
+            aas = cpu;
+            break;
+        }
+        case 2: /* OLTP total AAS 10..15, CPU demand about 1.5..2 */
+            aas = 10 + ((t * 5 + t / 7) % 6);
+            cpu = ((t / 10) & 1) ? 2 : 1 + (t & 1);
+            break;
+        case 3: { /* a 3s ~4-CPU burst once per minute */
+            int within_minute = t % (60 * 10);
+            if (within_minute < 3 * 10) {
+                cpu = jittery_storm_cpu(within_minute);
+            } else {
+                cpu = baseline_cpu_demand(t);
+            }
+            aas = cpu;
+            break;
+        }
+        case 4: /* post-lull: noisy mean 0.5 -> noisy mean 2 */
+            if (t < 30 * 60 * 10)
+                cpu = t & 1;
+            else
+                cpu = 1 + ((t * 7 + 1) % 3);
+            aas = cpu;
+            break;
+        }
+        struct pgwt_anomaly_decision d =
+            cpu_tick(&a, aas, cpu, 4.0, true, false, false, &clk);
+        grants += d.action == PGWT_ANOMALY_FIRE;
+    }
+
+    CHECK(grants == 0 && a.fires_total == 0,
+          "%s: %d grants / %llu fires in one hour", name, grants,
+          (unsigned long long)a.fires_total);
+    CHECK(a.cpu_saturation_fires_total == 0,
+          "%s: %llu CPU-rule fires in one hour", name,
+          (unsigned long long)a.cpu_saturation_fires_total);
+    CHECK(a.dropped_budget == 0,
+          "%s: %llu budget drops in one hour", name,
+          (unsigned long long)a.dropped_budget);
+}
+
+/* ── AAS-1 Stage 3: long false-positive matrix + boundaries ──────────── */
+static void test_cpu_cusum_false_positive_matrix(void)
+{
+    printf("--- CPU CUSUM: one-hour realistic negative matrix ---\n");
+    run_quiet_hour(0, "AAS 1.5<->3.5 / CPU .4<->1");
+    run_quiet_hour(1, "adversarial CPU 1.5<->3.5");
+    run_quiet_hour(2, "OLTP AAS 10..15 / CPU 1.5<->2");
+    run_quiet_hour(3, "3s four-CPU burst once/min");
+    run_quiet_hour(4, "post-lull .5->2");
+
+    /* Boundary: noisy integer demand with mean exactly .8C has zero net
+     * drift. A 37-stride permutation spreads the exact 80/20 mix of 3/4 CPU
+     * ticks irregularly while bounding excursions over every 100-tick block. */
+    struct pgwt_anomaly boundary;
+    pgwt_anomaly_init(&boundary, true, 10);
+    isolate_cpu_rule(&boundary);
+    uint64_t clk = TICK_NS;
+    double max_s = 0.0;
+    int grants = 0;
+    for (int t = 0; t < 60 * 60 * 10; t++) {
+        int q = (t * 37 + 11) % 100;
+        int cpu = q < 80 ? 3 : 4; /* mean 3.2 == .8C */
+        struct pgwt_anomaly_decision d =
+            cpu_tick(&boundary, cpu, cpu, 4.0,
+                     true, false, false, &clk);
+        if (boundary.cpu_cusum > max_s)
+            max_s = boundary.cpu_cusum;
+        grants += d.action == PGWT_ANOMALY_FIRE;
+    }
+    CHECK(grants == 0 && max_s < 0.061,
+          "noisy mean .8C grants=%d max_S=%.6f", grants, max_s);
+
+    /* The required once-per-minute burst shape contributes about .6, then
+     * ordinary low demand drains it back to zero rather than banking it. */
+    struct pgwt_anomaly burst;
+    pgwt_anomaly_init(&burst, true, 10);
+    isolate_cpu_rule(&burst);
+    clk = TICK_NS;
+    for (int t = 0; t < 3 * 10; t++) {
+        int cpu = jittery_storm_cpu(t);
+        cpu_tick(&burst, cpu, cpu, 4.0, true, false, false, &clk);
+    }
+    CHECK(burst.cpu_cusum > 0.62 && burst.cpu_cusum < 0.64,
+          "3s noisy four-CPU burst contributes S=%.6f expected ~0.63",
+          burst.cpu_cusum);
+    for (int t = 0; t < 100; t++) {
+        int cpu = baseline_cpu_demand(t);
+        cpu_tick(&burst, cpu, cpu, 4.0, true, false, false, &clk);
+    }
+    CHECK(burst.cpu_cusum == 0.0,
+          "post-burst low demand did not drain S (%.6f)", burst.cpu_cusum);
+
+    /* Noisy mean .9C: mean drift is .1 evidence-seconds/s, so h=1.5 fires
+     * at 15 seconds. */
+    struct pgwt_anomaly high;
+    pgwt_anomaly_init(&high, true, 10);
+    isolate_cpu_rule(&high);
+    clk = TICK_NS;
+    int fire_tick = 0;
+    for (int t = 0; t < 200; t++) {
+        int q = (t * 7 + 3) % 10;
+        int cpu = q < 4 ? 3 : 4; /* mean 3.6 == .9C */
+        struct pgwt_anomaly_decision d =
+            cpu_tick(&high, cpu, cpu, 4.0,
+                     true, false, false, &clk);
+        if (d.action == PGWT_ANOMALY_FIRE) {
+            fire_tick = t + 1;
+            break;
+        }
+    }
+    CHECK(fire_tick >= 145 && fire_tick <= 155,
+          "noisy mean .9C fire tick=%d expected about 150", fire_tick);
+
+    /* Below-k ticks drain accumulated evidence; they do not hard-reset it. */
+    struct pgwt_anomaly drain;
+    pgwt_anomaly_init(&drain, true, 10);
+    isolate_cpu_rule(&drain);
+    clk = TICK_NS;
+    for (int t = 0; t < 10; t++)
+        cpu_tick(&drain, 5.0, 5.0, 4.0, true, false, false, &clk);
+    double high_s = drain.cpu_cusum;
+    cpu_tick(&drain, 0.0, 0.0, 4.0, true, false, false, &clk);
+    CHECK(drain.cpu_cusum > 0.0 && drain.cpu_cusum < high_s,
+          "one low tick should drain, not reset: %.3f -> %.3f",
+          high_s, drain.cpu_cusum);
+    CHECK(drain.cpu_cusum > 0.369 && drain.cpu_cusum < 0.371,
+          "drain amount %.6f expected 0.370", drain.cpu_cusum);
+}
+
 int main(void)
 {
     test_disabled();
@@ -492,6 +969,10 @@ int main(void)
     test_lock_min_activity();
     test_baseline_learn_through();
     test_combined_fire();
+    test_cpu_cusum_incidents();
+    test_cpu_cusum_gates();
+    test_cpu_cusum_disable_contract();
+    test_cpu_cusum_false_positive_matrix();
 
     printf("\n%d/%d checks passed\n", tests_passed, tests_run);
     return tests_passed == tests_run ? 0 : 1;

--- a/tests/test_capture_smoke.py
+++ b/tests/test_capture_smoke.py
@@ -1188,13 +1188,15 @@ def phase_stale_seed_sweep(pm_pid):
 
 
 def phase_sampled_aas_truth(pm_pid):
-    """T2 (AAS-1) definition-of-done: sampled AAS — now CPU-inclusive —
-    must match pg_stat_activity 1s-sampling ground truth. A CPU-bound
+    """T2 (AAS-1) CPU-observability contract, independent of escalation
+    policy: sampled AAS — now CPU-inclusive — must match pg_stat_activity
+    ground truth. A CPU-bound
     storm (3 hogs) + a pg_sleep session; pre-T2 the sampler skipped all
     we==0 and reported AAS ~ 0.0x for exactly this shape (study Q4:
     -98%%). Anomaly escalation is disabled (huge factor) so the window is
-    PURE sampled tier."""
-    print("--- Phase 5: sampled CPU-inclusive AAS vs pg_stat_activity ---")
+    PURE sampled tier. The legacy huge-factor switch also disables the CPU
+    saturation guard, so this phase cannot pass because of escalation."""
+    print("--- Phase 5: CPU observability in pure sampled AAS ---")
     trace_dir = tempfile.mkdtemp(prefix="pgwt_smoke_aas_")
     os.chmod(trace_dir, 0o755)
 
@@ -1259,32 +1261,40 @@ def phase_sampled_aas_truth(pm_pid):
 
 
 def phase_cpu_storm_escalation(pm_pid):
-    """T2 definition-of-done: a SELECT-storm CPU incident raises sampled
-    AAS enough to trigger anomaly escalation (the engine was blind to CPU
-    before — AAS-1), and the AAS chart shows no step artifact across the
-    sampled->exact tier switch."""
-    print("--- Phase 6: CPU storm triggers escalation; no AAS step ---")
+    """AAS-1 Stage 3 saturation-policy contract. The target capacity is an
+    explicit C=2 override, so three CPU-demand sessions are deterministically
+    saturating regardless of runner size. Assert the distinct CPU CUSUM rule,
+    full-tier transition, and continuity across the sampled->exact switch."""
+    print("--- Phase 6: CPU saturation CUSUM escalation; no AAS step ---")
     trace_dir = tempfile.mkdtemp(prefix="pgwt_smoke_esc_")
     os.chmod(trace_dir, 0o755)
 
     storm = CpuStorm(3)
     tracer = subprocess.Popen(
         [TRACER, "--mode", "tiered", "--pid", str(pm_pid),
-         "-T", trace_dir, "--duration", "20", "--quiet",
-         "--interval", "5"],
+         "-T", trace_dir, "--duration", "22", "--quiet",
+         "--interval", "5", "--anomaly-cpu-capacity", "2",
+         # Isolate the CPU rule without crossing the >=1e6 legacy switch that
+         # deliberately disables it too. The pre-warmup storm gives the AAS
+         # baseline a positive value, making this factor unreachable.
+         "--anomaly-aas-factor", "999999"],
         stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    time.sleep(7.0)   # BPF load + scan + anomaly baseline warmup (~5 s idle)
+    time.sleep(3.0)   # BPF load + scan; CPU guard needs no baseline warmup
     try:
         storm_from = time.time_ns()
-        storm.fire()
-        time.sleep(5.0)
+        storm.fire(reps=800)
+        # Keep 3 demand sessions active for >=10s. C=2 reaches h after roughly
+        # 3.3s at capped demand; querying after the full observation interval
+        # avoids any host-speed/tick-phase timing assumption.
+        storm_active = sample_active_sessions(10.0, interval=0.5)
+        storm_to = time.time_ns()
         metrics = {}
+        status = {}
         try:
             metrics = ctl_query(trace_dir, "metrics")
+            status = ctl_query(trace_dir, "status")
         except OSError as e:
             print(f"  (control socket: {e})")
-        storm_active = sample_active_sessions(3.0, interval=0.5)
-        storm_to = time.time_ns()
         _, stderr = tracer.communicate(timeout=40)
         err = stderr.decode('utf-8', errors='replace')
     except subprocess.TimeoutExpired:
@@ -1294,23 +1304,35 @@ def phase_cpu_storm_escalation(pm_pid):
     finally:
         storm.stop()
 
-    fires = metrics.get("anomaly_fires_total", 0)
+    cpu_fires = metrics.get("anomaly_cpu_saturation_fires_total", 0)
     windows = metrics.get("escalation_windows_total", 0)
-    check(fires >= 1 and windows >= 1,
-          f"CPU storm triggered anomaly escalation "
-          f"(anomaly_fires_total={fires}, escalation_windows_total={windows}, "
-          f"tier={metrics.get('tier')!r}) [AAS-1: engine no longer CPU-blind]"
-          + ("" if fires >= 1 else f" (tracer stderr tail: {err[-300:]!r})"))
+    check(metrics.get("effective_cpu_capacity_cores") == 2 and
+          metrics.get("effective_cpu_capacity_source") == "override",
+          f"saturation test reports C=2 override "
+          f"(capacity={metrics.get('effective_cpu_capacity_cores')!r}, "
+          f"source={metrics.get('effective_cpu_capacity_source')!r})")
+    check(cpu_fires >= 1 and windows >= 1,
+          f"CPU saturation rule opened a full-fidelity window "
+          f"(cpu_fires={cpu_fires}, escalation_windows_total={windows}, "
+          f"tier={metrics.get('tier')!r})"
+          + ("" if cpu_fires >= 1 else
+             f" (tracer stderr tail: {err[-300:]!r})"))
+    check(status.get("tier") == "escalated" and
+          status.get("escalation_reason") == "cpu_saturation",
+          f"CPU-rule window is full tier with distinct reason "
+          f"(tier={status.get('tier')!r}, "
+          f"reason={status.get('escalation_reason')!r})")
+    check("rule=cpu-saturation" in err,
+          "CPU saturation fire is distinct in the daemon log")
 
     # No step artifact: every interior 1s bucket across the tier switch
-    # must show the storm. The anomaly fires ~0.3-1 s into the storm, so
-    # starting the window at +0.7 s puts the sampled->exact switch INSIDE
-    # the asserted range. Pre-T2, sampled buckets read ~0.0 while exact
-    # (escalated) buckets read ~3 — a hard step.
+    # must show the storm. With C=2 the CUSUM switch occurs during this >=10s
+    # window, without relying on a sub-second firing assumption. Pre-T2,
+    # sampled buckets read ~0.0 while exact buckets read ~3 — a hard step.
     resp = server_query(trace_dir, "aas",
-                        extra={"from": storm_from + 700_000_000,
-                               "to": storm_to - 1_000_000_000,
-                               "buckets": 7})
+                        extra={"from": storm_from + 500_000_000,
+                               "to": storm_to - 500_000_000,
+                               "buckets": 8})
     buckets = resp.get("buckets", [])
     check(len(buckets) >= 3, f"aas buckets across the tier switch "
           f"(got {len(buckets)}, fidelity={resp.get('fidelity')!r})")

--- a/tests/test_control.sh
+++ b/tests/test_control.sh
@@ -155,6 +155,8 @@ for k in ('events_total', 'events_per_sec', 'lifecycle_events_total',
           'state_map_full_total', 'seen_query_ids_full_total',
           'invalid_wait_reads_total', 'sampler_ticks_missed_total',
           'state_reseeds_total',
+          # AAS-1 Stage 3 CPU-saturation rule counter/state.
+          'anomaly_cpu_saturation_fires_total', 'anomaly_cpu_cusum',
           # T8 measured-CPU counters (§5.6). Present + numeric here; the exact
           # magnitudes are proven by the pure-CPU straddle acceptance test.
           'cpu_ns_total', 'offcpu_ns_total', 'cpu_clamped_total',
@@ -166,6 +168,7 @@ assert r['cpu_accounting'] in ('measured', 'legacy'), r
 # AAS-1 Stage 2: the explicit capacity override wins and is observable.
 assert r['effective_cpu_capacity_cores'] == 3.25, r
 assert r['effective_cpu_capacity_source'] == 'override', r
+assert r['anomaly_cpu_cusum_enabled'] is True, r
 "
 check $? "metrics: all counters present and numeric"
 

--- a/tests/test_sampler.c
+++ b/tests/test_sampler.c
@@ -342,10 +342,13 @@ static void test_read_validity_excludes_failures(void)
     CHECK(cpu_samples == 1,
           "exactly one CPU sample: failed reads add no CPU-class demand");
 
-    double aas = -1.0, lock_fraction = -1.0;
-    pgwt_anomaly_metrics_from_batch(out, n, &aas, &lock_fraction);
+    double aas = -1.0, lock_fraction = -1.0, cpu_aas = -1.0;
+    pgwt_anomaly_metrics_from_batch(out, n, &aas, &lock_fraction, &cpu_aas);
     CHECK(aas == 2.0,
           "AAS includes only valid CPU+wait targets (%.1f expected 2.0)", aas);
+    CHECK(cpu_aas == 1.0,
+          "CPU AAS includes only the valid CPU target (%.1f expected 1.0)",
+          cpu_aas);
 }
 
 /* ── Test 4: child process read (cross-pid, shared mapping) ───────────── */


### PR DESCRIPTION
## Summary

- add a baseline-independent CPU-demand CUSUM alongside the existing AAS and lock rules
- normalize CPU-class AAS by the postmaster's effective CPU capacity and refresh capacity at sampler cadence
- gate evidence on complete sampler read coverage and known, stable capacity; clear evidence across material capacity changes, active windows, cooldowns, and fires
- add configurable k/h/cap parameters, an independent disable switch, a distinct `cpu_saturation` escalation reason, and CPU-rule metrics
- split CPU observability from saturation-policy escalation in the capture smoke test, using a deterministic C=2 override for the latter

## Detector

`u = min(cpu_class_aas / C, 1.25)`

`S = max(0, S + nominal_dt * (u - 0.80))`

Fire at `S >= 1.50`, then reset `S`. The existing `--anomaly-aas-factor >= 1000000` convention disables this guard too.

The cap limits a single extreme sample to 0.045 evidence at the default 10 Hz. At steady demand, 100% capacity fires in about 7.5 seconds, capped demand in about 3.3 seconds, and 90% capacity in about 15 seconds.

## Safety and tests

The deterministic C tests use the requested noisy integer distributions:

- storm: P(2,3,4,5,6) = .02,.23,.50,.23,.02 (mean 4)
- drifted prelude: P(1,2,3) = .10,.60,.30 (mean 2.2) with CPU demand mean 0.8
- C=4 fires within 9 seconds without crossing the total-AAS 3x predicate
- C=2 fires in about 3.4 seconds
- cold-start C=4 fires without baseline warmup
- C=16, one extreme tick, low coverage, UNKNOWN capacity, and all required one-hour negative streams produce zero fires, grant attempts, or budget drops
- noisy 0.8C stays bounded, noisy 0.9C fires at about 15 seconds, low demand drains rather than hard-resets evidence
- delayed ticks add one nominal observation only

## Validation

- `make BPFTOOL=/tmp/bpftool/src/bpftool`
- `make -C tests check`
- `test_sampler`: 99/99
- `test_anomaly`: 153/153
- Python AST parse for `tests/test_capture_smoke.py`

No local PostgreSQL or tracer execution was performed.
