### PR TITLE
Prevent event ring drain from starving timer ticks

### DIFF
--- a/docs/ROADMAP_AND_STATUS.md
+++ b/docs/ROADMAP_AND_STATUS.md
@@ -1353,6 +1353,27 @@ to a CHANGELOG entry).
   early skip taken by every entry). Third-generation instrumentation queued:
   STATEDUMP-TIMER (per-tick gate decision) + STATEDUMP-SCAN (iteration and
   skip-path counters).
+  **RESOLVED 2026-08-11 — FOURTH mode was an unbounded event-ring drain.**
+  The main-loop liveness trap caught the whole 13.78s capture inside
+  `event_ring_drain` (`loop_iterations=1`, `timer_ticks=0`; the hog's state
+  remained healthy/countable and its terminal trace flush was correct).
+  Finer callback-stage timing plus the bounded
+  `PGWT_TEST_EVENT_CALLBACK_DELAY_US` fault pinned the leaf: bundled libbpf
+  1.4.7's `ring_buffer__consume()` reloads `producer_pos` until an iteration
+  sees no new data, so a sustained producer can keep one consume call alive
+  indefinitely. The forced pre-fix run processed 164601 callbacks in one
+  20.686s drain; aggregate callback time was 20.673s, no callback exceeded
+  21.5ms, no writer/summary/accumulator leaf exceeded the 50ms strike line,
+  `timer_ticks=0`, live CPU*=0, while /proc measured 18.38s and the terminal
+  trace carried 21.30s. The fix caps each main-loop drain at 64 fully-processed
+  records by using the documented negative-callback stop path; a yielded
+  backlog re-enters epoll with timeout 0, so timer/signal/control fds run
+  between batches without adding a 10ms sleep or dropping the consumed record.
+  Shutdown's final correctness drain stays exhaustive. Deterministic positive
+  and negative coverage lives in `phase_event_ring_drain_budget`: fixed run
+  `timer_ticks=3`, CPU*=7059ms, `/proc=18.40s`, trace=21.32s; test-only
+  `PGWT_TEST_NO_EVENT_DRAIN_BUDGET` restores the pre-fix direction on demand
+  (`timer_ticks=0`, CPU*=0, `/proc=18.39s`, trace=21.30s).
 
 - **Multi-window %DB: windowed-delta drift of measured-CPU vs wall.** The
   multi-window `--view` (Last 1s / Last 3s) differences two cumulative ring

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -28,6 +28,8 @@
 #include "pg_wait_tracer.skel.h"
 
 #define PGWT_DEBUG_BLOCK_NS (50ULL * 1000ULL * 1000ULL)
+#define PGWT_TEST_EVENT_DELAY_COUNT 1024U
+#define PGWT_EVENT_DRAIN_CALLBACK_BUDGET 64U
 
 uint64_t pgwt_debug_monotonic_ns(void)
 {
@@ -42,6 +44,58 @@ void pgwt_debug_block_report(const char *op, pid_t pid, uint64_t started_ns)
     if (ended_ns >= started_ns && ended_ns - started_ns > PGWT_DEBUG_BLOCK_NS)
         fprintf(stderr, "STATEDUMP-BLOCK: op=%s pid=%d dur_ms=%.3f\n",
                 op, pid, (double)(ended_ns - started_ns) / 1e6);
+}
+
+/* Attribute a slow event-ring consume to callback work versus libbpf's own
+ * drain loop. ring_buffer__consume() can repeatedly reload producer_pos and
+ * therefore has no finite work bound while a producer keeps refilling the
+ * ring. The callback counters make that case decisive: many individually
+ * short callbacks whose aggregate time fills the whole block are an
+ * unbounded drain, while one slow callback stage is reported by the finer
+ * probes in event_stream.c. */
+static bool consume_event_ring(struct pgwt_daemon *d, const char *op,
+                               bool bounded)
+{
+    uint64_t started_ns = d->debug_dump_state
+                        ? pgwt_debug_monotonic_ns() : 0;
+    uint64_t callbacks_before = d->debug_event_callbacks_total;
+    uint64_t callback_ns_before = d->debug_event_callback_ns_total;
+
+    d->event_drain_callbacks_current = 0;
+    d->event_drain_callback_limit =
+        bounded && !d->test_no_event_drain_budget
+        ? PGWT_EVENT_DRAIN_CALLBACK_BUDGET : 0;
+    int rc = ring_buffer__consume(d->event_rb);
+    bool yielded = d->event_drain_callback_limit != 0
+                && d->event_drain_callbacks_current
+                   >= d->event_drain_callback_limit
+                && rc < 0;
+    d->event_drain_callback_limit = 0;
+    if (yielded && d->debug_dump_state)
+        d->debug_event_drain_yields++;
+
+    if (!d->debug_dump_state)
+        return yielded;
+
+    uint64_t ended_ns = pgwt_debug_monotonic_ns();
+
+    if (ended_ns >= started_ns && ended_ns - started_ns > PGWT_DEBUG_BLOCK_NS) {
+        uint64_t callback_ns = d->debug_event_callback_ns_total
+                             - callback_ns_before;
+        uint64_t total_ns = ended_ns - started_ns;
+        uint64_t outside_ns = callback_ns < total_ns
+                            ? total_ns - callback_ns : 0;
+        fprintf(stderr,
+                "STATEDUMP-BLOCK: op=%s pid=0 dur_ms=%.3f callbacks=%llu "
+                "callback_ms=%.3f outside_callback_ms=%.3f "
+                "max_callback_ms=%.3f rc=%d\n",
+                op, (double)total_ns / 1e6,
+                (unsigned long long)(d->debug_event_callbacks_total
+                                     - callbacks_before),
+                (double)callback_ns / 1e6, (double)outside_ns / 1e6,
+                (double)d->debug_event_callback_max_ns / 1e6, rc);
+    }
+    return yielded;
 }
 
 /* Ring buffer callback for lifecycle events */
