### PR TITLE
Preserve CPU CUSUM across brief coverage flaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -512,6 +512,7 @@ Auto-escalation rules evaluated on the sampled stream. Ignored outside
 | `--anomaly-cpu-cusum-k <K>` | — | `0.80` | CPU-demand CUSUM slack/reference utilization |
 | `--anomaly-cpu-cusum-h <H>` | — | `1.50` | CPU-demand CUSUM fire threshold |
 | `--anomaly-cpu-cusum-cap <U>` | — | `1.25` | Cap `cpu_AAS / effective_capacity` per tick |
+| `--anomaly-cpu-coverage-gap-s <S>` | — | `2.0` | Consecutive blind duration before held CPU evidence is discarded; converted to ticks using `--sample-rate` |
 | `--anomaly-cpu-cusum-disable` | — | off | Disable only the CPU saturation guard |
 
 For compatibility with existing pure-sampled and manual-window deployments,

--- a/src/anomaly.c
+++ b/src/anomaly.c
@@ -13,6 +13,7 @@
 #include "anomaly.h"
 #include "pg_wait_tracer.h"   /* WE_CLASS, PG_WAIT_LOCK, marker macros */
 
+#include <limits.h>
 #include <stdio.h>
 #include <string.h>
 
@@ -91,6 +92,8 @@ void pgwt_anomaly_init(struct pgwt_anomaly *a, bool enabled,
      * the small-alpha regime. H = 60s * rate. Warm up over ~5s of ticks. */
     int hz = sample_rate_hz > 0 ? sample_rate_hz : 10;
     a->sample_period_s = 1.0 / (double)hz;
+    pgwt_anomaly_set_cpu_coverage_gap_s(
+        a, PGWT_ANOMALY_DEF_CPU_COVERAGE_GAP_S);
     double half_life_ticks = 60.0 * (double)hz;
     if (half_life_ticks < 1.0)
         half_life_ticks = 1.0;
@@ -105,6 +108,30 @@ void pgwt_anomaly_init(struct pgwt_anomaly *a, bool enabled,
         PGWT_ANOMALY_DEF_LEARN_THROUGH_MIN * 60 * hz;
     if (a->slow_release_div <= 0)
         a->slow_release_div = PGWT_ANOMALY_DEF_SLOW_RELEASE_DIV;
+}
+
+void pgwt_anomaly_set_cpu_coverage_gap_s(struct pgwt_anomaly *a,
+                                         double cpu_coverage_gap_s)
+{
+    if (!(cpu_coverage_gap_s > 0.0))
+        cpu_coverage_gap_s = PGWT_ANOMALY_DEF_CPU_COVERAGE_GAP_S;
+
+    double ticks = cpu_coverage_gap_s / a->sample_period_s;
+    int reset_ticks;
+    if (ticks >= (double)INT_MAX) {
+        reset_ticks = INT_MAX;
+    } else {
+        reset_ticks = (int)ticks;
+        /* Round up fractional ticks. Tolerate floating-point noise when a
+         * duration is already an exact multiple of the nominal period. */
+        if (ticks - (double)reset_ticks > 1e-9)
+            reset_ticks++;
+        if (reset_ticks < 1)
+            reset_ticks = 1;
+    }
+
+    a->cpu_coverage_gap_reset_s = cpu_coverage_gap_s;
+    a->cpu_coverage_gap_reset_ticks = reset_ticks;
 }
 
 struct pgwt_anomaly_decision
@@ -140,21 +167,19 @@ pgwt_anomaly_eval_observation(struct pgwt_anomaly *a,
     bool cpu_fire = false;
     bool cpu_cusum_climbed = false;
 
-    /* A partial-read tick cannot establish whether demand recovered. Brief
-     * gaps hold evidence so intermittent read failures do not erase a real
-     * incident. A sustained blind interval can hide genuine recovery, so it
-     * invalidates pre-gap evidence. Once a coverage gap starts, UNKNOWN
-     * capacity remains part of that blind interval until a trusted return. */
-    if (!obs->cpu_coverage_ok
-        || (a->cpu_coverage_gap_ticks > 0
-            && obs->cpu_capacity <= 0.0)) {
+    /* LOW coverage or UNKNOWN capacity cannot establish whether demand
+     * recovered. Brief blind gaps hold evidence so intermittent failures do
+     * not erase a real incident. A sustained blind interval can hide genuine
+     * recovery, so it invalidates pre-gap evidence. Fresh UNKNOWN starts a
+     * gap independently; this core does not rely on capacity_changed edges. */
+    if (!obs->cpu_coverage_ok || obs->cpu_capacity <= 0.0) {
         if (a->cpu_coverage_gap_ticks
-            < PGWT_ANOMALY_CPU_COVERAGE_GAP_RESET_TICKS)
+            < a->cpu_coverage_gap_reset_ticks)
             a->cpu_coverage_gap_ticks++;
         if (a->cpu_coverage_gap_ticks
-            >= PGWT_ANOMALY_CPU_COVERAGE_GAP_RESET_TICKS)
+            >= a->cpu_coverage_gap_reset_ticks)
             a->cpu_cusum = 0.0;
-    } else if (obs->cpu_capacity > 0.0) {
+    } else {
         a->cpu_coverage_gap_ticks = 0;
     }
 

--- a/src/anomaly.c
+++ b/src/anomaly.c
@@ -140,14 +140,22 @@ pgwt_anomaly_eval_observation(struct pgwt_anomaly *a,
     bool cpu_fire = false;
     bool cpu_cusum_climbed = false;
 
-    /* A partial-read tick cannot establish whether demand recovered. Hold its
-     * evidence, but remember the gap so the first subsequent complete,
-     * capacity-known observation cannot fire from stale pre-gap state. */
-    if (!obs->cpu_coverage_ok)
-        a->cpu_coverage_gap = true;
-    else if (obs->cpu_capacity > 0.0 && a->cpu_coverage_gap) {
-        a->cpu_cusum = 0.0;
-        a->cpu_coverage_gap = false;
+    /* A partial-read tick cannot establish whether demand recovered. Brief
+     * gaps hold evidence so intermittent read failures do not erase a real
+     * incident. A sustained blind interval can hide genuine recovery, so it
+     * invalidates pre-gap evidence. Once a coverage gap starts, UNKNOWN
+     * capacity remains part of that blind interval until a trusted return. */
+    if (!obs->cpu_coverage_ok
+        || (a->cpu_coverage_gap_ticks > 0
+            && obs->cpu_capacity <= 0.0)) {
+        if (a->cpu_coverage_gap_ticks
+            < PGWT_ANOMALY_CPU_COVERAGE_GAP_RESET_TICKS)
+            a->cpu_coverage_gap_ticks++;
+        if (a->cpu_coverage_gap_ticks
+            >= PGWT_ANOMALY_CPU_COVERAGE_GAP_RESET_TICKS)
+            a->cpu_cusum = 0.0;
+    } else if (obs->cpu_capacity > 0.0) {
+        a->cpu_coverage_gap_ticks = 0;
     }
 
     /* A capacity discontinuity invalidates all evidence accumulated in the
@@ -186,8 +194,8 @@ pgwt_anomaly_eval_observation(struct pgwt_anomaly *a,
                     && a->cpu_cusum >= a->cpu_cusum_h;
         }
     }
-    /* LOW coverage and UNKNOWN capacity intentionally take neither branch:
-     * S is held unchanged and cannot fire from an untrusted observation. */
+    /* LOW coverage and UNKNOWN capacity never evaluate demand or fire from an
+     * untrusted observation. Brief gaps hold S; sustained gaps clear it above. */
     d.cpu_cusum = a->cpu_cusum;
 
     /* ── AAS-vs-baseline rule ──────────────────────────────────────────── */

--- a/src/anomaly.h
+++ b/src/anomaly.h
@@ -132,7 +132,7 @@ struct pgwt_anomaly {
     double sample_period_s;   /* NOMINAL 1/sample_rate_hz, never wall gap */
     double cpu_cusum;         /* O(1) accumulated saturation evidence */
     bool   cpu_armed;         /* one fire until trusted below-k recovery */
-    bool   cpu_coverage_gap;  /* reset evidence when complete coverage returns */
+    int    cpu_coverage_gap_ticks; /* blind ticks since a partial-read gap */
 
     /* ESC-7 baseline slow learn-through: after the AAS metric has been
      * continuously over the multiplicative threshold for learn_through_ticks,
@@ -185,6 +185,9 @@ struct pgwt_anomaly {
 #define PGWT_ANOMALY_DEF_CPU_CUSUM_K   0.80
 #define PGWT_ANOMALY_DEF_CPU_CUSUM_H   1.50
 #define PGWT_ANOMALY_DEF_CPU_CUSUM_CAP 1.25
+/* Brief partial-read flaps hold CPU evidence. A sustained blind interval can
+ * hide recovery, so discard pre-gap evidence after this many observations. */
+#define PGWT_ANOMALY_CPU_COVERAGE_GAP_RESET_TICKS 3
 /* Existing smoke/operational contract: this sentinel disables automatic AAS
  * anomaly behavior. Stage 3 also disables the CPU guard at this value. */
 #define PGWT_ANOMALY_DISABLE_AAS_FACTOR 1000000.0

--- a/src/anomaly.h
+++ b/src/anomaly.h
@@ -19,8 +19,8 @@
  *      CPU-class AAS divided by the postmaster's effective CPU capacity. The
  *      CUSUM advances by nominal sample time (never a delayed wall-clock gap),
  *      drains below its slack point, and fires at its evidence threshold.
- *      Config: --anomaly-cpu-min-aas/-margin, --anomaly-cpu-cusum-k/-h/-cap and
- *      --anomaly-cpu-cusum-disable.
+ *      Config: --anomaly-cpu-min-aas/-margin, --anomaly-cpu-cusum-k/-h/-cap,
+ *      --anomaly-cpu-coverage-gap-s and --anomaly-cpu-cusum-disable.
  *
  * Hysteresis + cooldown: once an auto-escalation fires, a minimum cooldown
  * (--anomaly-cooldown-s) must elapse before another auto-escalation can fire,
@@ -132,7 +132,9 @@ struct pgwt_anomaly {
     double sample_period_s;   /* NOMINAL 1/sample_rate_hz, never wall gap */
     double cpu_cusum;         /* O(1) accumulated saturation evidence */
     bool   cpu_armed;         /* one fire until trusted below-k recovery */
-    int    cpu_coverage_gap_ticks; /* blind ticks since a partial-read gap */
+    double cpu_coverage_gap_reset_s; /* configured blind-gap duration */
+    int    cpu_coverage_gap_reset_ticks; /* duration rounded up to ticks */
+    int    cpu_coverage_gap_ticks; /* consecutive LOW/UNKNOWN ticks */
 
     /* ESC-7 baseline slow learn-through: after the AAS metric has been
      * continuously over the multiplicative threshold for learn_through_ticks,
@@ -185,9 +187,11 @@ struct pgwt_anomaly {
 #define PGWT_ANOMALY_DEF_CPU_CUSUM_K   0.80
 #define PGWT_ANOMALY_DEF_CPU_CUSUM_H   1.50
 #define PGWT_ANOMALY_DEF_CPU_CUSUM_CAP 1.25
-/* Brief partial-read flaps hold CPU evidence. A sustained blind interval can
- * hide recovery, so discard pre-gap evidence after this many observations. */
-#define PGWT_ANOMALY_CPU_COVERAGE_GAP_RESET_TICKS 3
+/* Brief LOW-coverage or UNKNOWN-capacity flaps hold CPU evidence. Two seconds
+ * is comfortably beyond sub-second coverage flapping, but still discards
+ * evidence across a genuinely blind interval. The reset tick count is derived
+ * from this duration and the actual sample rate, never a fixed 10 Hz value. */
+#define PGWT_ANOMALY_DEF_CPU_COVERAGE_GAP_S 2.0
 /* Existing smoke/operational contract: this sentinel disables automatic AAS
  * anomaly behavior. Stage 3 also disables the CPU guard at this value. */
 #define PGWT_ANOMALY_DISABLE_AAS_FACTOR 1000000.0
@@ -200,6 +204,12 @@ struct pgwt_anomaly {
  * wall-clock horizon regardless of tick rate. */
 void pgwt_anomaly_init(struct pgwt_anomaly *a, bool enabled,
                        int sample_rate_hz);
+
+/* Configure how long LOW coverage or UNKNOWN CPU capacity may hold evidence.
+ * The duration is rounded up to nominal sample ticks so the reset never occurs
+ * before cpu_coverage_gap_s has elapsed. */
+void pgwt_anomaly_set_cpu_coverage_gap_s(struct pgwt_anomaly *a,
+                                         double cpu_coverage_gap_s);
 
 /* ── Pure rule evaluation (no BPF, no escalation, unit-testable) ────────── */
 

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -1074,6 +1074,9 @@ int pgwt_daemon_init(struct pgwt_daemon *d)
             d->anomaly.cpu_cusum_h = d->anomaly_cpu_cusum_h;
         if (d->anomaly_cpu_cusum_cap > 0.0)
             d->anomaly.cpu_cusum_cap = d->anomaly_cpu_cusum_cap;
+        if (d->anomaly_cpu_coverage_gap_s > 0.0)
+            pgwt_anomaly_set_cpu_coverage_gap_s(
+                &d->anomaly, d->anomaly_cpu_coverage_gap_s);
         if (d->anomaly_cpu_cusum_disabled)
             d->anomaly.cpu_cusum_enabled = false;
         if (d->verbose)
@@ -1081,7 +1084,7 @@ int pgwt_daemon_init(struct pgwt_daemon *d)
                     "INFO: anomaly triggers armed: aas>%.1f*baseline for %d "
                     "ticks, lock_frac>%.2f for %d ticks, cooldown %llus, "
                     "window %ds, cpu_cusum=%s(min_aas=%.3f margin=%.3f "
-                    "k=%.3f h=%.3f cap=%.3f)\n",
+                    "k=%.3f h=%.3f cap=%.3f coverage_gap=%.3fs/%d ticks)\n",
                     d->anomaly.aas_factor, d->anomaly.aas_ticks,
                     d->anomaly.lock_fraction, d->anomaly.lock_ticks,
                     (unsigned long long)(d->anomaly.cooldown_ns / 1000000000ULL),
@@ -1092,7 +1095,9 @@ int pgwt_daemon_init(struct pgwt_daemon *d)
                         ? "enabled" : "disabled",
                     d->anomaly.cpu_min_aas, d->anomaly.cpu_margin,
                     d->anomaly.cpu_cusum_k, d->anomaly.cpu_cusum_h,
-                    d->anomaly.cpu_cusum_cap);
+                    d->anomaly.cpu_cusum_cap,
+                    d->anomaly.cpu_coverage_gap_reset_s,
+                    d->anomaly.cpu_coverage_gap_reset_ticks);
     }
 
     /* Arm the active capture provider. For the full tier this is a no-op

--- a/src/daemon.h
+++ b/src/daemon.h
@@ -193,6 +193,7 @@ struct pgwt_daemon {
     double      anomaly_cpu_cusum_k;     /* --anomaly-cpu-cusum-k (<0 = default) */
     double      anomaly_cpu_cusum_h;     /* --anomaly-cpu-cusum-h (<0 = default) */
     double      anomaly_cpu_cusum_cap;   /* --anomaly-cpu-cusum-cap (<0 = default) */
+    double      anomaly_cpu_coverage_gap_s; /* --anomaly-cpu-coverage-gap-s */
     bool        anomaly_cpu_cusum_disabled; /* independent CPU-guard switch */
 
     /* AAS-1 Stage 2: target postmaster effective logical-core capacity.

--- a/src/pg_wait_tracer.c
+++ b/src/pg_wait_tracer.c
@@ -91,6 +91,8 @@ static void usage(const char *prog)
         "      --anomaly-cpu-cusum-k <K> CPU saturation slack/reference (default 0.80)\n"
         "      --anomaly-cpu-cusum-h <H> CPU saturation evidence threshold (default 1.50)\n"
         "      --anomaly-cpu-cusum-cap <U> Cap CPU demand/capacity ratio (default 1.25)\n"
+        "      --anomaly-cpu-coverage-gap-s <S> Blind duration before CPU evidence\n"
+        "                             resets (default 2.0s; derived at sample rate)\n"
         "      --anomaly-cpu-cusum-disable  Disable only the CPU saturation guard\n"
         "                             (--anomaly-aas-factor >= 1000000 also disables it)\n"
         "\n"
@@ -239,6 +241,7 @@ static enum pgwt_mode parse_mode(const char *s)
 #define OPT_ANOM_CPU_CUSUM_DISABLE 278
 #define OPT_ANOM_CPU_MIN_AAS 279
 #define OPT_ANOM_CPU_MARGIN 280
+#define OPT_ANOM_CPU_COVERAGE_GAP 281
 
 static struct option long_opts[] = {
     {"pid",        required_argument, NULL, 'p'},
@@ -279,6 +282,8 @@ static struct option long_opts[] = {
     {"anomaly-cpu-cusum-k", required_argument, NULL, OPT_ANOM_CPU_CUSUM_K},
     {"anomaly-cpu-cusum-h", required_argument, NULL, OPT_ANOM_CPU_CUSUM_H},
     {"anomaly-cpu-cusum-cap", required_argument, NULL, OPT_ANOM_CPU_CUSUM_CAP},
+    {"anomaly-cpu-coverage-gap-s", required_argument, NULL,
+     OPT_ANOM_CPU_COVERAGE_GAP},
     {"anomaly-cpu-cusum-disable", no_argument, NULL, OPT_ANOM_CPU_CUSUM_DISABLE},
     {"quiet",           no_argument,       NULL, 'q'},
     {"verbose",         no_argument,       NULL, 'v'},
@@ -318,6 +323,7 @@ int main(int argc, char **argv)
     d->anomaly_cpu_cusum_k   = -1.0;
     d->anomaly_cpu_cusum_h   = -1.0;
     d->anomaly_cpu_cusum_cap = -1.0;
+    d->anomaly_cpu_coverage_gap_s = -1.0;
 
     pid_t pm_pid = 0;
     const char *pgdata = NULL;
@@ -457,6 +463,20 @@ int main(int argc, char **argv)
                 return 1;
             }
             d->anomaly_cpu_cusum_cap = cap;
+            break;
+        }
+        case OPT_ANOM_CPU_COVERAGE_GAP: {
+            char *end = NULL;
+            errno = 0;
+            double seconds = strtod(optarg, &end);
+            if (errno || end == optarg || *end != '\0' ||
+                !isfinite(seconds) || seconds <= 0.0) {
+                fprintf(stderr, "FATAL: --anomaly-cpu-coverage-gap-s must "
+                        "be a finite value > 0 (got '%s')\n", optarg);
+                free(d);
+                return 1;
+            }
+            d->anomaly_cpu_coverage_gap_s = seconds;
             break;
         }
         case OPT_ANOM_CPU_CUSUM_DISABLE:

--- a/tests/test_anomaly.c
+++ b/tests/test_anomaly.c
@@ -901,10 +901,52 @@ static void test_cpu_cusum_floor_and_margin(void)
            floor_grants, affinity_grants, no_margin_grants);
 }
 
-/* ── AAS-1 Stage 3 fix: discard evidence across partial-read gaps ────── */
+/* ── CPU CUSUM regression: partial-read coverage flaps ──────────────── */
+static void test_cpu_cusum_coverage_flaps(void)
+{
+    printf("--- CPU CUSUM: brief coverage flaps retain evidence ---\n");
+
+    struct pgwt_anomaly flap;
+    pgwt_anomaly_init(&flap, true, 10);
+    isolate_cpu_rule(&flap);
+    uint64_t clk = TICK_NS;
+    int grants = 0;
+    double max_cusum = 0.0;
+    int fire_tick = 0;
+
+    /* A short-statement storm can miss one partial-read tick without the
+     * workload itself recovering. Model that as one LOW tick in every three;
+     * the two complete ticks remain saturated at the utilization cap. */
+    for (int t = 0; t < 61; t++) {
+        bool coverage_ok = t % 3 != 2;
+        struct pgwt_anomaly_decision d =
+            cpu_tick(&flap, 4.0, 4.0, 2.0,
+                     coverage_ok, false, false, &clk);
+        grants += d.action == PGWT_ANOMALY_FIRE;
+        if (d.action == PGWT_ANOMALY_FIRE && fire_tick == 0)
+            fire_tick = t + 1;
+        if (flap.cpu_cusum > max_cusum)
+            max_cusum = flap.cpu_cusum;
+    }
+
+    CHECK(grants == 1 && flap.cpu_saturation_fires_total == 1,
+          "coverage-flap storm expected one fire "
+          "(%d grants / %llu CPU fires)", grants,
+          (unsigned long long)flap.cpu_saturation_fires_total);
+    CHECK(fire_tick >= 49 && fire_tick <= 51,
+          "coverage-flap storm fire tick=%d expected about 50", fire_tick);
+    CHECK(max_cusum > 1.48 && max_cusum < 1.49,
+          "coverage-flap storm max pre-fire S=%.6f expected near h",
+          max_cusum);
+
+    printf("  flapping storm: fire=%.1fs grants=%d max_pre_fire_S=%.3f\n",
+           fire_tick / 10.0, grants, max_cusum);
+}
+
+/* ── AAS-1 Stage 3 fix: discard evidence across sustained blind gaps ── */
 static void test_cpu_cusum_coverage_return(void)
 {
-    printf("--- CPU CUSUM: coverage return resets stale evidence ---\n");
+    printf("--- CPU CUSUM: long coverage gap resets stale evidence ---\n");
 
     struct pgwt_anomaly idle_return;
     pgwt_anomaly_init(&idle_return, true, 10);
@@ -1194,6 +1236,7 @@ int main(void)
     test_cpu_cusum_gates();
     test_cpu_cusum_episode_latch();
     test_cpu_cusum_floor_and_margin();
+    test_cpu_cusum_coverage_flaps();
     test_cpu_cusum_coverage_return();
     test_cpu_cusum_near_flag();
     test_cpu_cusum_disable_contract();

--- a/tests/test_anomaly.c
+++ b/tests/test_anomaly.c
@@ -943,6 +943,106 @@ static void test_cpu_cusum_coverage_flaps(void)
            fire_tick / 10.0, grants, max_cusum);
 }
 
+/* ── CPU CUSUM regression: blind-gap reset boundaries + UNKNOWN ─────── */
+static void test_cpu_cusum_coverage_gap_boundaries(void)
+{
+    printf("--- CPU CUSUM: blind-gap boundaries and fresh UNKNOWN ---\n");
+
+    struct pgwt_anomaly rate;
+    pgwt_anomaly_init(&rate, true, 10);
+    CHECK(rate.cpu_coverage_gap_reset_s == 2.0
+          && rate.cpu_coverage_gap_reset_ticks == 20,
+          "default coverage gap is %.3fs/%d ticks, expected 2.0s/20",
+          rate.cpu_coverage_gap_reset_s,
+          rate.cpu_coverage_gap_reset_ticks);
+    pgwt_anomaly_init(&rate, true, 25);
+    CHECK(rate.cpu_coverage_gap_reset_ticks == 50,
+          "default 2.0s gap at 25Hz derived %d ticks, expected 50",
+          rate.cpu_coverage_gap_reset_ticks);
+    pgwt_anomaly_set_cpu_coverage_gap_s(&rate, 1.5);
+    CHECK(rate.cpu_coverage_gap_reset_ticks == 38,
+          "configured 1.5s gap at 25Hz derived %d ticks, expected ceil(37.5)",
+          rate.cpu_coverage_gap_reset_ticks);
+
+    /* Prime S one saturated tick below h: the next trusted saturated tick
+     * fires iff the pre-gap evidence was retained. */
+    struct pgwt_anomaly hold;
+    pgwt_anomaly_init(&hold, true, 10);
+    isolate_cpu_rule(&hold);
+    uint64_t clk = TICK_NS;
+    for (int t = 0; t < 33; t++)
+        cpu_tick(&hold, 5.0, 5.0, 4.0,
+                 true, false, false, &clk);
+    double held_s = hold.cpu_cusum;
+    int reset_ticks = hold.cpu_coverage_gap_reset_ticks;
+    for (int t = 0; t < reset_ticks - 1; t++)
+        cpu_tick(&hold, 0.0, 0.0, 4.0,
+                 false, false, false, &clk);
+    CHECK(hold.cpu_coverage_gap_ticks == reset_ticks - 1
+          && hold.cpu_cusum == held_s,
+          "RESET_TICKS-1 gap did not hold S "
+          "(gap=%d/%d S=%.6f->%.6f)",
+          hold.cpu_coverage_gap_ticks, reset_ticks, held_s, hold.cpu_cusum);
+    struct pgwt_anomaly_decision held_return =
+        cpu_tick(&hold, 5.0, 5.0, 4.0,
+                 true, false, false, &clk);
+    CHECK(held_return.action == PGWT_ANOMALY_FIRE
+          && (held_return.fired_mask & PGWT_RULE_CPU_SATURATION),
+          "RESET_TICKS-1 gap lost live incident evidence "
+          "(action=%d mask=%u)", held_return.action, held_return.fired_mask);
+
+    /* At the exact reset boundary, stale S is discarded. The trusted return
+     * contributes its own tick, but that tick alone cannot fire. */
+    struct pgwt_anomaly wipe;
+    pgwt_anomaly_init(&wipe, true, 10);
+    isolate_cpu_rule(&wipe);
+    clk = TICK_NS;
+    for (int t = 0; t < 33; t++)
+        cpu_tick(&wipe, 5.0, 5.0, 4.0,
+                 true, false, false, &clk);
+    reset_ticks = wipe.cpu_coverage_gap_reset_ticks;
+    for (int t = 0; t < reset_ticks; t++)
+        cpu_tick(&wipe, 0.0, 0.0, 4.0,
+                 false, false, false, &clk);
+    CHECK(wipe.cpu_coverage_gap_ticks == reset_ticks
+          && wipe.cpu_cusum == 0.0,
+          "RESET_TICKS gap did not wipe S (gap=%d/%d S=%.6f)",
+          wipe.cpu_coverage_gap_ticks, reset_ticks, wipe.cpu_cusum);
+    struct pgwt_anomaly_decision wiped_return =
+        cpu_tick(&wipe, 5.0, 5.0, 4.0,
+                 true, false, false, &clk);
+    CHECK(wiped_return.action != PGWT_ANOMALY_FIRE
+          && wipe.cpu_cusum > 0.044 && wipe.cpu_cusum < 0.046,
+          "RESET_TICKS gap stale-fired on trusted saturated return "
+          "(action=%d S=%.6f)", wiped_return.action, wipe.cpu_cusum);
+
+    /* Fresh UNKNOWN must bootstrap a blind gap without a preceding LOW tick
+     * or a capacity_changed edge, then reach the same exact reset boundary. */
+    struct pgwt_anomaly unknown;
+    pgwt_anomaly_init(&unknown, true, 10);
+    isolate_cpu_rule(&unknown);
+    clk = TICK_NS;
+    for (int t = 0; t < 33; t++)
+        cpu_tick(&unknown, 5.0, 5.0, 4.0,
+                 true, false, false, &clk);
+    reset_ticks = unknown.cpu_coverage_gap_reset_ticks;
+    for (int t = 0; t < reset_ticks; t++)
+        cpu_tick(&unknown, 0.0, 0.0, -1.0,
+                 true, false, false, &clk);
+    CHECK(unknown.cpu_coverage_gap_ticks == reset_ticks
+          && unknown.cpu_cusum == 0.0,
+          "fresh UNKNOWN did not independently wipe S "
+          "(gap=%d/%d S=%.6f)",
+          unknown.cpu_coverage_gap_ticks, reset_ticks, unknown.cpu_cusum);
+    struct pgwt_anomaly_decision unknown_return =
+        cpu_tick(&unknown, 5.0, 5.0, 4.0,
+                 true, false, false, &clk);
+    CHECK(unknown_return.action != PGWT_ANOMALY_FIRE
+          && unknown.cpu_cusum > 0.044 && unknown.cpu_cusum < 0.046,
+          "fresh UNKNOWN held stale S across trusted return "
+          "(action=%d S=%.6f)", unknown_return.action, unknown.cpu_cusum);
+}
+
 /* ── AAS-1 Stage 3 fix: discard evidence across sustained blind gaps ── */
 static void test_cpu_cusum_coverage_return(void)
 {
@@ -1237,6 +1337,7 @@ int main(void)
     test_cpu_cusum_episode_latch();
     test_cpu_cusum_floor_and_margin();
     test_cpu_cusum_coverage_flaps();
+    test_cpu_cusum_coverage_gap_boundaries();
     test_cpu_cusum_coverage_return();
     test_cpu_cusum_near_flag();
     test_cpu_cusum_disable_contract();


### PR DESCRIPTION
## Reproduction

- Added a deterministic C=2, CPU AAS=4.0 storm with one isolated LOW-coverage tick in every three observations.
- Before the detector change it reproduced the failure exactly: 0 grants, 0 CPU fires, final S=0.045, max S=0.090.

## Fix

- Count blind observations after partial-read coverage loss.
- Retain CUSUM evidence across gaps shorter than three observations.
- Reset evidence once the blind gap reaches three observations; UNKNOWN capacity continues an open blind interval until a trusted return.
- Leave capacity-change, active-window, cooldown, disable, absolute-floor, and drain-before-rearm gates unchanged.

## Validation

Run only on the Hetzner test box:

- Top-level build with the requested bpftool path: passed.
- make -C tests check: passed.
- test_anomaly: 173/173 checks passed.
- Flapping C=2 storm: fired once at 5.0s, max pre-fire S=1.485.
- Long 100-tick blind gap after S=1.485: no stale fire; sustained demand after return fired from fresh evidence in 3.4s.
- Existing matrix: C=4 8.4s, C=2 3.5s, C=16 0 grants; chronic busy 1 grant/hour; five normal one-hour workloads 0 grants/0 drops.

The capture-smoke storm window remains 10 seconds, twice the flapping-regression fire time, so no integration timeout change was needed.