@@ -410,8 +464,52 @@ int pgwt_daemon_init(struct pgwt_daemon *d)
     d->debug_max_timer_expirations = 0;
     d->debug_last_loop_ts_ns = 0;
     d->debug_max_loop_gap_ns = 0;
+    d->debug_event_callbacks_total = 0;
+    d->debug_event_callback_ns_total = 0;
+    d->debug_event_callback_max_ns = 0;
+    d->debug_event_drain_yields = 0;
     d->debug_timer_settime_rc = 0;
     d->debug_timer_epoll_rc = 0;
+    d->test_event_callback_delay_us = 0;
+    d->test_event_callback_delays_left = 0;
+    d->test_no_event_drain_budget =
+        getenv("PGWT_TEST_NO_EVENT_DRAIN_BUDGET") != NULL;
+    d->event_drain_callback_limit = 0;
+    d->event_drain_callbacks_current = 0;
+    if (d->test_no_event_drain_budget)
+        fprintf(stderr,
+                "WARN: PGWT_TEST_NO_EVENT_DRAIN_BUDGET — event-ring consume "
+                "is unbounded (deterministic mode-4 negative; TEST ONLY)\n");
+
+    /* TEST HOOK: slow each of a bounded number of trace-event callbacks so a
+     * sustained wait-transition producer deterministically keeps libbpf's
+     * drain-until-empty loop non-empty. This reproduces the mode-4 main-loop
+     * starvation without relying on 2-vCPU scheduler luck. */
+    {
+        const char *delay_env = getenv("PGWT_TEST_EVENT_CALLBACK_DELAY_US");
+        if (delay_env) {
+            char *end = NULL;
+            unsigned long delay_us = strtoul(delay_env, &end, 10);
+            if (end != delay_env && *end == '\0' && delay_us > 0
+                && delay_us <= 100000UL) {
+                d->test_event_callback_delay_us = (uint32_t)delay_us;
+                d->test_event_callback_delays_left =
+                    PGWT_TEST_EVENT_DELAY_COUNT;
+                fprintf(stderr,
+                        "WARN: PGWT_TEST_EVENT_CALLBACK_DELAY_US=%u — delaying "
+                        "the first %u trace callbacks (deterministic "
+                        "event-ring drain stall; TEST ONLY)\n",
+                        d->test_event_callback_delay_us,
+                        PGWT_TEST_EVENT_DELAY_COUNT);
+            } else {
+                fprintf(stderr,
+                        "WARN: ignoring invalid "
+                        "PGWT_TEST_EVENT_CALLBACK_DELAY_US=%s "
+                        "(expected integer 1..100000)\n",
+                        delay_env);
+            }
+        }
+    }
 
     /* Resolve before the control socket becomes reachable, then refresh from
      * the display timer. A failed read is represented as UNKNOWN/-1; startup
@@ -1129,6 +1227,7 @@ int pgwt_daemon_run(struct pgwt_daemon *d)
     struct epoll_event events[8];
     int rb_fd = ring_buffer__epoll_fd(d->rb);
     int event_rb_fd = d->event_rb ? ring_buffer__epoll_fd(d->event_rb) : -1;
+    bool event_ring_backlog = false;
 
     uint64_t deadline = 0;
     if (d->duration > 0) {
@@ -1147,7 +1246,10 @@ int pgwt_daemon_run(struct pgwt_daemon *d)
         d->debug_last_loop_ts_ns = pgwt_debug_monotonic_ns();
 
     while (d->running) {
-        int timeout_ms = poll_ms;
+        /* A budget yield means records remain. Re-enter epoll without sleeping
+         * so ready timer/signal/control fds run before the next event batch;
+         * if none are ready, immediately continue draining the backlog. */
+        int timeout_ms = event_ring_backlog ? 0 : poll_ms;
         if (deadline > 0) {
             struct timespec ts;
             clock_gettime(CLOCK_MONOTONIC, &ts);
@@ -1191,9 +1293,8 @@ int pgwt_daemon_run(struct pgwt_daemon *d)
                 ring_buffer__consume(d->rb);
                 pgwt_debug_block_end(d, "lifecycle_ring_consume", 0, started_ns);
             } else if (events[i].data.fd == event_rb_fd) {
-                started_ns = pgwt_debug_block_begin(d);
-                ring_buffer__consume(d->event_rb);
-                pgwt_debug_block_end(d, "event_ring_consume", 0, started_ns);
+                /* The common bounded drain below handles this readiness. Doing
+                 * it here as well would spend two callback budgets per pass. */
             } else if (events[i].data.fd == d->signal_fd) {
                 started_ns = pgwt_debug_block_begin(d);
                 handle_signal(d);
@@ -1212,9 +1313,8 @@ int pgwt_daemon_run(struct pgwt_daemon *d)
 
         /* Drain event ringbuf on every iteration (poll-based with NO_WAKEUP) */
         if (d->event_rb) {
-            started_ns = pgwt_debug_block_begin(d);
-            ring_buffer__consume(d->event_rb);
-            pgwt_debug_block_end(d, "event_ring_drain", 0, started_ns);
+            event_ring_backlog = consume_event_ring(
+                d, "event_ring_drain", true);
         }
 
         if (d->debug_dump_state) {
@@ -1229,9 +1329,7 @@ int pgwt_daemon_run(struct pgwt_daemon *d)
 
     /* Drain remaining events before cleanup */
     if (d->event_rb) {
-        uint64_t started_ns = pgwt_debug_block_begin(d);
-        ring_buffer__consume(d->event_rb);
-        pgwt_debug_block_end(d, "event_ring_final_drain", 0, started_ns);
+        consume_event_ring(d, "event_ring_final_drain", false);
     }
     uint64_t started_ns = pgwt_debug_block_begin(d);
     ring_buffer__consume(d->rb);
@@ -1287,6 +1385,9 @@ static void pgwt_debug_dump_state_map(struct pgwt_daemon *d)
             "loop_iterations=%llu timer_ticks=%llu completed_ticks=%d "
             "timer_expirations=%llu max_timer_expirations=%llu "
             "max_loop_gap_ms=%.3f last_loop_age_ms=%.3f "
+            "event_callbacks_total=%llu callback_ms_total=%.3f "
+            "max_callback_ms=%.3f event_drain_yields=%llu "
+            "test_delays_left=%u "
             "timer_settime_rc=%d timer_epoll_rc=%d "
             "state_reseeds_total=%llu invalid_wait_reads_total=%llu "
             "wp_attach_failures_total=%llu state_map_full_total=%llu "
@@ -1300,6 +1401,11 @@ static void pgwt_debug_dump_state_map(struct pgwt_daemon *d)
             (unsigned long long)d->debug_max_timer_expirations,
             (double)d->debug_max_loop_gap_ns / 1e6,
             last_loop_age_ms,
+            (unsigned long long)d->debug_event_callbacks_total,
+            (double)d->debug_event_callback_ns_total / 1e6,
+            (double)d->debug_event_callback_max_ns / 1e6,
+            (unsigned long long)d->debug_event_drain_yields,
+            d->test_event_callback_delays_left,
             d->debug_timer_settime_rc,
             d->debug_timer_epoll_rc,
             (unsigned long long)d->counters.state_reseeds_total,

--- a/src/daemon.h
+++ b/src/daemon.h
@@ -268,8 +268,28 @@ struct pgwt_daemon {
     uint64_t    debug_max_timer_expirations;
     uint64_t    debug_last_loop_ts_ns;
     uint64_t    debug_max_loop_gap_ns;
+    uint64_t    debug_event_callbacks_total;
+    uint64_t    debug_event_callback_ns_total;
+    uint64_t    debug_event_callback_max_ns;
+    uint64_t    debug_event_drain_yields;
     int         debug_timer_settime_rc;   /* 0 or saved -errno */
     int         debug_timer_epoll_rc;     /* 0 or saved -errno */
+
+    /* Deterministic event-drain stall reproducer. A nonzero delay is injected
+     * into only the first PGWT_TEST_EVENT_DELAY_COUNT trace callbacks, keeping
+     * the test fault bounded even if a producer never stops. Never enabled in
+     * production; parsed and announced once during daemon init. */
+    uint32_t    test_event_callback_delay_us;
+    uint32_t    test_event_callback_delays_left;
+    bool        test_no_event_drain_budget;
+
+    /* Per-main-loop consume budget. ring_buffer__consume() has no record
+     * limit, so the callback returns a private stop sentinel after this many
+     * fully processed records. Zero means an intentional unbounded drain
+     * (shutdown/finalization). Single-threaded: only the event callback reads
+     * these while consume is active. */
+    uint32_t    event_drain_callback_limit;
+    uint32_t    event_drain_callbacks_current;
 
     /* Placed at end of struct to survive field overflow corruption */
     char       *pg_binary_saved;        /* heap-allocated postgres binary path for USDT */

--- a/src/event_stream.c
+++ b/src/event_stream.c
@@ -14,6 +14,7 @@
 
 #include <string.h>
 #include <time.h>
+#include <errno.h>
 
 /* duration_to_bucket() moved to map_reader.c as pgwt_duration_to_bucket() */
 
@@ -55,21 +56,48 @@ int pgwt_handle_trace_event(void *ctx, void *data, size_t data_sz)
     struct pgwt_daemon *d = ctx;
     struct pgwt_trace_event *evt = data;
     struct pgwt_accumulator *acc = d->event_accum;
+    uint64_t callback_started_ns = pgwt_debug_block_begin(d);
+    uint64_t stage_started_ns;
 
     (void)data_sz;
 
     d->counters.events_total++;
+    if (d->debug_dump_state)
+        d->debug_event_callbacks_total++;
+
+    if (d->test_event_callback_delay_us
+        && d->test_event_callback_delays_left > 0) {
+        d->test_event_callback_delays_left--;
+        struct timespec requested = {
+            .tv_sec = d->test_event_callback_delay_us / 1000000U,
+            .tv_nsec = (long)(d->test_event_callback_delay_us % 1000000U)
+                     * 1000L,
+        };
+        stage_started_ns = pgwt_debug_block_begin(d);
+        while (nanosleep(&requested, &requested) != 0 && errno == EINTR)
+            ;
+        pgwt_debug_block_end(d, "event_callback_test_delay", evt->pid,
+                             stage_started_ns);
+    }
 
     /* Write to trace file if recording is enabled (including markers) */
-    if (d->event_writer)
+    if (d->event_writer) {
+        stage_started_ns = pgwt_debug_block_begin(d);
         pgwt_writer_push_event(d->event_writer, evt);
+        pgwt_debug_block_end(d, "event_callback_trace_writer", evt->pid,
+                             stage_started_ns);
+    }
 
     /* Write to summary file if recording is enabled. Markers pass through
      * here too, but the summary writer's accum_event filters them (FID-4):
      * they must land in the trace (variants / lifecycle / escalation
      * coverage need them) while never entering wait accounting. */
-    if (d->summary_writer)
+    if (d->summary_writer) {
+        stage_started_ns = pgwt_debug_block_begin(d);
         pgwt_summary_push_event(d->summary_writer, evt);
+        pgwt_debug_block_end(d, "event_callback_summary_writer", evt->pid,
+                             stage_started_ns);
+    }
 
     uint32_t we = evt->old_event;
     uint64_t dur = evt->duration_ns;
@@ -79,14 +107,18 @@ int pgwt_handle_trace_event(void *ctx, void *data, size_t data_sz)
 
     /* Skip accumulation for marker events (duration=0, not real waits) */
     if (PGWT_IS_MARKER(we))
-        return 0;
+        goto done;
 
     /* T8: fold the measured CPU of this closed interval into the lifetime
      * counters (observability + the wait-gap self-check). Display-time CPU
      * accounting is unchanged — this only reads evt->cpu_ns. */
+    stage_started_ns = pgwt_debug_block_begin(d);
     pgwt_counters_add_cpu(d, we, dur, evt->cpu_ns);
+    pgwt_debug_block_end(d, "event_callback_cpu_counters", evt->pid,
+                         stage_started_ns);
 
     /* Per-PID accumulation */
+    stage_started_ns = pgwt_debug_block_begin(d);
     struct pgwt_pid_accum *pa = pgwt_get_or_create_pid(acc, evt->pid);
 
     /* T2 live classification (decomposed AAS, docs/AAS_SEMANTICS_DECISION.md).
@@ -133,8 +165,11 @@ int pgwt_handle_trace_event(void *ctx, void *data, size_t data_sz)
                 pa->db_time_ns += dur;
         }
     }
+    pgwt_debug_block_end(d, "event_callback_pid_accumulator", evt->pid,
+                         stage_started_ns);
 
     /* System-wide accumulation */
+    stage_started_ns = pgwt_debug_block_begin(d);
     struct pgwt_event_stats *se = pgwt_get_or_create_system_event(acc, we);
     if (se) {
         se->count++;
@@ -145,15 +180,21 @@ int pgwt_handle_trace_event(void *ctx, void *data, size_t data_sz)
         if (bucket < HISTOGRAM_BUCKETS)
             se->histogram[bucket]++;
     }
+    pgwt_debug_block_end(d, "event_callback_system_accumulator", evt->pid,
+                         stage_started_ns);
 
     /* Time model by class. io_worker time is excluded from DB Time; a
      * non-command CPU interval lands in the idle (Activity) bucket. */
+    stage_started_ns = pgwt_debug_block_begin(d);
     if (!io_worker)
         pgwt_update_time_model(&acc->tm,
                                noncmd_cpu ? WEI(PG_WAIT_ACTIVITY, 0) : we,
                                dur);
+    pgwt_debug_block_end(d, "event_callback_time_model", evt->pid,
+                         stage_started_ns);
 
     /* Query events */
+    stage_started_ns = pgwt_debug_block_begin(d);
     if (evt->query_id != 0 && !io_worker) {
         struct pgwt_query_event_stats *qe =
             pgwt_get_or_create_query_event(acc, evt->query_id, we);
@@ -165,6 +206,24 @@ int pgwt_handle_trace_event(void *ctx, void *data, size_t data_sz)
         }
     }
 
+    pgwt_debug_block_end(d, "event_callback_query_accumulator", evt->pid,
+                         stage_started_ns);
+
+done:
+    if (callback_started_ns) {
+        uint64_t callback_ended_ns = pgwt_debug_monotonic_ns();
+        uint64_t callback_ns = callback_ended_ns >= callback_started_ns
+                             ? callback_ended_ns - callback_started_ns : 0;
+        d->debug_event_callback_ns_total += callback_ns;
+        if (callback_ns > d->debug_event_callback_max_ns)
+            d->debug_event_callback_max_ns = callback_ns;
+        pgwt_debug_block_report("event_callback_total", evt->pid,
+                                callback_started_ns);
+    }
+    d->event_drain_callbacks_current++;
+    if (d->event_drain_callback_limit
+        && d->event_drain_callbacks_current >= d->event_drain_callback_limit)
+        return -EAGAIN;  /* record is fully processed; ask libbpf to yield */
     return 0;
 }
 

--- a/tests/test_capture_smoke.py
+++ b/tests/test_capture_smoke.py
@@ -874,6 +874,186 @@ def phase_pure_cpu_straddle(pm_pid, mode):
     subprocess.run(["rm", "-rf", trace_dir])
 
 
+def run_event_ring_stall_capture(pm_pid, extra_env):
+    """Run the mode-4 forced-stall workload and return all three witnesses.
+
+    One waitless DO backend supplies the straddling CPU interval. Eight
+    backends emit pg_sleep transitions faster than a deliberately slowed
+    event callback can consume them. On an unbounded libbpf consume, the ring
+    never becomes empty while those producers run, so the display timer cannot
+    run. The delay hook is capped in the daemon; the SQL producers and both
+    subprocess timeouts are bounded here as well.
+    """
+    trace_dir = tempfile.mkdtemp(prefix="pgwt_smoke_event_drain_")
+    os.chmod(trace_dir, 0o755)
+
+    hog = subprocess.Popen(
+        ["psql", "-U", "postgres", "-d", "postgres"],
+        stdin=subprocess.PIPE, stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL, text=True)
+    hog.stdin.write(
+        "DO $$ DECLARE x bigint := 0; BEGIN "
+        "FOR o IN 1..100000 LOOP "
+        "FOR i IN 1..1000000 LOOP x := x + i; END LOOP; x := 0; "
+        "END LOOP; END $$;\n")
+    hog.stdin.flush()
+    time.sleep(2.5)
+
+    # Eight finite producers remove dependence on per-backend scheduling and
+    # pg_sleep granularity; together they comfortably outrun the hook's
+    # 50-callback/s consumer for the whole negative capture.
+    floods = []
+    for _ in range(8):
+        flood = subprocess.Popen(
+            ["psql", "-U", "postgres", "-d", "postgres"],
+            stdin=subprocess.PIPE, stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL, text=True)
+        flood.stdin.write(
+            "SELECT pg_sleep(0.001) FROM generate_series(1, 20000);\n")
+        flood.stdin.flush()
+        floods.append(flood)
+    time.sleep(0.3)
+
+    argv = [TRACER, "--mode", "full", "--pid", str(pm_pid),
+            "-T", trace_dir, "--duration", "8", "--interval", "2",
+            "--view", "time_model"]
+    env = {**os.environ, "PGWT_DEBUG_DUMP_STATE": "1",
+           "PGWT_TEST_EVENT_CALLBACK_DELAY_US": "20000", **extra_env}
+    tracer = subprocess.Popen(argv, stdout=subprocess.PIPE,
+                              stderr=subprocess.PIPE, env=env)
+    hog_pid = None
+    oncpu_before = oncpu_after = None
+    win_from = time.time_ns()
+    try:
+        time.sleep(3.0)
+        hog_pid = find_active_do_backend()
+        producer_pids = psql(
+            "SELECT string_agg(pid::text, ',' ORDER BY pid) "
+            "FROM pg_stat_activity WHERE state='active' "
+            "AND query LIKE 'SELECT pg_sleep(0.001)%'")
+        print(f"    forced producer pids={producer_pids!r}; "
+              f"psql_statuses={[proc.poll() for proc in floods]}")
+        oncpu_before = proc_oncpu_ns(hog_pid) if hog_pid else None
+        stdout, stderr = tracer.communicate(timeout=50)
+        oncpu_after = proc_oncpu_ns(hog_pid) if hog_pid else None
+    except subprocess.TimeoutExpired:
+        tracer.kill()
+        stdout, stderr = tracer.communicate()
+        oncpu_after = proc_oncpu_ns(hog_pid) if hog_pid else None
+    finally:
+        for proc in (*floods, hog):
+            try:
+                proc.stdin.write("\\q\n")
+                proc.stdin.flush()
+            except (BrokenPipeError, ValueError):
+                pass
+            proc.terminate()
+        cleanup_stale_backends()
+
+    out = STRIP_ANSI.sub('', stdout.decode('utf-8', errors='replace'))
+    err = stderr.decode('utf-8', errors='replace')
+    proc_ms = ((oncpu_after - oncpu_before) / 1e6
+               if oncpu_before is not None and oncpu_after is not None
+               and oncpu_after > oncpu_before else 0.0)
+    hog_trace_ms = 0.0
+    if hog_pid:
+        win_to = time.time_ns() + 3_000_000_000
+        aresp = server_query(trace_dir, "aas",
+                             extra={"from": win_from, "to": win_to,
+                                    "buckets": 12,
+                                    "filters": {"pid": hog_pid}})
+        buckets = aresp.get("buckets", [])
+        cpu_mean = (sum(b.get("cpu", 0.0) for b in buckets) / len(buckets)
+                    if buckets else 0.0)
+        hog_trace_ms = cpu_mean * (win_to - win_from) / 1e9 * 1000.0
+
+    subprocess.run(["rm", "-rf", trace_dir])
+    return out, err, hog_pid, proc_ms, hog_trace_ms
+
+
+def phase_event_ring_drain_budget(pm_pid):
+    """Mode-4 deterministic regression: a busy event ring must yield to ticks.
+
+    PGWT_TEST_EVENT_CALLBACK_DELAY_US makes a sustained transition producer
+    outrun the trace callback. libbpf 1.4.7's ring_buffer__consume() reloads
+    producer_pos until no new record arrived, so without the daemon-side work
+    budget this single drain spans the capture: timer_ticks=0, live CPU*=0,
+    while the terminal flush and /proc both show the waitless hog's CPU.
+    """
+    print("--- Phase: event-ring drain budget DETERMINISTIC "
+          "(slow callback + sustained producer) ---")
+    out, err, hog_pid, proc_ms, hog_trace_ms = run_event_ring_stall_capture(
+        pm_pid, {})
+
+    for line in err.splitlines():
+        if (line.startswith("STATEDUMP-BLOCK:")
+                or line.startswith("STATEDUMP-META:")
+                or (line.startswith("STATEDUMP:")
+                    and hog_pid is not None and f"pid={hog_pid} " in line)
+                or "PGWT_TEST_EVENT_CALLBACK_DELAY_US" in line):
+            print(f"    {line}")
+
+    check("PGWT_TEST_EVENT_CALLBACK_DELAY_US=20000" in err,
+          "bounded slow-callback hook active")
+    check(re.search(r"STATEDUMP-BLOCK: op=event_ring_(?:consume|drain).*"
+                    r"callbacks=[1-9][0-9]*", err) is not None,
+          f"slow drain reports callback count and attribution "
+          f"(stderr tail {err[-300:]!r})")
+    timer_match = re.search(r"STATEDUMP-META: .*timer_ticks=(\d+)", err)
+    timer_ticks = int(timer_match.group(1)) if timer_match else 0
+    yield_match = re.search(r"STATEDUMP-META: .*event_drain_yields=(\d+)",
+                            err)
+    drain_yields = int(yield_match.group(1)) if yield_match else 0
+    check(drain_yields > 0,
+          f"event drain hit its callback budget and yielded "
+          f"(yields={drain_yields})")
+    check(timer_ticks > 0,
+          f"display timer kept running during the forced drain "
+          f"(timer_ticks={timer_ticks})")
+    live_cpu = parse_time_model(out).get('CPU*', 0.0)
+    check(live_cpu > 500.0,
+          f"forced-drain straddler stays visible live: CPU*={live_cpu:.0f}ms")
+    check(hog_pid is not None and proc_ms > 500.0,
+          f"/proc confirms the waitless hog burned CPU "
+          f"(pid={hog_pid}, delta={proc_ms:.0f}ms)")
+    check(hog_trace_ms > 500.0,
+          f"terminal trace flush preserves the hog CPU "
+          f"(pid={hog_pid}, trace={hog_trace_ms:.0f}ms)")
+
+    # Negative: same bounded fault and producer, but explicitly restore the
+    # pre-fix unbounded libbpf call. It must recreate all three mode-4
+    # witnesses on demand: no display tick/live CPU, positive /proc CPU, and a
+    # correct terminal trace flush. This is intentionally test-only; the loud
+    # hook warning prevents accidental production use.
+    neg_out, neg_err, neg_hog_pid, neg_proc_ms, neg_trace_ms = \
+        run_event_ring_stall_capture(
+            pm_pid, {"PGWT_TEST_NO_EVENT_DRAIN_BUDGET": "1"})
+    for line in neg_err.splitlines():
+        if (line.startswith("STATEDUMP-BLOCK:")
+                or line.startswith("STATEDUMP-META:")
+                or "PGWT_TEST_NO_EVENT_DRAIN_BUDGET" in line):
+            print(f"    NEGATIVE {line}")
+    check("PGWT_TEST_NO_EVENT_DRAIN_BUDGET" in neg_err,
+          "negative restored the pre-fix unbounded consume")
+    neg_timer_match = re.search(
+        r"STATEDUMP-META: .*timer_ticks=(\d+)", neg_err)
+    neg_timer_ticks = (int(neg_timer_match.group(1))
+                       if neg_timer_match else -1)
+    check(neg_timer_ticks == 0,
+          f"unbounded negative starves the display timer "
+          f"(timer_ticks={neg_timer_ticks})")
+    neg_live_cpu = parse_time_model(neg_out).get('CPU*', 0.0)
+    check(neg_live_cpu == 0.0,
+          f"unbounded negative reproduces live CPU*=0 "
+          f"(CPU*={neg_live_cpu:.0f}ms)")
+    check(neg_hog_pid is not None and neg_proc_ms > 500.0,
+          f"negative /proc witness remains positive "
+          f"(pid={neg_hog_pid}, delta={neg_proc_ms:.0f}ms)")
+    check(neg_trace_ms > 500.0,
+          f"negative terminal trace remains correct "
+          f"(pid={neg_hog_pid}, trace={neg_trace_ms:.0f}ms)")
+
+
 def phase_straddle_recovery(pm_pid, mode):
     """DETERMINISTIC regression for the initial-scan straddle race
     (pgwt_recover_unattached_backends, docs/ROADMAP_AND_STATUS.md). phase_pure_cpu_
@@ -1444,6 +1624,8 @@ def main():
                              'need hardware watchpoints to actually fire and '
                              'precise multi-core scheduling (validated on the '
                              'T0 hosted runner + live EL8/EL9 boxes).')
+    parser.add_argument('--event-drain-only', action='store_true',
+                        help='run only the deterministic mode-4 event-drain phase')
     args = parser.parse_args()
 
     if os.geteuid() != 0:
@@ -1476,6 +1658,13 @@ def main():
 
     cleanup_stale_backends()
 
+    if args.event_drain_only:
+        if args.mode != 'full':
+            parser.error('--event-drain-only requires --mode full')
+        phase_event_ring_drain_budget(pm_pid)
+        print(f"\n{tests_passed}/{tests_run} checks passed")
+        sys.exit(0 if tests_failed == 0 else 1)
+
     core = args.capture_core
     phase_live_system_event(pm_pid, args.mode, core=core)
     phase_live_query_event(pm_pid, args.mode, core=core)
@@ -1507,6 +1696,7 @@ def main():
         # sampled/tiered the straddler is found by the sampler's lazy discovery
         # (covered by phase_pure_cpu_straddle above), not this recovery.
         if args.mode == 'full':
+            phase_event_ring_drain_budget(pm_pid)
             phase_straddle_recovery(pm_pid, args.mode)
             # Deterministic regression for the live-view CPU*=0 straddle flake:
             # a pg_sleep→loop straddler with sched_switch forced inert reads


### PR DESCRIPTION
Summary
- cap each main-loop event-ring consume at 64 fully processed callbacks
- re-enter epoll with zero timeout while backlog remains so timers, signals, and control fds run between batches
- add callback-stage liveness attribution and a bounded forced-stall hook
- add a live positive/negative regression for the mode-4 straddle signature

Pinned mechanism
The pre-fix forced run processed 164601 callbacks in one 20.686s event_ring_drain. Aggregate callback time was 20.673s, no callback exceeded 21.5ms, timer_ticks stayed 0, and live CPU* stayed 0. The same run measured 18.38s in /proc and 21.30s in the terminal trace. This pins libbpf ring_buffer__consume drain-until-empty behavior under a sustained producer, rather than watchpoint attach or a single blocking callback leaf.

Validation
All commands below ran on the Rocky 8.10 Hetzner PG13 box in /root/pgwt-mode4; nothing was built or executed locally.
- make BPFTOOL=/root/pgwt/build/bpftool/src/bpftool
- make -C tests check
- test_capture_smoke.py --mode full --pid 26393: 57/57 checks passed
- forced fixed direction: timer_ticks=3, CPU*=7070ms, /proc=18.79s, trace=21.67s
- forced unbounded negative: timer_ticks=0, CPU*=0, /proc and terminal trace positive
- existing #52, #56, and #63 deterministic straddle phases all passed