### PR TITLE
Stage 1: discover and validate PgBackendStatus layouts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,6 +100,7 @@ USER_SRCS  = $(SRC_DIR)/pg_wait_tracer.c \
              $(SRC_DIR)/anomaly.c \
              $(SRC_DIR)/backend.c \
              $(SRC_DIR)/discovery.c \
+             $(SRC_DIR)/backend_status_layout.c \
              $(SRC_DIR)/map_reader.c \
              $(SRC_DIR)/event_stream.c \
              $(SRC_DIR)/output.c \

--- a/src/backend.c
+++ b/src/backend.c
@@ -372,6 +372,14 @@ int pgwt_scan_existing_backends(struct pgwt_daemon *d)
         if (ppid != d->postmaster_pid)
             continue;
 
+        if (pgwt_pgbs_exclusion_contains(&d->pgbs_validation_exclusions,
+                                         pid)) {
+            if (d->verbose)
+                fprintf(stderr, "INFO: excluding PgBackendStatus validation "
+                        "PID %d from startup capture enrollment\n", pid);
+            continue;
+        }
+
         /* TEST HOOK: skip a straddling in-command backend (see top of fn) so
          * pgwt_recover_unattached_backends must attach it later. */
         if (skip_straddle && d->debug_query_string_addr) {
@@ -580,6 +588,10 @@ int pgwt_recover_unattached_backends(struct pgwt_daemon *d)
         if (sscanf(last_paren + 1, " %c %d", &state, &ppid) != 2)
             continue;
         if (ppid != d->postmaster_pid)
+            continue;
+
+        if (pgwt_pgbs_exclusion_contains(&d->pgbs_validation_exclusions,
+                                         pid))
             continue;
 
         /* Resolvable AND initialized (PGPROC in shm)? Attach directly — the
@@ -819,6 +831,14 @@ int pgwt_confirm_wait_offset(struct pgwt_daemon *d)
 
 int pgwt_handle_fork(struct pgwt_daemon *d, pid_t child_pid)
 {
+    if (pgwt_pgbs_exclusion_contains(&d->pgbs_validation_exclusions,
+                                     child_pid)) {
+        if (d->verbose)
+            fprintf(stderr, "INFO: excluding PgBackendStatus validation "
+                    "PID %d from fork capture enrollment\n", child_pid);
+        return 0;
+    }
+
     /* Check for duplicate */
     if (pgwt_find_backend(&d->backends, child_pid))
         return 0;
@@ -897,6 +917,9 @@ int pgwt_handle_fork(struct pgwt_daemon *d, pid_t child_pid)
 
 int pgwt_handle_init(struct pgwt_daemon *d, pid_t pid, uint64_t addr)
 {
+    if (pgwt_pgbs_exclusion_contains(&d->pgbs_validation_exclusions, pid))
+        return 0;
+
     struct pgwt_backend *be = pgwt_find_backend(&d->backends, pid);
     if (!be) {
         /* Unknown PID — might have been forked before daemon started */

--- a/src/backend_status_layout.c
+++ b/src/backend_status_layout.c
@@ -1,0 +1,1486 @@
+/* backend_status_layout.c -- strict PgBackendStatus layout discovery.
+ *
+ * This is Stage 1 shadow machinery.  Nothing in the BPF program, sampler or
+ * query attribution path reads this descriptor.  A candidate layout is useful
+ * only after both structural checks and a live coherent read accept it. */
+#define _GNU_SOURCE
+#include "backend_status_layout.h"
+#include "spawn.h"
+
+#include <ctype.h>
+#include <dirent.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <inttypes.h>
+#include <poll.h>
+#include <pwd.h>
+#include <signal.h>
+#include <stdarg.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/utsname.h>
+#include <unistd.h>
+
+/* ── Names and native key ─────────────────────────────────── */
+
+enum pgwt_pgbs_arch pgwt_pgbs_arch_from_name(const char *name)
+{
+    if (!name)
+        return PGWT_PGBS_ARCH_UNKNOWN;
+    if (strcmp(name, "x86_64") == 0 || strcmp(name, "amd64") == 0)
+        return PGWT_PGBS_ARCH_X86_64;
+    if (strcmp(name, "aarch64") == 0 || strcmp(name, "arm64") == 0)
+        return PGWT_PGBS_ARCH_ARM64;
+    return PGWT_PGBS_ARCH_UNKNOWN;
+}
+
+enum pgwt_pgbs_abi pgwt_pgbs_abi_for_arch(enum pgwt_pgbs_arch arch,
+                                           unsigned pointer_width)
+{
+    if (pointer_width != 8 || sizeof(long) != 8)
+        return PGWT_PGBS_ABI_UNKNOWN;
+    if (arch == PGWT_PGBS_ARCH_X86_64)
+        return PGWT_PGBS_ABI_SYSV_LP64;
+    if (arch == PGWT_PGBS_ARCH_ARM64)
+        return PGWT_PGBS_ABI_AAPCS64_LP64;
+    return PGWT_PGBS_ABI_UNKNOWN;
+}
+
+const char *pgwt_pgbs_arch_name(enum pgwt_pgbs_arch arch)
+{
+    switch (arch) {
+    case PGWT_PGBS_ARCH_X86_64: return "x86_64";
+    case PGWT_PGBS_ARCH_ARM64:  return "arm64";
+    default:                    return "unknown";
+    }
+}
+
+const char *pgwt_pgbs_abi_name(enum pgwt_pgbs_abi abi)
+{
+    switch (abi) {
+    case PGWT_PGBS_ABI_SYSV_LP64:    return "sysv-lp64";
+    case PGWT_PGBS_ABI_AAPCS64_LP64: return "aapcs64-lp64";
+    default:                         return "unknown";
+    }
+}
+
+const char *pgwt_pgbs_source_name(enum pgwt_pgbs_source source)
+{
+    switch (source) {
+    case PGWT_PGBS_SOURCE_DWARF:      return "DWARF";
+    case PGWT_PGBS_SOURCE_HARD_TABLE: return "hard-table";
+    default:                          return "none";
+    }
+}
+
+const char *pgwt_pgbs_validation_name(enum pgwt_pgbs_validation validation)
+{
+    switch (validation) {
+    case PGWT_PGBS_VALIDATION_VALIDATED: return "validated";
+    case PGWT_PGBS_VALIDATION_DEGRADED:  return "degraded";
+    case PGWT_PGBS_VALIDATION_REJECTED:  return "rejected";
+    default:                             return "not-run";
+    }
+}
+
+static void set_detail(struct PgBackendStatusLayout *layout,
+                       const char *fmt, ...)
+{
+    va_list ap;
+    va_start(ap, fmt);
+    vsnprintf(layout->detail, sizeof(layout->detail), fmt, ap);
+    va_end(ap);
+}
+
+static void set_field(struct pgwt_pgbs_field *field, uint32_t offset,
+                      uint8_t width, bool present)
+{
+    field->offset = offset;
+    field->width = width;
+    field->present = present;
+    field->validation = present ? PGWT_PGBS_FIELD_NOT_RUN
+                                : PGWT_PGBS_FIELD_ABSENT;
+}
+
+/* ── Header-derived hard table ────────────────────────────── */
+
+struct pgwt_pgbs_hard_row {
+    int major;
+    enum pgwt_pgbs_arch arch;
+    enum pgwt_pgbs_abi abi;
+    uint8_t pointer_width;
+    uint16_t struct_size;
+    uint16_t changecount;
+    uint8_t changecount_width;
+    uint16_t procpid;
+    uint8_t procpid_width;
+    uint16_t databaseid;
+    uint8_t databaseid_width;
+    uint16_t userid;
+    uint8_t userid_width;
+    uint16_t state;
+    uint8_t state_width;
+    uint16_t activity_raw;
+    uint8_t activity_raw_width;
+    uint16_t query_id;
+    uint8_t query_id_width;
+    bool query_present;
+    bool query_signed;
+    int8_t state_running;
+    int8_t state_fastpath;
+    int8_t state_max;
+};
+
+/* Generated with offsetof/sizeof probes against PGDG server headers:
+ *   x86_64: 13.23, 14.24, 15.19, 16.15, 17.10, 18.4
+ *   ARM64:  PGDG ARM64 headers, compiled by Clang --target=aarch64-linux-gnu
+ *           against an ARM64 Rocky 8 sysroot.  PG13's removed package used
+ *           its 13.23 server headers with the native ARM64 PG configuration.
+ * Every field width and enum value is part of the key's value.  Do not merge
+ * rows across architectures merely because these LP64 results coincide. */
+#define PGBS_ROW(pg, architecture, abi_, size_, qpresent_, qsigned_, run_, fast_, max_) \
+    { (pg), (architecture), (abi_), 8, (size_), \
+      0, 4, 4, 4, 48, 4, 52, 4, 232, 4, 248, 8, \
+      (qpresent_) ? 424 : 0, (qpresent_) ? 8 : 0, \
+      (qpresent_), (qsigned_), (run_), (fast_), (max_) }
+
+static const struct pgwt_pgbs_hard_row hard_rows[] = {
+    PGBS_ROW(13, PGWT_PGBS_ARCH_X86_64, PGWT_PGBS_ABI_SYSV_LP64,
+             424, false, false, 2, 4, 6),
+    PGBS_ROW(14, PGWT_PGBS_ARCH_X86_64, PGWT_PGBS_ABI_SYSV_LP64,
+             432, true,  false, 2, 4, 6),
+    PGBS_ROW(15, PGWT_PGBS_ARCH_X86_64, PGWT_PGBS_ABI_SYSV_LP64,
+             432, true,  false, 2, 4, 6),
+    PGBS_ROW(16, PGWT_PGBS_ARCH_X86_64, PGWT_PGBS_ABI_SYSV_LP64,
+             432, true,  false, 2, 4, 6),
+    PGBS_ROW(17, PGWT_PGBS_ARCH_X86_64, PGWT_PGBS_ABI_SYSV_LP64,
+             432, true,  false, 2, 4, 6),
+    PGBS_ROW(18, PGWT_PGBS_ARCH_X86_64, PGWT_PGBS_ABI_SYSV_LP64,
+             440, true,  true,  3, 5, 7),
+
+    PGBS_ROW(13, PGWT_PGBS_ARCH_ARM64, PGWT_PGBS_ABI_AAPCS64_LP64,
+             424, false, false, 2, 4, 6),
+    PGBS_ROW(14, PGWT_PGBS_ARCH_ARM64, PGWT_PGBS_ABI_AAPCS64_LP64,
+             432, true,  false, 2, 4, 6),
+    PGBS_ROW(15, PGWT_PGBS_ARCH_ARM64, PGWT_PGBS_ABI_AAPCS64_LP64,
+             432, true,  false, 2, 4, 6),
+    PGBS_ROW(16, PGWT_PGBS_ARCH_ARM64, PGWT_PGBS_ABI_AAPCS64_LP64,
+             432, true,  false, 2, 4, 6),
+    PGBS_ROW(17, PGWT_PGBS_ARCH_ARM64, PGWT_PGBS_ABI_AAPCS64_LP64,
+             432, true,  false, 2, 4, 6),
+    PGBS_ROW(18, PGWT_PGBS_ARCH_ARM64, PGWT_PGBS_ABI_AAPCS64_LP64,
+             440, true,  true,  3, 5, 7),
+};
+
+#undef PGBS_ROW
+
+static void layout_from_row(const struct pgwt_pgbs_hard_row *row,
+                            struct PgBackendStatusLayout *out)
+{
+    memset(out, 0, sizeof(*out));
+    out->major = row->major;
+    out->arch = row->arch;
+    out->abi = row->abi;
+    out->pointer_width = row->pointer_width;
+    out->struct_size = row->struct_size;
+    set_field(&out->st_changecount, row->changecount,
+              row->changecount_width, true);
+    set_field(&out->st_procpid, row->procpid, row->procpid_width, true);
+    set_field(&out->st_databaseid, row->databaseid,
+              row->databaseid_width, true);
+    set_field(&out->st_userid, row->userid, row->userid_width, true);
+    set_field(&out->st_state, row->state, row->state_width, true);
+    set_field(&out->st_activity_raw, row->activity_raw,
+              row->activity_raw_width, true);
+    set_field(&out->st_query_id, row->query_id, row->query_id_width,
+              row->query_present);
+    out->st_query_id_signed = row->query_signed;
+    out->state_running = row->state_running;
+    out->state_fastpath = row->state_fastpath;
+    out->state_max = row->state_max;
+    out->source = PGWT_PGBS_SOURCE_HARD_TABLE;
+    out->validation = PGWT_PGBS_VALIDATION_NOT_RUN;
+    set_detail(out, "header-derived candidate; runtime validation pending");
+}
+
+int pgwt_pgbs_hard_table_lookup(int pg_major, enum pgwt_pgbs_arch arch,
+                                unsigned pointer_width,
+                                enum pgwt_pgbs_abi abi,
+                                struct PgBackendStatusLayout *out)
+{
+    if (!out)
+        return -1;
+    memset(out, 0, sizeof(*out));
+    for (size_t i = 0; i < sizeof(hard_rows) / sizeof(hard_rows[0]); i++) {
+        const struct pgwt_pgbs_hard_row *row = &hard_rows[i];
+        if (row->major == pg_major && row->arch == arch &&
+            row->pointer_width == pointer_width && row->abi == abi) {
+            layout_from_row(row, out);
+            return 0;
+        }
+    }
+    return -1;
+}
+
+/* ── Strict readelf/DWARF parser ──────────────────────────── */
+
+enum dwarf_tag {
+    DT_OTHER = 0,
+    DT_STRUCTURE,
+    DT_TYPEDEF,
+    DT_MEMBER,
+    DT_BASE,
+    DT_POINTER,
+    DT_ENUM,
+    DT_ENUMERATOR,
+    DT_CONST,
+    DT_VOLATILE,
+    DT_RESTRICT,
+    DT_ATOMIC,
+};
+
+enum dwarf_name {
+    DN_NONE = 0,
+    DN_PGBS,
+    DN_CHANGECOUNT,
+    DN_PROCPID,
+    DN_DATABASEID,
+    DN_USERID,
+    DN_STATE,
+    DN_ACTIVITY_RAW,
+    DN_QUERY_ID,
+    DN_STATE_RUNNING,
+    DN_STATE_FASTPATH,
+    DN_STATE_DISABLED,
+};
+
+struct dwarf_die {
+    uint64_t id;
+    uint64_t type_id;
+    int parent;
+    int depth;
+    uint32_t byte_size;
+    int64_t const_value;
+    int encoding;
+    enum dwarf_tag tag;
+    enum dwarf_name name;
+    bool has_type;
+    bool has_byte_size;
+    bool has_const_value;
+    bool declaration;
+    bool location_seen;
+    bool location_constant;
+    uint64_t location;
+};
+
+struct dwarf_vec {
+    struct dwarf_die *dies;
+    size_t count;
+    size_t capacity;
+};
+
+static enum dwarf_tag dwarf_tag_code(const char *tag)
+{
+    if (strcmp(tag, "DW_TAG_structure_type") == 0) return DT_STRUCTURE;
+    if (strcmp(tag, "DW_TAG_typedef") == 0) return DT_TYPEDEF;
+    if (strcmp(tag, "DW_TAG_member") == 0) return DT_MEMBER;
+    if (strcmp(tag, "DW_TAG_base_type") == 0) return DT_BASE;
+    if (strcmp(tag, "DW_TAG_pointer_type") == 0) return DT_POINTER;
+    if (strcmp(tag, "DW_TAG_enumeration_type") == 0) return DT_ENUM;
+    if (strcmp(tag, "DW_TAG_enumerator") == 0) return DT_ENUMERATOR;
+    if (strcmp(tag, "DW_TAG_const_type") == 0) return DT_CONST;
+    if (strcmp(tag, "DW_TAG_volatile_type") == 0) return DT_VOLATILE;
+    if (strcmp(tag, "DW_TAG_restrict_type") == 0) return DT_RESTRICT;
+    if (strcmp(tag, "DW_TAG_atomic_type") == 0) return DT_ATOMIC;
+    return DT_OTHER;
+}
+
+static enum dwarf_name dwarf_name_code(const char *name)
+{
+    if (strcmp(name, "PgBackendStatus") == 0) return DN_PGBS;
+    if (strcmp(name, "st_changecount") == 0) return DN_CHANGECOUNT;
+    if (strcmp(name, "st_procpid") == 0) return DN_PROCPID;
+    if (strcmp(name, "st_databaseid") == 0) return DN_DATABASEID;
+    if (strcmp(name, "st_userid") == 0) return DN_USERID;
+    if (strcmp(name, "st_state") == 0) return DN_STATE;
+    if (strcmp(name, "st_activity_raw") == 0) return DN_ACTIVITY_RAW;
+    if (strcmp(name, "st_query_id") == 0) return DN_QUERY_ID;
+    if (strcmp(name, "STATE_RUNNING") == 0) return DN_STATE_RUNNING;
+    if (strcmp(name, "STATE_FASTPATH") == 0) return DN_STATE_FASTPATH;
+    if (strcmp(name, "STATE_DISABLED") == 0) return DN_STATE_DISABLED;
+    return DN_NONE;
+}
+
+static int dwarf_push(struct dwarf_vec *vec, const struct dwarf_die *die)
+{
+    if (vec->count == vec->capacity) {
+        size_t cap = vec->capacity ? vec->capacity * 2 : 4096;
+        void *p = realloc(vec->dies, cap * sizeof(*vec->dies));
+        if (!p)
+            return -1;
+        vec->dies = p;
+        vec->capacity = cap;
+    }
+    vec->dies[vec->count++] = *die;
+    return 0;
+}
+
+static const char *attr_value(const char *line, const char *attr)
+{
+    const char *p = strstr(line, attr);
+    if (!p)
+        return NULL;
+    p = strchr(p + strlen(attr), ':');
+    if (!p)
+        return NULL;
+    p++;
+    while (isspace((unsigned char)*p))
+        p++;
+    return p;
+}
+
+static bool parse_uint_constant(const char *value, uint64_t *out)
+{
+    if (!value || !*value || *value == '-')
+        return false;
+    errno = 0;
+    char *end = NULL;
+    unsigned long long v = strtoull(value, &end, 0);
+    if (errno || end == value)
+        return false;
+    while (isspace((unsigned char)*end))
+        end++;
+    if (*end != '\0')
+        return false;
+    *out = (uint64_t)v;
+    return true;
+}
+
+static bool parse_int_constant(const char *value, int64_t *out)
+{
+    if (!value || !*value)
+        return false;
+    errno = 0;
+    char *end = NULL;
+    long long v = strtoll(value, &end, 0);
+    if (errno || end == value)
+        return false;
+    while (isspace((unsigned char)*end))
+        end++;
+    if (*end != '\0')
+        return false;
+    *out = (int64_t)v;
+    return true;
+}
+
+static void parse_dwarf_name(struct dwarf_die *die, const char *value)
+{
+    /* readelf may prefix an indirect-string description.  The actual name is
+     * after its last colon; target names themselves contain no colon. */
+    const char *name = strrchr(value, ':');
+    name = name ? name + 1 : value;
+    while (isspace((unsigned char)*name))
+        name++;
+    char buf[96];
+    size_t n = strcspn(name, "\r\n");
+    while (n > 0 && isspace((unsigned char)name[n - 1]))
+        n--;
+    if (n >= sizeof(buf))
+        n = sizeof(buf) - 1;
+    memcpy(buf, name, n);
+    buf[n] = '\0';
+    die->name = dwarf_name_code(buf);
+}
+
+static int parse_dwarf_stream(FILE *fp, struct dwarf_vec *vec,
+                              char *why, size_t why_sz)
+{
+    int stack[64];
+    for (size_t i = 0; i < sizeof(stack) / sizeof(stack[0]); i++)
+        stack[i] = -1;
+    int current = -1;
+    char line[2048];
+
+    while (fgets(line, sizeof(line), fp)) {
+        int depth = 0, abbrev = 0;
+        unsigned long long id = 0;
+        char tag[80];
+        if (sscanf(line, " <%d><%llx>: Abbrev Number: %d (%79[^)])",
+                   &depth, &id, &abbrev, tag) == 4) {
+            if (depth < 0 || depth >= (int)(sizeof(stack) / sizeof(stack[0]))) {
+                snprintf(why, why_sz, "DWARF nesting depth out of range");
+                return -1;
+            }
+            struct dwarf_die die;
+            memset(&die, 0, sizeof(die));
+            die.id = id;
+            die.depth = depth;
+            die.parent = depth > 0 ? stack[depth - 1] : -1;
+            die.tag = dwarf_tag_code(tag);
+            if (dwarf_push(vec, &die) != 0) {
+                snprintf(why, why_sz, "out of memory parsing DWARF");
+                return -1;
+            }
+            current = (int)vec->count - 1;
+            stack[depth] = current;
+            for (int i = depth + 1; i < (int)(sizeof(stack) / sizeof(stack[0])); i++)
+                stack[i] = -1;
+            continue;
+        }
+        if (current < 0)
+            continue;
+
+        struct dwarf_die *die = &vec->dies[current];
+        const char *value;
+        if ((value = attr_value(line, "DW_AT_name")) != NULL) {
+            parse_dwarf_name(die, value);
+        } else if ((value = attr_value(line, "DW_AT_type")) != NULL) {
+            const char *p = strstr(value, "<0x");
+            unsigned long long type_id;
+            if (p && sscanf(p, "<0x%llx>", &type_id) == 1) {
+                die->type_id = type_id;
+                die->has_type = true;
+            }
+        } else if ((value = attr_value(line, "DW_AT_byte_size")) != NULL) {
+            uint64_t v;
+            if (parse_uint_constant(value, &v) && v <= UINT32_MAX) {
+                die->byte_size = (uint32_t)v;
+                die->has_byte_size = true;
+            }
+        } else if ((value = attr_value(line,
+                                        "DW_AT_data_member_location")) != NULL) {
+            uint64_t v;
+            die->location_seen = true;
+            die->location_constant = parse_uint_constant(value, &v);
+            if (die->location_constant)
+                die->location = v;
+        } else if ((value = attr_value(line, "DW_AT_const_value")) != NULL) {
+            int64_t v;
+            if (parse_int_constant(value, &v)) {
+                die->const_value = v;
+                die->has_const_value = true;
+            }
+        } else if ((value = attr_value(line, "DW_AT_encoding")) != NULL) {
+            die->encoding = atoi(value);
+        } else if ((value = attr_value(line, "DW_AT_declaration")) != NULL) {
+            die->declaration = atoi(value) != 0;
+        }
+    }
+    return 0;
+}
+
+static int find_die(const struct dwarf_vec *vec, uint64_t id)
+{
+    /* DIE offsets emitted by readelf are monotonically increasing. */
+    size_t lo = 0, hi = vec->count;
+    while (lo < hi) {
+        size_t mid = lo + (hi - lo) / 2;
+        if (vec->dies[mid].id < id)
+            lo = mid + 1;
+        else
+            hi = mid;
+    }
+    if (lo < vec->count && vec->dies[lo].id == id)
+        return (int)lo;
+    return -1;
+}
+
+static int resolve_type(const struct dwarf_vec *vec, int index)
+{
+    for (int depth = 0; index >= 0 && depth < 32; depth++) {
+        const struct dwarf_die *die = &vec->dies[index];
+        if (die->tag != DT_TYPEDEF && die->tag != DT_CONST &&
+            die->tag != DT_VOLATILE && die->tag != DT_RESTRICT &&
+            die->tag != DT_ATOMIC)
+            return index;
+        if (!die->has_type)
+            return -1;
+        index = find_die(vec, die->type_id);
+    }
+    return -1;
+}
+
+static int member_type(const struct dwarf_vec *vec,
+                       const struct dwarf_die *member)
+{
+    if (!member->has_type)
+        return -1;
+    int index = find_die(vec, member->type_id);
+    return resolve_type(vec, index);
+}
+
+static bool fields_overlap(const struct pgwt_pgbs_field *a,
+                           const struct pgwt_pgbs_field *b)
+{
+    if (!a->present || !b->present)
+        return false;
+    return a->offset < b->offset + b->width &&
+           b->offset < a->offset + a->width;
+}
+
+static int structurally_sane(const struct PgBackendStatusLayout *layout,
+                             char *why, size_t why_sz)
+{
+    const struct pgwt_pgbs_field *fields[] = {
+        &layout->st_changecount, &layout->st_procpid,
+        &layout->st_databaseid, &layout->st_userid, &layout->st_state,
+        &layout->st_activity_raw, &layout->st_query_id,
+    };
+    if (layout->struct_size < 32 || layout->struct_size > 65536) {
+        snprintf(why, why_sz, "implausible PgBackendStatus byte size %u",
+                 layout->struct_size);
+        return -1;
+    }
+    if (!layout->st_changecount.present || layout->st_changecount.width != 4 ||
+        !layout->st_procpid.present || layout->st_procpid.width != 4 ||
+        !layout->st_databaseid.present || layout->st_databaseid.width != 4 ||
+        !layout->st_userid.present || layout->st_userid.width != 4 ||
+        !layout->st_state.present || layout->st_state.width != 4 ||
+        !layout->st_activity_raw.present ||
+        layout->st_activity_raw.width != layout->pointer_width) {
+        snprintf(why, why_sz, "missing mandatory member or implausible width");
+        return -1;
+    }
+    if (layout->major >= 14 &&
+        (!layout->st_query_id.present || layout->st_query_id.width != 8)) {
+        snprintf(why, why_sz, "PG%d requires an 8-byte st_query_id",
+                 layout->major);
+        return -1;
+    }
+    if (layout->major == 13 && layout->st_query_id.present) {
+        snprintf(why, why_sz, "PG13 unexpectedly declares st_query_id");
+        return -1;
+    }
+    for (size_t i = 0; i < sizeof(fields) / sizeof(fields[0]); i++) {
+        if (fields[i]->present &&
+            (uint64_t)fields[i]->offset + fields[i]->width > layout->struct_size) {
+            snprintf(why, why_sz, "member extends beyond struct byte size");
+            return -1;
+        }
+        for (size_t j = i + 1; j < sizeof(fields) / sizeof(fields[0]); j++) {
+            if (fields_overlap(fields[i], fields[j])) {
+                snprintf(why, why_sz, "selected members overlap");
+                return -1;
+            }
+        }
+    }
+    if (layout->state_running < 0 || layout->state_fastpath < 0 ||
+        layout->state_max < layout->state_running ||
+        layout->state_max < layout->state_fastpath ||
+        layout->state_running == layout->state_fastpath ||
+        layout->state_max > 64) {
+        snprintf(why, why_sz, "implausible BackendState enumerators");
+        return -1;
+    }
+    return 0;
+}
+
+static struct pgwt_pgbs_field *layout_field(struct PgBackendStatusLayout *layout,
+                                             enum dwarf_name name)
+{
+    switch (name) {
+    case DN_CHANGECOUNT: return &layout->st_changecount;
+    case DN_PROCPID:     return &layout->st_procpid;
+    case DN_DATABASEID:  return &layout->st_databaseid;
+    case DN_USERID:      return &layout->st_userid;
+    case DN_STATE:       return &layout->st_state;
+    case DN_ACTIVITY_RAW:return &layout->st_activity_raw;
+    case DN_QUERY_ID:    return &layout->st_query_id;
+    default:             return NULL;
+    }
+}
+
+static int layout_from_struct(const struct dwarf_vec *vec, int struct_index,
+                              int pg_major, unsigned pointer_width,
+                              struct PgBackendStatusLayout *layout,
+                              char *why, size_t why_sz)
+{
+    const struct dwarf_die *structure = &vec->dies[struct_index];
+    memset(layout, 0, sizeof(*layout));
+    layout->major = pg_major;
+    layout->pointer_width = pointer_width;
+    layout->source = PGWT_PGBS_SOURCE_DWARF;
+    if (!structure->has_byte_size) {
+        snprintf(why, why_sz, "PgBackendStatus has no byte size");
+        return -1;
+    }
+    layout->struct_size = structure->byte_size;
+    set_field(&layout->st_query_id, 0, 0, false);
+
+    int state_type = -1;
+    unsigned found_mask = 0;
+    for (size_t i = 0; i < vec->count; i++) {
+        const struct dwarf_die *member = &vec->dies[i];
+        if (member->parent != struct_index || member->tag != DT_MEMBER)
+            continue;
+        struct pgwt_pgbs_field *field = layout_field(layout, member->name);
+        if (!field)
+            continue;
+        unsigned bit = 1u << (unsigned)(member->name - DN_CHANGECOUNT);
+        if (found_mask & bit) {
+            snprintf(why, why_sz, "duplicate member in PgBackendStatus");
+            return -1;
+        }
+        found_mask |= bit;
+        if (!member->location_seen || !member->location_constant ||
+            member->location > UINT32_MAX) {
+            snprintf(why, why_sz,
+                     "member location is missing or is a DWARF expression");
+            return -1;
+        }
+        int type_index = member_type(vec, member);
+        if (type_index < 0 || !vec->dies[type_index].has_byte_size ||
+            vec->dies[type_index].byte_size == 0 ||
+            vec->dies[type_index].byte_size > UINT8_MAX) {
+            snprintf(why, why_sz, "member type has no plausible byte size");
+            return -1;
+        }
+        set_field(field, (uint32_t)member->location,
+                  (uint8_t)vec->dies[type_index].byte_size, true);
+        if (member->name == DN_STATE)
+            state_type = type_index;
+        if (member->name == DN_ACTIVITY_RAW &&
+            vec->dies[type_index].tag != DT_POINTER) {
+            snprintf(why, why_sz, "st_activity_raw is not a pointer");
+            return -1;
+        }
+        if (member->name == DN_QUERY_ID) {
+            if (vec->dies[type_index].tag != DT_BASE) {
+                snprintf(why, why_sz, "st_query_id is not an integer base type");
+                return -1;
+            }
+            if (vec->dies[type_index].encoding == 5 ||
+                vec->dies[type_index].encoding == 6)
+                layout->st_query_id_signed = true;
+            else if (vec->dies[type_index].encoding == 7 ||
+                     vec->dies[type_index].encoding == 8)
+                layout->st_query_id_signed = false;
+            else {
+                snprintf(why, why_sz, "st_query_id has unsupported signedness");
+                return -1;
+            }
+        }
+    }
+
+    if (state_type < 0 || vec->dies[state_type].tag != DT_ENUM) {
+        snprintf(why, why_sz, "st_state does not resolve to an enum");
+        return -1;
+    }
+    bool have_running = false, have_fastpath = false, have_disabled = false;
+    for (size_t i = 0; i < vec->count; i++) {
+        const struct dwarf_die *e = &vec->dies[i];
+        if (e->parent != state_type || e->tag != DT_ENUMERATOR)
+            continue;
+        if (e->name == DN_STATE_RUNNING || e->name == DN_STATE_FASTPATH ||
+            e->name == DN_STATE_DISABLED) {
+            if (!e->has_const_value || e->const_value < 0 ||
+                e->const_value > INT32_MAX) {
+                snprintf(why, why_sz, "BackendState enumerator has no constant value");
+                return -1;
+            }
+            if (e->name == DN_STATE_RUNNING) {
+                if (have_running) goto duplicate_enum;
+                have_running = true;
+                layout->state_running = (int)e->const_value;
+            } else if (e->name == DN_STATE_FASTPATH) {
+                if (have_fastpath) goto duplicate_enum;
+                have_fastpath = true;
+                layout->state_fastpath = (int)e->const_value;
+            } else {
+                if (have_disabled) goto duplicate_enum;
+                have_disabled = true;
+                layout->state_max = (int)e->const_value;
+            }
+        }
+    }
+    if (!have_running || !have_fastpath || !have_disabled) {
+        snprintf(why, why_sz, "mandatory BackendState enumerator missing");
+        return -1;
+    }
+    if (structurally_sane(layout, why, why_sz) != 0)
+        return -1;
+    set_detail(layout, "complete constant-offset DWARF candidate; runtime validation pending");
+    return 0;
+
+duplicate_enum:
+    snprintf(why, why_sz, "duplicate BackendState enumerator");
+    return -1;
+}
+
+static bool layouts_equal(const struct PgBackendStatusLayout *a,
+                          const struct PgBackendStatusLayout *b)
+{
+#define SAME_FIELD(f) \
+    (a->f.present == b->f.present && a->f.offset == b->f.offset && \
+     a->f.width == b->f.width)
+    return a->struct_size == b->struct_size &&
+           SAME_FIELD(st_changecount) && SAME_FIELD(st_procpid) &&
+           SAME_FIELD(st_databaseid) && SAME_FIELD(st_userid) &&
+           SAME_FIELD(st_state) && SAME_FIELD(st_activity_raw) &&
+           SAME_FIELD(st_query_id) &&
+           a->st_query_id_signed == b->st_query_id_signed &&
+           a->state_running == b->state_running &&
+           a->state_fastpath == b->state_fastpath &&
+           a->state_max == b->state_max;
+#undef SAME_FIELD
+}
+
+int pgwt_pgbs_parse_dwarf(FILE *fp, int pg_major, unsigned pointer_width,
+                          struct PgBackendStatusLayout *out,
+                          char *why, size_t why_sz)
+{
+    if (!fp || !out || !why || why_sz == 0)
+        return -1;
+    memset(out, 0, sizeof(*out));
+    why[0] = '\0';
+    struct dwarf_vec vec = {0};
+    if (parse_dwarf_stream(fp, &vec, why, why_sz) != 0) {
+        free(vec.dies);
+        return -1;
+    }
+
+    struct PgBackendStatusLayout accepted;
+    bool have_accepted = false;
+    int seen_structs[256];
+    size_t nseen = 0;
+    for (size_t i = 0; i < vec.count; i++) {
+        const struct dwarf_die *root = &vec.dies[i];
+        if (root->name != DN_PGBS ||
+            (root->tag != DT_STRUCTURE && root->tag != DT_TYPEDEF))
+            continue;
+        int target = (int)i;
+        if (root->tag == DT_TYPEDEF) {
+            if (!root->has_type)
+                continue;
+            target = resolve_type(&vec, find_die(&vec, root->type_id));
+        }
+        if (target < 0 || vec.dies[target].tag != DT_STRUCTURE ||
+            vec.dies[target].declaration)
+            continue;
+        bool duplicate = false;
+        for (size_t j = 0; j < nseen; j++)
+            if (seen_structs[j] == target)
+                duplicate = true;
+        if (duplicate)
+            continue;
+        if (nseen < sizeof(seen_structs) / sizeof(seen_structs[0]))
+            seen_structs[nseen++] = target;
+
+        struct PgBackendStatusLayout candidate;
+        char candidate_why[160];
+        if (layout_from_struct(&vec, target, pg_major, pointer_width,
+                               &candidate, candidate_why,
+                               sizeof(candidate_why)) != 0)
+            continue;
+        if (!have_accepted) {
+            accepted = candidate;
+            have_accepted = true;
+        } else if (!layouts_equal(&accepted, &candidate)) {
+            snprintf(why, why_sz,
+                     "ambiguous PgBackendStatus definitions disagree");
+            free(vec.dies);
+            return -1;
+        }
+    }
+    free(vec.dies);
+
+    if (!have_accepted) {
+        snprintf(why, why_sz,
+                 "no complete unambiguous PgBackendStatus definition");
+        return -1;
+    }
+    *out = accepted;
+    return 0;
+}
+
+/* ── Discovery order ─────────────────────────────────────── */
+
+static void native_key(enum pgwt_pgbs_arch *arch, enum pgwt_pgbs_abi *abi)
+{
+    struct utsname un;
+    *arch = PGWT_PGBS_ARCH_UNKNOWN;
+    *abi = PGWT_PGBS_ABI_UNKNOWN;
+    if (uname(&un) == 0)
+        *arch = pgwt_pgbs_arch_from_name(un.machine);
+    *abi = pgwt_pgbs_abi_for_arch(*arch, sizeof(void *));
+}
+
+static uint32_t required_fallback_mask(int pg_major)
+{
+    uint32_t mask = PGWT_PGBS_FALLBACK_STATE |
+                    PGWT_PGBS_FALLBACK_ACTIVITY_RAW;
+    if (pg_major >= 14)
+        mask |= PGWT_PGBS_FALLBACK_QUERY_ID;
+    return mask;
+}
+
+int pgwt_pgbs_discover(const char *pg_binary, int pg_major,
+                       struct PgBackendStatusLayout *out)
+{
+    if (!out)
+        return -1;
+    memset(out, 0, sizeof(*out));
+    enum pgwt_pgbs_arch arch;
+    enum pgwt_pgbs_abi abi;
+    native_key(&arch, &abi);
+
+    char dwarf_why[160] = "readelf unavailable";
+    if (pg_binary && *pg_binary) {
+        char *argv[] = { "readelf", "--debug-dump=info", "--wide",
+                         (char *)pg_binary, NULL };
+        struct pgwt_proc proc;
+        if (pgwt_proc_open(&proc, argv) == 0) {
+            struct PgBackendStatusLayout dwarf;
+            int rc = pgwt_pgbs_parse_dwarf(proc.out, pg_major, sizeof(void *),
+                                           &dwarf, dwarf_why,
+                                           sizeof(dwarf_why));
+            int status = pgwt_proc_close(&proc);
+            if (rc == 0 && status == 0) {
+                dwarf.arch = arch;
+                dwarf.abi = abi;
+                *out = dwarf;
+                return 0;
+            }
+        }
+    }
+
+    if (pgwt_pgbs_hard_table_lookup(pg_major, arch, sizeof(void *), abi,
+                                    out) == 0) {
+        set_detail(out, "DWARF rejected (%s); header-derived candidate; "
+                   "runtime validation pending", dwarf_why);
+        return 0;
+    }
+
+    out->major = pg_major;
+    out->arch = arch;
+    out->abi = abi;
+    out->pointer_width = sizeof(void *);
+    out->source = PGWT_PGBS_SOURCE_NONE;
+    out->validation = PGWT_PGBS_VALIDATION_REJECTED;
+    out->fallback_mask = required_fallback_mask(pg_major);
+    set_detail(out, "DWARF rejected (%s); no exact hard-table key", dwarf_why);
+    return -1;
+}
+
+/* ── Pure runtime validation ──────────────────────────────── */
+
+static bool has_read(const struct pgwt_pgbs_snapshot *snapshot, uint32_t bit)
+{
+    return (snapshot->read_mask & bit) != 0;
+}
+
+int pgwt_pgbs_validate_snapshot(struct PgBackendStatusLayout *layout,
+                                const struct pgwt_pgbs_snapshot *snapshot,
+                                const struct pgwt_pgbs_expected *expected)
+{
+    if (!layout || !snapshot || !expected)
+        return -1;
+
+    bool coherent = has_read(snapshot, PGWT_PGBS_READ_CHANGECOUNT) &&
+                    snapshot->changecount_before ==
+                        snapshot->changecount_after &&
+                    (snapshot->changecount_before & 1u) == 0;
+    bool pid_ok = has_read(snapshot, PGWT_PGBS_READ_PROCPID) &&
+                  snapshot->procpid == (uint32_t)expected->pid &&
+                  snapshot->procpid > 0;
+    bool db_ok = has_read(snapshot, PGWT_PGBS_READ_DATABASEID) &&
+                 snapshot->databaseid > 0 &&
+                 (!expected->databaseid ||
+                  snapshot->databaseid == expected->databaseid);
+    bool user_ok = has_read(snapshot, PGWT_PGBS_READ_USERID) &&
+                   snapshot->userid > 0 &&
+                   (!expected->userid || snapshot->userid == expected->userid);
+    bool identity_ok = coherent && pid_ok && db_ok && user_ok;
+
+    layout->st_changecount.validation = coherent
+        ? PGWT_PGBS_FIELD_VALIDATED : PGWT_PGBS_FIELD_INVALID;
+    layout->st_procpid.validation = pid_ok
+        ? PGWT_PGBS_FIELD_VALIDATED : PGWT_PGBS_FIELD_INVALID;
+    layout->st_databaseid.validation = db_ok
+        ? PGWT_PGBS_FIELD_VALIDATED : PGWT_PGBS_FIELD_INVALID;
+    layout->st_userid.validation = user_ok
+        ? PGWT_PGBS_FIELD_VALIDATED : PGWT_PGBS_FIELD_INVALID;
+
+    bool state_ok = identity_ok && has_read(snapshot, PGWT_PGBS_READ_STATE) &&
+                    snapshot->state <= (uint32_t)layout->state_max &&
+                    (!expected->require_running ||
+                     snapshot->state == (uint32_t)layout->state_running ||
+                     snapshot->state == (uint32_t)layout->state_fastpath);
+    if (state_ok && expected->state_shadow_available) {
+        bool active = snapshot->state == (uint32_t)layout->state_running ||
+                      snapshot->state == (uint32_t)layout->state_fastpath;
+        state_ok = active == expected->state_active;
+    }
+    layout->st_state.validation = state_ok
+        ? PGWT_PGBS_FIELD_VALIDATED : PGWT_PGBS_FIELD_INVALID;
+
+    bool activity_ok = identity_ok &&
+                       has_read(snapshot, PGWT_PGBS_READ_ACTIVITY) &&
+                       snapshot->activity_raw != 0 &&
+                       snapshot->activity_readable;
+    layout->st_activity_raw.validation = activity_ok
+        ? PGWT_PGBS_FIELD_VALIDATED : PGWT_PGBS_FIELD_INVALID;
+
+    bool query_ok = true;
+    if (layout->major >= 14) {
+        query_ok = identity_ok && layout->st_query_id.present &&
+                   has_read(snapshot, PGWT_PGBS_READ_QUERY_ID) &&
+                   expected->query_id_available &&
+                   snapshot->query_id == expected->query_id;
+        layout->st_query_id.validation = query_ok
+            ? PGWT_PGBS_FIELD_VALIDATED : PGWT_PGBS_FIELD_INVALID;
+    } else {
+        layout->st_query_id.validation = PGWT_PGBS_FIELD_ABSENT;
+    }
+
+    layout->fallback_mask = 0;
+    if (!state_ok)
+        layout->fallback_mask |= PGWT_PGBS_FALLBACK_STATE;
+    if (!activity_ok)
+        layout->fallback_mask |= PGWT_PGBS_FALLBACK_ACTIVITY_RAW;
+    if (layout->major >= 14 && !query_ok)
+        layout->fallback_mask |= PGWT_PGBS_FALLBACK_QUERY_ID;
+    layout->validation = layout->fallback_mask
+        ? PGWT_PGBS_VALIDATION_DEGRADED
+        : PGWT_PGBS_VALIDATION_VALIDATED;
+    layout->validated_pid = identity_ok ? expected->pid : 0;
+
+    if (layout->validation == PGWT_PGBS_VALIDATION_VALIDATED)
+        set_detail(layout, "coherent controlled-backend read and shadow comparison passed");
+    else
+        set_detail(layout,
+                   "runtime validation failed: coherent=%s pid=%s db=%s user=%s "
+                   "state=%s activity=%s query=%s",
+                   coherent ? "yes" : "no", pid_ok ? "yes" : "no",
+                   db_ok ? "yes" : "no", user_ok ? "yes" : "no",
+                   state_ok ? "yes" : "no", activity_ok ? "yes" : "no",
+                   layout->major < 14 ? "n/a" : (query_ok ? "yes" : "no"));
+    return layout->validation == PGWT_PGBS_VALIDATION_VALIDATED ? 0 : -1;
+}
+
+/* ── Live controlled-backend validator ───────────────────── */
+
+static ssize_t pread_exact(int fd, void *buf, size_t size, uint64_t addr)
+{
+    ssize_t n;
+    do {
+        n = pread(fd, buf, size, (off_t)addr);
+    } while (n < 0 && errno == EINTR);
+    return n == (ssize_t)size ? n : -1;
+}
+
+static int read_field_value(int fd, uint64_t base,
+                            const struct pgwt_pgbs_field *field,
+                            uint64_t *value)
+{
+    uint8_t buf[8] = {0};
+    if (!field->present || field->width == 0 || field->width > sizeof(buf) ||
+        pread_exact(fd, buf, field->width, base + field->offset) < 0)
+        return -1;
+    memcpy(value, buf, field->width);
+    return 0;
+}
+
+static int read_snapshot_fd(int fd, uint64_t base,
+                            const struct PgBackendStatusLayout *layout,
+                            struct pgwt_pgbs_snapshot *snapshot,
+                            char *activity, size_t activity_sz)
+{
+    memset(snapshot, 0, sizeof(*snapshot));
+    if (activity && activity_sz)
+        activity[0] = '\0';
+    for (int attempt = 0; attempt < 32; attempt++) {
+        uint64_t value;
+        snapshot->read_mask = 0;
+        if (read_field_value(fd, base, &layout->st_changecount, &value) != 0)
+            return -1;
+        snapshot->changecount_before = (uint32_t)value;
+        snapshot->read_mask |= PGWT_PGBS_READ_CHANGECOUNT;
+        if (snapshot->changecount_before & 1u)
+            continue;
+
+#define READ_VALUE(field_, member_, bit_) do { \
+            if (read_field_value(fd, base, &layout->field_, &value) == 0) { \
+                snapshot->member_ = (__typeof__(snapshot->member_))value; \
+                snapshot->read_mask |= (bit_); \
+            } \
+        } while (0)
+        READ_VALUE(st_procpid, procpid, PGWT_PGBS_READ_PROCPID);
+        READ_VALUE(st_databaseid, databaseid, PGWT_PGBS_READ_DATABASEID);
+        READ_VALUE(st_userid, userid, PGWT_PGBS_READ_USERID);
+        READ_VALUE(st_state, state, PGWT_PGBS_READ_STATE);
+        READ_VALUE(st_activity_raw, activity_raw, PGWT_PGBS_READ_ACTIVITY);
+        if (layout->st_query_id.present)
+            READ_VALUE(st_query_id, query_id, PGWT_PGBS_READ_QUERY_ID);
+#undef READ_VALUE
+
+        if (read_field_value(fd, base, &layout->st_changecount, &value) != 0)
+            return -1;
+        snapshot->changecount_after = (uint32_t)value;
+        if (snapshot->changecount_before != snapshot->changecount_after ||
+            (snapshot->changecount_after & 1u))
+            continue;
+
+        if (snapshot->activity_raw && activity && activity_sz) {
+            ssize_t n = pread(fd, activity, activity_sz - 1,
+                              (off_t)snapshot->activity_raw);
+            if (n > 0) {
+                activity[n] = '\0';
+                snapshot->activity_readable = true;
+            }
+        }
+        return 0;
+    }
+    return -1;
+}
+
+static int open_mem(pid_t pid)
+{
+    char path[64];
+    snprintf(path, sizeof(path), "/proc/%d/mem", pid);
+    return open(path, O_RDONLY | O_CLOEXEC);
+}
+
+static int candidate_ok(int fd, uint64_t base,
+                        const struct PgBackendStatusLayout *layout,
+                        const struct pgwt_pgbs_expected *expected,
+                        const char *activity_marker,
+                        struct pgwt_pgbs_snapshot *snapshot)
+{
+    char activity[512];
+    if (read_snapshot_fd(fd, base, layout, snapshot,
+                         activity, sizeof(activity)) != 0)
+        return 0;
+    if (snapshot->procpid != (uint32_t)expected->pid ||
+        snapshot->databaseid == 0 || snapshot->userid == 0 ||
+        (expected->databaseid &&
+         snapshot->databaseid != expected->databaseid) ||
+        (expected->userid && snapshot->userid != expected->userid) ||
+        snapshot->state > (uint32_t)layout->state_max ||
+        !snapshot->activity_readable ||
+        (activity_marker && !strstr(activity, activity_marker)))
+        return 0;
+    if (expected->state_shadow_available) {
+        bool active = snapshot->state == (uint32_t)layout->state_running ||
+                      snapshot->state == (uint32_t)layout->state_fastpath;
+        if (active != expected->state_active)
+            return 0;
+    }
+    return 1;
+}
+
+static uint64_t scan_shared_for_entry(pid_t pid,
+                                      const struct PgBackendStatusLayout *layout,
+                                      const struct pgwt_pgbs_expected *expected,
+                                      const char *activity_marker,
+                                      struct pgwt_pgbs_snapshot *snapshot)
+{
+    char maps_path[64];
+    snprintf(maps_path, sizeof(maps_path), "/proc/%d/maps", pid);
+    FILE *maps = fopen(maps_path, "r");
+    if (!maps)
+        return 0;
+    int mem_fd = open_mem(pid);
+    if (mem_fd < 0) {
+        fclose(maps);
+        return 0;
+    }
+
+    const size_t chunk_size = 1024 * 1024;
+    const uint64_t scan_cap = 512ULL * 1024 * 1024;
+    uint8_t *buf = malloc(chunk_size);
+    uint64_t scanned = 0, found = 0;
+    unsigned matches = 0;
+    char line[1024];
+    while (buf && scanned < scan_cap && fgets(line, sizeof(line), maps)) {
+        unsigned long long start, end;
+        char perms[5] = "";
+        if (sscanf(line, "%llx-%llx %4s", &start, &end, perms) != 3 ||
+            perms[0] != 'r' || perms[1] != 'w' || perms[3] != 's' ||
+            end <= start)
+            continue;
+        for (uint64_t pos = start; pos < end && scanned < scan_cap;) {
+            size_t want = (size_t)((end - pos) > chunk_size
+                                   ? chunk_size : (end - pos));
+            if (scanned + want > scan_cap)
+                want = (size_t)(scan_cap - scanned);
+            ssize_t n = pread(mem_fd, buf, want, (off_t)pos);
+            scanned += want;
+            if (n > 0) {
+                for (size_t off = 0; off + sizeof(uint32_t) <= (size_t)n;
+                     off += sizeof(uint32_t)) {
+                    uint32_t value;
+                    memcpy(&value, buf + off, sizeof(value));
+                    if (value != (uint32_t)expected->pid ||
+                        pos + off < layout->st_procpid.offset)
+                        continue;
+                    uint64_t base = pos + off - layout->st_procpid.offset;
+                    if (base % layout->pointer_width != 0 ||
+                        base < start || base + layout->struct_size > end)
+                        continue;
+                    struct pgwt_pgbs_snapshot candidate;
+                    if (candidate_ok(mem_fd, base, layout, expected,
+                                     activity_marker, &candidate)) {
+                        found = base;
+                        *snapshot = candidate;
+                        matches++;
+                    }
+                }
+            }
+            pos += want;
+        }
+    }
+    free(buf);
+    close(mem_fd);
+    fclose(maps);
+    return matches == 1 ? found : 0;
+}
+
+static int postmaster_connection(pid_t postmaster_pid, int *port,
+                                 char *socket_dir, size_t socket_sz,
+                                 char *user, size_t user_sz)
+{
+    char cwd_link[64], pgdata[512];
+    snprintf(cwd_link, sizeof(cwd_link), "/proc/%d/cwd", postmaster_pid);
+    ssize_t n = readlink(cwd_link, pgdata, sizeof(pgdata) - 1);
+    if (n < 0)
+        return -1;
+    pgdata[n] = '\0';
+    char pidfile[640];
+    snprintf(pidfile, sizeof(pidfile), "%s/postmaster.pid", pgdata);
+    FILE *fp = fopen(pidfile, "r");
+    if (!fp)
+        return -1;
+    *port = 5432;
+    socket_dir[0] = '\0';
+    char line[512];
+    for (int lineno = 1; fgets(line, sizeof(line), fp); lineno++) {
+        line[strcspn(line, "\r\n")] = '\0';
+        if (lineno == 4)
+            *port = atoi(line);
+        else if (lineno == 5)
+            snprintf(socket_dir, socket_sz, "%s", line);
+    }
+    fclose(fp);
+    char *comma = strchr(socket_dir, ',');
+    if (comma)
+        *comma = '\0';
+    while (socket_dir[0] && isspace((unsigned char)socket_dir[0]))
+        memmove(socket_dir, socket_dir + 1, strlen(socket_dir));
+
+    char status_path[64];
+    snprintf(status_path, sizeof(status_path), "/proc/%d/status", postmaster_pid);
+    fp = fopen(status_path, "r");
+    if (!fp)
+        return -1;
+    uid_t uid = (uid_t)-1;
+    while (fgets(line, sizeof(line), fp)) {
+        unsigned value;
+        if (sscanf(line, "Uid:\t%u", &value) == 1) {
+            uid = (uid_t)value;
+            break;
+        }
+    }
+    fclose(fp);
+    struct passwd *pw = uid == (uid_t)-1 ? NULL : getpwuid(uid);
+    if (!pw)
+        return -1;
+    snprintf(user, user_sz, "%s", pw->pw_name);
+    return *port > 0 ? 0 : -1;
+}
+
+static int spawn_psql(const char *psql, const char *user,
+                      const char *socket_dir, int port, const char *sql,
+                      struct pgwt_proc *proc)
+{
+    char port_str[16];
+    snprintf(port_str, sizeof(port_str), "%d", port);
+    char *argv_with_socket[] = {
+        "runuser", "-u", (char *)user, "--", (char *)psql,
+        "-X", "-Atq", "-v", "ON_ERROR_STOP=1",
+        "-h", (char *)socket_dir, "-p", port_str,
+        "-d", "postgres", "-c", (char *)sql, NULL,
+    };
+    char *argv_default_socket[] = {
+        "runuser", "-u", (char *)user, "--", (char *)psql,
+        "-X", "-Atq", "-v", "ON_ERROR_STOP=1",
+        "-p", port_str, "-d", "postgres", "-c", (char *)sql, NULL,
+    };
+    return pgwt_proc_open(proc, socket_dir[0] ? argv_with_socket
+                                              : argv_default_socket);
+}
+
+static int observe_controlled_backend(const char *psql, const char *user,
+                                      const char *socket_dir, int port,
+                                      const char *appname, int pg_major,
+                                      struct pgwt_pgbs_expected *expected)
+{
+    char sql[768];
+    if (pg_major >= 14)
+        snprintf(sql, sizeof(sql),
+                 "SELECT pid,datid,usesysid,COALESCE(query_id,0)::text "
+                 "FROM pg_stat_activity WHERE application_name='%s' "
+                 "AND state='active' ORDER BY backend_start DESC LIMIT 1",
+                 appname);
+    else
+        snprintf(sql, sizeof(sql),
+                 "SELECT pid,datid,usesysid FROM pg_stat_activity "
+                 "WHERE application_name='%s' AND state='active' "
+                 "ORDER BY backend_start DESC LIMIT 1", appname);
+
+    for (int attempt = 0; attempt < 12; attempt++) {
+        struct pgwt_proc observer;
+        if (spawn_psql(psql, user, socket_dir, port, sql, &observer) != 0)
+            return -1;
+        char line[256] = "";
+        bool got = fgets(line, sizeof(line), observer.out) != NULL;
+        int status = pgwt_proc_close(&observer);
+        if (got && status == 0) {
+            char *save = NULL;
+            char *pid_s = strtok_r(line, "|\r\n", &save);
+            char *db_s = strtok_r(NULL, "|\r\n", &save);
+            char *user_s = strtok_r(NULL, "|\r\n", &save);
+            char *qid_s = pg_major >= 14
+                ? strtok_r(NULL, "|\r\n", &save) : NULL;
+            if (pid_s && db_s && user_s) {
+                expected->pid = (pid_t)strtol(pid_s, NULL, 10);
+                expected->databaseid = (uint32_t)strtoul(db_s, NULL, 10);
+                expected->userid = (uint32_t)strtoul(user_s, NULL, 10);
+                expected->require_running = true;
+                expected->state_shadow_available = true;
+                expected->state_active = true;
+                if (pg_major >= 14 && qid_s) {
+                    expected->query_id = (uint64_t)strtoll(qid_s, NULL, 10);
+                    expected->query_id_available = true;
+                }
+                if (expected->pid > 0 && expected->databaseid > 0 &&
+                    expected->userid > 0)
+                    return 0;
+            }
+        }
+        usleep(50000);
+    }
+    return -1;
+}
+
+static void degrade_unvalidated(struct PgBackendStatusLayout *layout,
+                                const char *reason)
+{
+    struct pgwt_pgbs_field *fields[] = {
+        &layout->st_changecount, &layout->st_procpid,
+        &layout->st_databaseid, &layout->st_userid, &layout->st_state,
+        &layout->st_activity_raw, &layout->st_query_id,
+    };
+    for (size_t i = 0; i < sizeof(fields) / sizeof(fields[0]); i++)
+        fields[i]->validation = fields[i]->present
+            ? PGWT_PGBS_FIELD_INVALID : PGWT_PGBS_FIELD_ABSENT;
+    layout->validation = layout->source == PGWT_PGBS_SOURCE_NONE
+        ? PGWT_PGBS_VALIDATION_REJECTED : PGWT_PGBS_VALIDATION_DEGRADED;
+    layout->fallback_mask = required_fallback_mask(layout->major);
+    layout->validated_pid = 0;
+    set_detail(layout, "%s", reason);
+}
+
+int pgwt_pgbs_validate_runtime(struct PgBackendStatusLayout *layout,
+                               pid_t postmaster_pid,
+                               uint64_t my_be_entry_addr,
+                               const char *pg_binary)
+{
+    if (!layout || layout->source == PGWT_PGBS_SOURCE_NONE) {
+        if (layout)
+            degrade_unvalidated(layout, "no discovered layout to validate");
+        return -1;
+    }
+    int port;
+    char socket_dir[512], user[128];
+    if (!pg_binary ||
+        postmaster_connection(postmaster_pid, &port, socket_dir,
+                              sizeof(socket_dir), user, sizeof(user)) != 0) {
+        degrade_unvalidated(layout,
+                            "controlled-backend connection metadata unavailable");
+        return -1;
+    }
+    char psql[512];
+    snprintf(psql, sizeof(psql), "%s", pg_binary);
+    char *slash = strrchr(psql, '/');
+    if (!slash) {
+        degrade_unvalidated(layout, "postgres binary has no bindir");
+        return -1;
+    }
+    snprintf(slash + 1, (size_t)(psql + sizeof(psql) - slash - 1), "psql");
+
+    char appname[96], controlled_sql[256];
+    snprintf(appname, sizeof(appname), "pgwt-layout-validation-%d",
+             postmaster_pid);
+    snprintf(controlled_sql, sizeof(controlled_sql),
+             "SET application_name='%s'; SELECT pg_sleep(5)", appname);
+    struct pgwt_proc controlled;
+    if (spawn_psql(psql, user, socket_dir, port, controlled_sql,
+                   &controlled) != 0) {
+        degrade_unvalidated(layout, "could not start controlled backend");
+        return -1;
+    }
+
+    struct pgwt_pgbs_expected expected;
+    memset(&expected, 0, sizeof(expected));
+    int observed = observe_controlled_backend(psql, user, socket_dir, port,
+                                              appname, layout->major,
+                                              &expected);
+    struct pgwt_pgbs_snapshot snapshot;
+    memset(&snapshot, 0, sizeof(snapshot));
+    uint64_t base = 0;
+    if (observed == 0) {
+        int mem_fd = open_mem(expected.pid);
+        if (mem_fd >= 0) {
+            if (my_be_entry_addr)
+                (void)pread_exact(mem_fd, &base, sizeof(base),
+                                  my_be_entry_addr);
+            if (base)
+                (void)read_snapshot_fd(mem_fd, base, layout, &snapshot,
+                                       (char[512]){0}, 512);
+            close(mem_fd);
+        }
+        if (!base)
+            base = scan_shared_for_entry(expected.pid, layout, &expected,
+                                         "pg_sleep",
+                                         &snapshot);
+    }
+
+    /* Terminate the short validation client.  If runuser does not forward the
+     * signal, pg_sleep bounds the reap to five seconds. */
+    kill(controlled.pid, SIGTERM);
+    (void)pgwt_proc_close(&controlled);
+
+    if (observed != 0) {
+        degrade_unvalidated(layout,
+                            "controlled backend/auth unavailable; no offset accepted");
+        return -1;
+    }
+    if (!base) {
+        degrade_unvalidated(layout,
+                            "controlled backend entry was not uniquely resolved");
+        return -1;
+    }
+    return pgwt_pgbs_validate_snapshot(layout, &snapshot, &expected);
+}
+
+int pgwt_pgbs_validate_uprobe_shadow(struct PgBackendStatusLayout *layout,
+                                     pid_t backend_pid,
+                                     uint64_t my_be_entry_addr,
+                                     bool cmd_open,
+                                     bool query_id_available,
+                                     uint64_t query_id)
+{
+    if (!layout || layout->source == PGWT_PGBS_SOURCE_NONE || backend_pid <= 0)
+        return -1;
+    struct pgwt_pgbs_expected expected = {
+        .pid = backend_pid,
+        .state_shadow_available = true,
+        .state_active = cmd_open,
+        .query_id_available = layout->major >= 14 && query_id_available,
+        .query_id = query_id,
+    };
+    struct pgwt_pgbs_snapshot snapshot;
+    memset(&snapshot, 0, sizeof(snapshot));
+    uint64_t base = 0;
+    int mem_fd = open_mem(backend_pid);
+    if (mem_fd >= 0) {
+        if (my_be_entry_addr)
+            (void)pread_exact(mem_fd, &base, sizeof(base), my_be_entry_addr);
+        if (base)
+            (void)read_snapshot_fd(mem_fd, base, layout, &snapshot,
+                                   (char[512]){0}, 512);
+        close(mem_fd);
+    }
+    if (!base)
+        base = scan_shared_for_entry(backend_pid, layout, &expected, NULL,
+                                     &snapshot);
+    if (!base)
+        return -1;
+    return pgwt_pgbs_validate_snapshot(layout, &snapshot, &expected);
+}
+
+/* ── Reporting ────────────────────────────────────────────── */
+
+unsigned pgwt_pgbs_fallback_count(const struct PgBackendStatusLayout *layout)
+{
+    if (!layout)
+        return 0;
+    uint32_t mask = layout->fallback_mask;
+    unsigned count = 0;
+    while (mask) {
+        count += mask & 1u;
+        mask >>= 1;
+    }
+    return count;
+}
+
+static const char *field_validation_name(enum pgwt_pgbs_field_validation value)
+{
+    switch (value) {
+    case PGWT_PGBS_FIELD_VALIDATED: return "validated";
+    case PGWT_PGBS_FIELD_ABSENT:    return "ABSENT";
+    case PGWT_PGBS_FIELD_INVALID:   return "invalid";
+    default:                        return "not-run";
+    }
+}
+
+static void log_field(const char *name, const struct pgwt_pgbs_field *field)
+{
+    if (field->present)
+        fprintf(stderr, " %s=%u/%u(%s)", name, field->offset, field->width,
+                field_validation_name(field->validation));
+    else
+        fprintf(stderr, " %s=ABSENT", name);
+}
+
+void pgwt_pgbs_log(const struct PgBackendStatusLayout *layout)
+{
+    if (!layout)
+        return;
+    fprintf(stderr,
+            "INFO: PgBackendStatus layout PG%d source=%s arch=%s ptr=%u "
+            "abi=%s size=%u validation=%s pid=%d enums=RUNNING:%d,"
+            "FASTPATH:%d,max:%d\n",
+            layout->major, pgwt_pgbs_source_name(layout->source),
+            pgwt_pgbs_arch_name(layout->arch), layout->pointer_width,
+            pgwt_pgbs_abi_name(layout->abi), layout->struct_size,
+            pgwt_pgbs_validation_name(layout->validation),
+            layout->validated_pid, layout->state_running,
+            layout->state_fastpath, layout->state_max);
+    fprintf(stderr, "INFO: PgBackendStatus fields:");
+    log_field("st_changecount", &layout->st_changecount);
+    log_field("st_procpid", &layout->st_procpid);
+    log_field("st_databaseid", &layout->st_databaseid);
+    log_field("st_userid", &layout->st_userid);
+    log_field("st_state", &layout->st_state);
+    log_field("st_activity_raw", &layout->st_activity_raw);
+    log_field("st_query_id", &layout->st_query_id);
+    if (layout->st_query_id.present)
+        fprintf(stderr, "[%s]",
+                layout->st_query_id_signed ? "signed" : "unsigned");
+    fprintf(stderr, "\nINFO: PgBackendStatus validation detail: %s\n",
+            layout->detail);
+
+    if (layout->fallback_mask) {
+        fprintf(stderr, "WARN: PgBackendStatus layout fallback:");
+        if (layout->fallback_mask & PGWT_PGBS_FALLBACK_STATE)
+            fprintf(stderr, " st_state->activity-uprobe");
+        if (layout->fallback_mask & PGWT_PGBS_FALLBACK_ACTIVITY_RAW) {
+            if (layout->major == 13)
+                fprintf(stderr,
+                        " st_activity_raw->PG13-ExecutorStart-uprobe");
+            else
+                fprintf(stderr,
+                        " st_activity_raw->activity/query-text-uprobe");
+        }
+        if (layout->fallback_mask & PGWT_PGBS_FALLBACK_QUERY_ID)
+            fprintf(stderr, " st_query_id->query-id-uprobe");
+        fprintf(stderr, " (fallback_fields=%u; no offset guessed)\n",
+                pgwt_pgbs_fallback_count(layout));
+    }
+    fprintf(stderr,
+            "INFO: PgBackendStatus layout is shadow-only (Stage 1); "
+            "sampler and uprobe paths are unchanged\n");
+}

--- a/src/backend_status_layout.c
+++ b/src/backend_status_layout.c
@@ -1062,8 +1062,7 @@ static int candidate_ok(int fd, uint64_t base,
          snapshot->databaseid != expected->databaseid) ||
         (expected->userid && snapshot->userid != expected->userid) ||
         snapshot->state > (uint32_t)layout->state_max ||
-        !snapshot->activity_readable ||
-        (activity_marker && !snapshot->activity_marker_matched))
+        !snapshot->activity_readable)
         return 0;
     if (expected->state_shadow_available) {
         bool active = snapshot->state == (uint32_t)layout->state_running ||
@@ -1202,13 +1201,13 @@ static int spawn_psql(const char *psql, const char *user,
     snprintf(port_str, sizeof(port_str), "%d", port);
     char *argv_with_socket[] = {
         "runuser", "-u", (char *)user, "--", (char *)psql,
-        "-X", "-Atq", "-v", "ON_ERROR_STOP=1",
+        "-X", "-Atq", "-w", "-v", "ON_ERROR_STOP=1",
         "-h", (char *)socket_dir, "-p", port_str,
         "-d", "postgres", "-c", (char *)sql, NULL,
     };
     char *argv_default_socket[] = {
         "runuser", "-u", (char *)user, "--", (char *)psql,
-        "-X", "-Atq", "-v", "ON_ERROR_STOP=1",
+        "-X", "-Atq", "-w", "-v", "ON_ERROR_STOP=1",
         "-p", port_str, "-d", "postgres", "-c", (char *)sql, NULL,
     };
     return pgwt_proc_open(proc, socket_dir[0] ? argv_with_socket
@@ -1225,13 +1224,13 @@ static int spawn_psql_session(const char *psql, const char *user,
              "dbname=postgres application_name=%s", appname);
     char *argv_with_socket[] = {
         "runuser", "-u", (char *)user, "--", (char *)psql,
-        "-X", "-Atq", "-v", "ON_ERROR_STOP=1",
+        "-X", "-Atq", "-w",
         "-h", (char *)socket_dir, "-p", port_str,
         "-d", dbspec, NULL,
     };
     char *argv_default_socket[] = {
         "runuser", "-u", (char *)user, "--", (char *)psql,
-        "-X", "-Atq", "-v", "ON_ERROR_STOP=1",
+        "-X", "-Atq", "-w",
         "-p", port_str, "-d", dbspec, NULL,
     };
     return pgwt_proc_open_rw(proc, socket_dir[0] ? argv_with_socket
@@ -1246,12 +1245,163 @@ static int send_psql(struct pgwt_proc *proc, const char *sql)
     return 0;
 }
 
-static int wait_for_pid_exit(pid_t pid)
+/* Read child output without an unbounded stdio wait.  stop_at_newline is used
+ * to learn a long-lived controlled session's server PID; otherwise the helper
+ * drains through EOF.  On timeout, stop the client so its PostgreSQL socket is
+ * closed and validation can degrade without delaying capture indefinitely. */
+static ssize_t read_proc_output_bounded(struct pgwt_proc *proc,
+                                        char *buf, size_t size,
+                                        int timeout_ms,
+                                        bool stop_at_newline)
+{
+    if (!proc || !proc->out || !buf || size < 2)
+        return -1;
+    int fd = fileno(proc->out);
+    size_t used = 0;
+    int remaining = timeout_ms;
+    while (used + 1 < size && remaining > 0) {
+        int slice = remaining > 100 ? 100 : remaining;
+        struct pollfd pfd = { .fd = fd, .events = POLLIN | POLLHUP };
+        int rc = poll(&pfd, 1, slice);
+        if (rc < 0) {
+            if (errno == EINTR)
+                continue;
+            break;
+        }
+        remaining -= slice;
+        if (rc == 0)
+            continue;
+        size_t want = stop_at_newline ? 1 : size - used - 1;
+        ssize_t n = read(fd, buf + used, want);
+        if (n == 0) {
+            buf[used] = '\0';
+            return (ssize_t)used;
+        }
+        if (n < 0) {
+            if (errno == EINTR || errno == EAGAIN)
+                continue;
+            break;
+        }
+        used += (size_t)n;
+        if (stop_at_newline && buf[used - 1] == '\n') {
+            buf[used] = '\0';
+            return (ssize_t)used;
+        }
+    }
+    buf[used] = '\0';
+    if (proc->pid > 0)
+        (void)kill(proc->pid, SIGTERM);
+    return -1;
+}
+
+int pgwt_pgbs_pid_start_time(pid_t pid, uint64_t *start_time)
+{
+    if (pid <= 0 || !start_time)
+        return -1;
+
+    char path[64], line[4096];
+    snprintf(path, sizeof(path), "/proc/%d/stat", pid);
+    FILE *fp = fopen(path, "r");
+    if (!fp)
+        return -1;
+    bool got = fgets(line, sizeof(line), fp) != NULL;
+    fclose(fp);
+    if (!got)
+        return -1;
+
+    /* comm (field 2) may contain spaces and parentheses.  Field 3 starts
+     * after the final ')'; walk tokens through field 22 (starttime). */
+    char *cursor = strrchr(line, ')');
+    if (!cursor)
+        return -1;
+    cursor++;
+    for (int field = 3; field <= 22; field++) {
+        while (*cursor && isspace((unsigned char)*cursor))
+            cursor++;
+        if (!*cursor)
+            return -1;
+        char *end = cursor;
+        while (*end && !isspace((unsigned char)*end))
+            end++;
+        if (field == 22) {
+            errno = 0;
+            char saved = *end;
+            *end = '\0';
+            char *number_end = NULL;
+            unsigned long long value = strtoull(cursor, &number_end, 10);
+            bool valid = !errno && number_end != cursor &&
+                         *number_end == '\0' && value != 0;
+            *end = saved;
+            if (!valid)
+                return -1;
+            *start_time = (uint64_t)value;
+            return 0;
+        }
+        cursor = end;
+    }
+    return -1;
+}
+
+bool pgwt_pgbs_pid_is_original(pid_t pid, uint64_t start_time)
+{
+    if (pid <= 0 || start_time == 0)
+        return false;
+    uint64_t current = 0;
+    return pgwt_pgbs_pid_start_time(pid, &current) == 0 &&
+           current == start_time;
+}
+
+int pgwt_pgbs_exclusion_add(struct pgwt_pgbs_exclusion_set *set, pid_t pid)
+{
+    if (!set || pid <= 0)
+        return -1;
+    uint64_t start_time = 0;
+    (void)pgwt_pgbs_pid_start_time(pid, &start_time);
+    for (unsigned i = 0; i < set->count; i++) {
+        if (set->entries[i].pid == pid &&
+            set->entries[i].start_time == start_time)
+            return 0;
+    }
+    if (set->count >= PGWT_PGBS_MAX_EXCLUDED_PIDS)
+        return -1;
+    set->entries[set->count++] = (struct pgwt_pgbs_excluded_pid) {
+        .pid = pid,
+        .start_time = start_time,
+    };
+    return 0;
+}
+
+bool pgwt_pgbs_exclusion_contains(const struct pgwt_pgbs_exclusion_set *set,
+                                  pid_t pid)
+{
+    if (!set || pid <= 0)
+        return false;
+    uint64_t current = 0;
+    int have_current = pgwt_pgbs_pid_start_time(pid, &current) == 0;
+    for (unsigned i = 0; i < set->count; i++) {
+        const struct pgwt_pgbs_excluded_pid *entry = &set->entries[i];
+        if (entry->pid != pid)
+            continue;
+        /* Failure to capture an identity is rare under the root daemon; keep
+         * that numeric PID conservatively excluded.  Otherwise a recycled
+         * PID is unrelated and must be eligible for capture. */
+        if (entry->start_time == 0 ||
+            (have_current && entry->start_time == current))
+            return true;
+    }
+    return false;
+}
+
+static int wait_for_pid_retirement(pid_t pid, uint64_t start_time)
 {
     if (pid <= 0)
         return -1;
+    if (start_time == 0) {
+        uint64_t current = 0;
+        return pgwt_pgbs_pid_start_time(pid, &current) != 0 ? 0 : -1;
+    }
     for (int attempt = 0; attempt < 100; attempt++) {
-        if (kill(pid, 0) != 0 && errno == ESRCH)
+        if (!pgwt_pgbs_pid_is_original(pid, start_time))
             return 0;
         usleep(50000);
     }
@@ -1262,32 +1412,45 @@ static int observe_controlled_backend(const char *psql, const char *user,
                                       const char *socket_dir, int port,
                                       const char *appname, int pg_major,
                                       bool want_active,
-                                      struct pgwt_pgbs_expected *expected)
+                                      struct pgwt_pgbs_expected *expected,
+                                      struct pgwt_pgbs_exclusion_set *exclusions)
 {
     char sql[1024];
     if (pg_major >= 14)
         snprintf(sql, sizeof(sql),
                  "WITH target AS (SELECT pid,datid,usesysid,query_id,state "
                  "FROM pg_stat_activity WHERE application_name='%s' "
-                 "AND state='%s' ORDER BY backend_start DESC LIMIT 1) "
-                 "SELECT 'target',pid::text,datid::text,usesysid::text,"
+                 "AND state='%s' ORDER BY backend_start DESC LIMIT 1), "
+                 "rows AS (SELECT 0 AS ord,'observer' AS kind,"
+                 "pg_backend_pid()::text AS pid,'0' AS datid,'0' AS usesysid,"
+                 "'0' AS query_id,'0' AS active UNION ALL SELECT 1,'target',"
+                 "pid::text,datid::text,usesysid::text,"
                  "COALESCE(query_id,0)::text,"
-                 "CASE WHEN state='active' THEN '1' ELSE '0' END FROM target "
-                 "UNION ALL SELECT 'observer',pg_backend_pid()::text,"
-                 "'0','0','0','0'",
+                 "CASE WHEN state='active' THEN '1' ELSE '0' END FROM target) "
+                 "SELECT kind,pid,datid,usesysid,query_id,active "
+                 "FROM rows ORDER BY ord",
                  appname, want_active ? "active" : "idle");
     else
         snprintf(sql, sizeof(sql),
                  "WITH target AS (SELECT pid,datid,usesysid,state "
                  "FROM pg_stat_activity WHERE application_name='%s' "
-                 "AND state='%s' ORDER BY backend_start DESC LIMIT 1) "
-                 "SELECT 'target',pid::text,datid::text,usesysid::text,'0',"
-                 "CASE WHEN state='active' THEN '1' ELSE '0' END FROM target "
-                 "UNION ALL SELECT 'observer',pg_backend_pid()::text,"
-                 "'0','0','0','0'",
+                 "AND state='%s' ORDER BY backend_start DESC LIMIT 1), "
+                 "rows AS (SELECT 0 AS ord,'observer' AS kind,"
+                 "pg_backend_pid()::text AS pid,'0' AS datid,'0' AS usesysid,"
+                 "'0' AS query_id,'0' AS active UNION ALL SELECT 1,'target',"
+                 "pid::text,datid::text,usesysid::text,'0',"
+                 "CASE WHEN state='active' THEN '1' ELSE '0' END FROM target) "
+                 "SELECT kind,pid,datid,usesysid,query_id,active "
+                 "FROM rows ORDER BY ord",
                  appname, want_active ? "active" : "idle");
 
     for (int attempt = 0; attempt < 20; attempt++) {
+        /* Never create a backend whose identity cannot be retained.  A full
+         * set is a degradable validation condition, not permission to let an
+         * observer become capture-eligible. */
+        if (!exclusions ||
+            exclusions->count >= PGWT_PGBS_MAX_EXCLUDED_PIDS)
+            return -1;
         struct pgwt_proc observer;
         if (spawn_psql(psql, user, socket_dir, port, sql, &observer) != 0)
             return -1;
@@ -1295,19 +1458,53 @@ static int observe_controlled_backend(const char *psql, const char *user,
         uint32_t databaseid = 0, userid = 0;
         long long query_id = 0;
         int active = -1;
-        char line[256];
-        while (fgets(line, sizeof(line), observer.out)) {
+        int observer_excluded = -1;
+        uint64_t observer_start_time = 0;
+        char observer_line[128], output[1024];
+        ssize_t observer_line_len = read_proc_output_bounded(
+            &observer, observer_line, sizeof(observer_line), 3000, true);
+        if (observer_line_len >= 0 &&
+            sscanf(observer_line, "observer|%d", &observer_pid) == 1 &&
+            observer_pid > 0) {
+            (void)pgwt_pgbs_pid_start_time(observer_pid,
+                                            &observer_start_time);
+            /* Even when /proc identity capture fails, retain a conservative
+             * numeric-PID exclusion.  exclusion_contains() deliberately
+             * keeps such entries excluded for the tracer lifetime. */
+            observer_excluded = pgwt_pgbs_exclusion_add(exclusions,
+                                                        observer_pid);
+        }
+        ssize_t output_len = observer_line_len >= 0
+            ? read_proc_output_bounded(&observer, output, sizeof(output),
+                                       3000, false)
+            : -1;
+        char *save = NULL;
+        for (char *line = output_len >= 0
+                 ? strtok_r(output, "\r\n", &save) : NULL;
+             line; line = strtok_r(NULL, "\r\n", &save)) {
             if (sscanf(line, "target|%d|%u|%u|%lld|%d",
                        &target_pid, &databaseid, &userid,
                        &query_id, &active) == 5)
                 continue;
-            (void)sscanf(line, "observer|%d", &observer_pid);
+        }
+        if (observer_pid > 0 && observer_excluded != 0) {
+            (void)kill(observer.pid, SIGTERM);
+            (void)pgwt_proc_close(&observer);
+            return -1;
+        }
+        if (target_pid > 0 &&
+            pgwt_pgbs_exclusion_add(exclusions, target_pid) != 0) {
+            (void)kill(observer.pid, SIGTERM);
+            (void)pgwt_proc_close(&observer);
+            return -1;
         }
         int status = pgwt_proc_close(&observer);
-        if (observer_pid > 0 && wait_for_pid_exit(observer_pid) != 0)
-            return -2;
+        if (observer_pid <= 0 || observer_start_time == 0 ||
+            wait_for_pid_retirement(observer_pid, observer_start_time) != 0)
+            return -1;
         bool qid_ok = pg_major < 14 || !want_active || query_id != 0;
-        if (status == 0 && target_pid > 0 && databaseid > 0 && userid > 0 &&
+        if (output_len >= 0 && status == 0 && target_pid > 0 &&
+            databaseid > 0 && userid > 0 &&
             active == (want_active ? 1 : 0) && qid_ok) {
             memset(expected, 0, sizeof(*expected));
             expected->pid = target_pid;
@@ -1369,15 +1566,21 @@ static void degrade_unvalidated(struct PgBackendStatusLayout *layout,
     set_detail(layout, "%s", reason);
 }
 
-int pgwt_pgbs_validate_runtime(struct PgBackendStatusLayout *layout,
-                               pid_t postmaster_pid,
-                               uint64_t my_be_entry_addr,
-                               const char *pg_binary)
+void pgwt_pgbs_validate_runtime(struct PgBackendStatusLayout *layout,
+                                pid_t postmaster_pid,
+                                uint64_t my_be_entry_addr,
+                                const char *pg_binary,
+                                struct pgwt_pgbs_exclusion_set *exclusions)
 {
     if (!layout || layout->source == PGWT_PGBS_SOURCE_NONE) {
         if (layout)
             degrade_unvalidated(layout, "no discovered layout to validate");
-        return -1;
+        return;
+    }
+    if (getenv("PGWT_TEST_PGBS_VALIDATION_FAIL")) {
+        degrade_unvalidated(layout,
+                            "forced validation failure (test hook); capture unaffected");
+        return;
     }
     int port;
     char socket_dir[512], user[128];
@@ -1386,14 +1589,14 @@ int pgwt_pgbs_validate_runtime(struct PgBackendStatusLayout *layout,
                               sizeof(socket_dir), user, sizeof(user)) != 0) {
         degrade_unvalidated(layout,
                             "controlled-backend connection metadata unavailable");
-        return -1;
+        return;
     }
     char psql[512];
     snprintf(psql, sizeof(psql), "%s", pg_binary);
     char *slash = strrchr(psql, '/');
     if (!slash) {
         degrade_unvalidated(layout, "postgres binary has no bindir");
-        return -1;
+        return;
     }
     snprintf(slash + 1, (size_t)(psql + sizeof(psql) - slash - 1), "psql");
 
@@ -1406,17 +1609,44 @@ int pgwt_pgbs_validate_runtime(struct PgBackendStatusLayout *layout,
              getpid());
     snprintf(second_marker, sizeof(second_marker), "pgwt-layout-active-b-%d",
              getpid());
+    if (!exclusions ||
+        exclusions->count >= PGWT_PGBS_MAX_EXCLUDED_PIDS) {
+        degrade_unvalidated(layout,
+                            "validation PID exclusion set has no capacity");
+        return;
+    }
     struct pgwt_proc controlled;
     if (spawn_psql_session(psql, user, socket_dir, port, appname,
                            &controlled) != 0) {
         degrade_unvalidated(layout, "could not start controlled backend");
-        return -1;
+        return;
     }
 
     char command[256];
-    int observed = 0;
+    const char *validation_step = "controlled PID handshake";
+    int observed = send_psql(
+        &controlled, "SELECT 'controlled',pg_backend_pid();");
+    pid_t controlled_pid = 0;
+    uint64_t controlled_start_time = 0;
+    char controlled_line[128];
+    if (observed == 0 &&
+        read_proc_output_bounded(&controlled, controlled_line,
+                                 sizeof(controlled_line), 3000, true) >= 0 &&
+        sscanf(controlled_line, "controlled|%d", &controlled_pid) == 1 &&
+        controlled_pid > 0) {
+        (void)pgwt_pgbs_pid_start_time(controlled_pid,
+                                        &controlled_start_time);
+        int excluded = pgwt_pgbs_exclusion_add(exclusions, controlled_pid);
+        if (controlled_start_time == 0 || excluded != 0)
+            observed = -1;
+    } else {
+        observed = -1;
+    }
     if (layout->major >= 14)
-        observed = send_psql(&controlled, "SET compute_query_id=on;");
+        if (observed == 0)
+            observed = send_psql(&controlled, "SET compute_query_id=on;");
+    if (observed == 0)
+        validation_step = "idle marker command";
     snprintf(command, sizeof(command), "SELECT 1 /* %s */;", idle_marker);
     if (observed == 0)
         observed = send_psql(&controlled, command);
@@ -1431,11 +1661,14 @@ int pgwt_pgbs_validate_runtime(struct PgBackendStatusLayout *layout,
     memset(&second_snapshot, 0, sizeof(second_snapshot));
     uint64_t idle_base = 0, first_base = 0, second_base = 0;
 
-    if (observed == 0)
+    if (observed == 0) {
+        validation_step = "idle observation";
         observed = observe_controlled_backend(
             psql, user, socket_dir, port, appname, layout->major, false,
-            &idle_expected);
+            &idle_expected, exclusions);
+    }
     if (observed == 0) {
+        validation_step = "idle activity-marker snapshot";
         idle_expected.activity_marker_required = true;
         idle_base = resolve_controlled_snapshot(
             idle_expected.pid, 0, my_be_entry_addr, layout, &idle_expected,
@@ -1445,19 +1678,36 @@ int pgwt_pgbs_validate_runtime(struct PgBackendStatusLayout *layout,
     }
 
     snprintf(command, sizeof(command),
-             "SELECT pg_sleep(0.25) /* %s */;", first_marker);
-    if (observed == 0)
+             "SELECT pg_sleep(2) /* %s */;", first_marker);
+    if (observed == 0) {
+        validation_step = "first active command";
         observed = send_psql(&controlled, command);
-    if (observed == 0)
+    }
+    if (observed == 0) {
+        validation_step = "first active observation";
         observed = observe_controlled_backend(
             psql, user, socket_dir, port, appname, layout->major, true,
-            &first_expected);
+            &first_expected, exclusions);
+    }
     if (observed == 0) {
+        validation_step = "first active activity-marker snapshot";
         first_expected.activity_marker_required = true;
         first_base = resolve_controlled_snapshot(
             first_expected.pid, idle_base, my_be_entry_addr, layout,
             &first_expected, first_marker, &first_snapshot);
         if (!first_base)
+            observed = -1;
+    }
+    /* The active command is a bounded observation window, not a startup
+     * delay.  Once the observer and coherent snapshot have both landed,
+     * cancel only our identity-checked validation backend.  With psql's
+     * default ON_ERROR_STOP=off the session returns to idle and remains
+     * usable for the independently shaped second query. */
+    if (observed == 0) {
+        validation_step = "first active cancellation";
+        if (!pgwt_pgbs_pid_is_original(controlled_pid,
+                                       controlled_start_time) ||
+            kill(controlled_pid, SIGINT) != 0)
             observed = -1;
     }
 
@@ -1466,20 +1716,27 @@ int pgwt_pgbs_validate_runtime(struct PgBackendStatusLayout *layout,
      * commands and gives st_state an observed active->idle boundary. */
     struct pgwt_pgbs_expected between_expected;
     memset(&between_expected, 0, sizeof(between_expected));
-    if (observed == 0)
+    if (observed == 0) {
+        validation_step = "between-command idle observation";
         observed = observe_controlled_backend(
             psql, user, socket_dir, port, appname, layout->major, false,
-            &between_expected);
+            &between_expected, exclusions);
+    }
 
     snprintf(command, sizeof(command),
-             "SELECT 1 FROM pg_sleep(0.25) /* %s */;", second_marker);
-    if (observed == 0)
+             "SELECT 1 FROM pg_sleep(2) /* %s */;", second_marker);
+    if (observed == 0) {
+        validation_step = "second active command";
         observed = send_psql(&controlled, command);
-    if (observed == 0)
+    }
+    if (observed == 0) {
+        validation_step = "second active observation";
         observed = observe_controlled_backend(
             psql, user, socket_dir, port, appname, layout->major, true,
-            &second_expected);
+            &second_expected, exclusions);
+    }
     if (observed == 0) {
+        validation_step = "second active activity-marker snapshot";
         second_expected.activity_marker_required = true;
         second_base = resolve_controlled_snapshot(
             second_expected.pid, idle_base, my_be_entry_addr, layout,
@@ -1487,8 +1744,14 @@ int pgwt_pgbs_validate_runtime(struct PgBackendStatusLayout *layout,
         if (!second_base)
             observed = -1;
     }
+    if (observed == 0) {
+        validation_step = "second active cancellation";
+        if (!pgwt_pgbs_pid_is_original(controlled_pid,
+                                       controlled_start_time) ||
+            kill(controlled_pid, SIGINT) != 0)
+            observed = -1;
+    }
 
-    pid_t controlled_pid = idle_expected.pid;
     /* Finish the final statement, then deliver EOF and drain psql's small
      * result stream before reaping it.  Closing stdout first would give psql
      * SIGPIPE after the validation had already succeeded. */
@@ -1496,12 +1759,14 @@ int pgwt_pgbs_validate_runtime(struct PgBackendStatusLayout *layout,
         fclose(controlled.in);
         controlled.in = NULL;
     }
-    char discard[256];
-    while (fgets(discard, sizeof(discard), controlled.out))
-        ;
+    char discard[512];
+    if (read_proc_output_bounded(&controlled, discard, sizeof(discard),
+                                 3000, false) < 0)
+        observed = -1;
     int controlled_status = pgwt_proc_close(&controlled);
     bool retired = controlled_pid > 0 &&
-                   wait_for_pid_exit(controlled_pid) == 0;
+                   wait_for_pid_retirement(controlled_pid,
+                                           controlled_start_time) == 0;
     if (!retired) {
         char reason[192];
         snprintf(reason, sizeof(reason),
@@ -1509,17 +1774,16 @@ int pgwt_pgbs_validate_runtime(struct PgBackendStatusLayout *layout,
                  "(pid=%d observation=%d client_status=%d)",
                  controlled_pid, observed, controlled_status);
         degrade_unvalidated(layout, reason);
-        return -2;
-    }
-    if (observed == -2) {
-        degrade_unvalidated(layout,
-                            "validation observer did not retire before capture");
-        return -2;
+        return;
     }
     if (observed != 0 || controlled_status != 0) {
-        degrade_unvalidated(layout,
-                            "controlled backend/auth unavailable; no offset accepted");
-        return -1;
+        char reason[192];
+        snprintf(reason, sizeof(reason),
+                 "controlled validation unavailable at %s "
+                 "(observation=%d client_status=%d); no offset accepted",
+                 validation_step, observed, controlled_status);
+        degrade_unvalidated(layout, reason);
+        return;
     }
 
     bool same_backend = idle_expected.pid == first_expected.pid &&
@@ -1532,8 +1796,8 @@ int pgwt_pgbs_validate_runtime(struct PgBackendStatusLayout *layout,
     struct PgBackendStatusLayout first_result = *layout;
     (void)pgwt_pgbs_validate_snapshot(&first_result, &first_snapshot,
                                       &first_expected);
-    int rc = pgwt_pgbs_validate_snapshot(layout, &second_snapshot,
-                                         &second_expected);
+    (void)pgwt_pgbs_validate_snapshot(layout, &second_snapshot,
+                                      &second_expected);
 
     bool idle_state = has_read(&idle_snapshot, PGWT_PGBS_READ_STATE) &&
         idle_snapshot.state <= (uint32_t)layout->state_max &&
@@ -1545,7 +1809,6 @@ int pgwt_pgbs_validate_runtime(struct PgBackendStatusLayout *layout,
     if (!active_transition) {
         layout->st_state.validation = PGWT_PGBS_FIELD_INVALID;
         layout->fallback_mask |= PGWT_PGBS_FALLBACK_STATE;
-        rc = -1;
     }
 
     bool query_varied = layout->major < 14 ||
@@ -1558,7 +1821,6 @@ int pgwt_pgbs_validate_runtime(struct PgBackendStatusLayout *layout,
     if (!query_varied && layout->major >= 14) {
         layout->st_query_id.validation = PGWT_PGBS_FIELD_INVALID;
         layout->fallback_mask |= PGWT_PGBS_FALLBACK_QUERY_ID;
-        rc = -1;
     }
     layout->validation = layout->fallback_mask
         ? PGWT_PGBS_VALIDATION_DEGRADED
@@ -1580,22 +1842,27 @@ int pgwt_pgbs_validate_runtime(struct PgBackendStatusLayout *layout,
                    layout->major < 14 ? "n/a" :
                        (query_varied ? "yes" : "no"));
     }
-    return rc;
+    return;
 }
 
 int pgwt_pgbs_validate_uprobe_shadow(struct PgBackendStatusLayout *layout,
                                      pid_t backend_pid,
                                      uint64_t my_be_entry_addr,
+                                     uint64_t debug_query_string_addr,
                                      bool cmd_open,
                                      bool query_id_available,
-                                     uint64_t query_id)
+                                     uint64_t query_id,
+                                     uint32_t *observed_state)
 {
+    if (observed_state)
+        *observed_state = UINT32_MAX;
     if (!layout || layout->source == PGWT_PGBS_SOURCE_NONE || backend_pid <= 0)
         return -1;
     struct pgwt_pgbs_expected expected = {
         .pid = backend_pid,
         .state_shadow_available = true,
         .state_active = cmd_open,
+        .activity_marker_required = true,
         .query_id_available = layout->major >= 14 && query_id_available &&
                               query_id != 0,
         .query_id = query_id,
@@ -1603,28 +1870,48 @@ int pgwt_pgbs_validate_uprobe_shadow(struct PgBackendStatusLayout *layout,
     struct pgwt_pgbs_snapshot snapshot;
     memset(&snapshot, 0, sizeof(snapshot));
     uint64_t base = 0;
+    char activity_marker[256] = "";
+    const char *marker = NULL;
     int mem_fd = open_mem(backend_pid);
     if (mem_fd >= 0) {
+        if (cmd_open && debug_query_string_addr) {
+            uint64_t query_string = 0;
+            if (pread_exact(mem_fd, &query_string, sizeof(query_string),
+                            debug_query_string_addr) >= 0 && query_string) {
+                ssize_t n = pread(mem_fd, activity_marker,
+                                  sizeof(activity_marker) - 1,
+                                  (off_t)query_string);
+                if (n > 0) {
+                    activity_marker[n] = '\0';
+                    if (activity_marker[0])
+                        marker = activity_marker;
+                }
+            }
+        }
         if (my_be_entry_addr)
             if (pread_exact(mem_fd, &base, sizeof(base),
                             my_be_entry_addr) < 0)
                 base = 0;
-        if (base && !candidate_ok(mem_fd, base, layout, &expected, NULL,
+        if (base && !candidate_ok(mem_fd, base, layout, &expected, marker,
                                   &snapshot))
             base = 0;
         close(mem_fd);
     }
     if (!base)
-        base = scan_shared_for_entry(backend_pid, layout, &expected, NULL,
+        base = scan_shared_for_entry(backend_pid, layout, &expected, marker,
                                      &snapshot);
     if (!base)
         return -1;
+    if (observed_state)
+        *observed_state = snapshot.state;
     return pgwt_pgbs_validate_snapshot(layout, &snapshot, &expected);
 }
 
 void pgwt_pgbs_warmup_note(struct pgwt_pgbs_warmup_evidence *evidence,
                            const struct PgBackendStatusLayout *candidate,
                            bool state_active,
+                           bool state_value_available,
+                           uint32_t state_value,
                            bool query_id_available,
                            uint64_t query_id)
 {
@@ -1634,6 +1921,20 @@ void pgwt_pgbs_warmup_note(struct pgwt_pgbs_warmup_evidence *evidence,
     if (state_active && candidate->st_state.validation ==
                         PGWT_PGBS_FIELD_VALIDATED)
         evidence->state_matches++;
+    if (state_value_available &&
+        state_value <= (uint32_t)candidate->state_max) {
+        bool value_active =
+            state_value == (uint32_t)candidate->state_running ||
+            state_value == (uint32_t)candidate->state_fastpath;
+        if (value_active == state_active) {
+            if (!evidence->state_seen) {
+                evidence->state_seen = true;
+                evidence->first_state = state_value;
+            } else if (state_value != evidence->first_state) {
+                evidence->state_varied = true;
+            }
+        }
+    }
     if (candidate->st_activity_raw.validation == PGWT_PGBS_FIELD_VALIDATED)
         evidence->activity_matches++;
     if (query_id_available && query_id != 0 &&
@@ -1652,7 +1953,7 @@ bool pgwt_pgbs_warmup_complete(
     const struct pgwt_pgbs_warmup_evidence *evidence, int pg_major)
 {
     if (!evidence || evidence->state_matches < 3 ||
-        evidence->activity_matches < 3)
+        !evidence->state_varied || evidence->activity_matches < 3)
         return false;
     return pg_major < 14 ||
            (evidence->query_matches >= 3 && evidence->query_id_varied);
@@ -1663,7 +1964,7 @@ void pgwt_pgbs_warmup_apply(struct PgBackendStatusLayout *layout,
 {
     if (!layout || !evidence)
         return;
-    bool state_ok = evidence->state_matches >= 3;
+    bool state_ok = evidence->state_matches >= 3 && evidence->state_varied;
     bool activity_ok = evidence->activity_matches >= 3;
     bool query_ok = layout->major < 14 ||
         (evidence->query_matches >= 3 && evidence->query_id_varied);

--- a/src/backend_status_layout.c
+++ b/src/backend_status_layout.c
@@ -902,23 +902,24 @@ int pgwt_pgbs_validate_snapshot(struct PgBackendStatusLayout *layout,
     layout->st_userid.validation = user_ok
         ? PGWT_PGBS_FIELD_VALIDATED : PGWT_PGBS_FIELD_INVALID;
 
+    bool state_active = snapshot->state == (uint32_t)layout->state_running ||
+                        snapshot->state == (uint32_t)layout->state_fastpath;
+    /* Idle agreement is not evidence for a field offset: most nearby padding
+     * and unrelated enum fields also look like a valid non-running state.
+     * Only an independently observed active backend can validate st_state. */
     bool state_ok = identity_ok && has_read(snapshot, PGWT_PGBS_READ_STATE) &&
                     snapshot->state <= (uint32_t)layout->state_max &&
-                    (!expected->require_running ||
-                     snapshot->state == (uint32_t)layout->state_running ||
-                     snapshot->state == (uint32_t)layout->state_fastpath);
-    if (state_ok && expected->state_shadow_available) {
-        bool active = snapshot->state == (uint32_t)layout->state_running ||
-                      snapshot->state == (uint32_t)layout->state_fastpath;
-        state_ok = active == expected->state_active;
-    }
+                    expected->state_shadow_available &&
+                    expected->state_active && state_active;
     layout->st_state.validation = state_ok
         ? PGWT_PGBS_FIELD_VALIDATED : PGWT_PGBS_FIELD_INVALID;
 
     bool activity_ok = identity_ok &&
                        has_read(snapshot, PGWT_PGBS_READ_ACTIVITY) &&
                        snapshot->activity_raw != 0 &&
-                       snapshot->activity_readable;
+                       snapshot->activity_readable &&
+                       (!expected->activity_marker_required ||
+                        snapshot->activity_marker_matched);
     layout->st_activity_raw.validation = activity_ok
         ? PGWT_PGBS_FIELD_VALIDATED : PGWT_PGBS_FIELD_INVALID;
 
@@ -927,6 +928,7 @@ int pgwt_pgbs_validate_snapshot(struct PgBackendStatusLayout *layout,
         query_ok = identity_ok && layout->st_query_id.present &&
                    has_read(snapshot, PGWT_PGBS_READ_QUERY_ID) &&
                    expected->query_id_available &&
+                   expected->query_id != 0 && snapshot->query_id != 0 &&
                    snapshot->query_id == expected->query_id;
         layout->st_query_id.validation = query_ok
             ? PGWT_PGBS_FIELD_VALIDATED : PGWT_PGBS_FIELD_INVALID;
@@ -1052,6 +1054,8 @@ static int candidate_ok(int fd, uint64_t base,
     if (read_snapshot_fd(fd, base, layout, snapshot,
                          activity, sizeof(activity)) != 0)
         return 0;
+    snapshot->activity_marker_matched =
+        activity_marker && strstr(activity, activity_marker) != NULL;
     if (snapshot->procpid != (uint32_t)expected->pid ||
         snapshot->databaseid == 0 || snapshot->userid == 0 ||
         (expected->databaseid &&
@@ -1059,7 +1063,7 @@ static int candidate_ok(int fd, uint64_t base,
         (expected->userid && snapshot->userid != expected->userid) ||
         snapshot->state > (uint32_t)layout->state_max ||
         !snapshot->activity_readable ||
-        (activity_marker && !strstr(activity, activity_marker)))
+        (activity_marker && !snapshot->activity_marker_matched))
         return 0;
     if (expected->state_shadow_available) {
         bool active = snapshot->state == (uint32_t)layout->state_running ||
@@ -1211,57 +1215,140 @@ static int spawn_psql(const char *psql, const char *user,
                                               : argv_default_socket);
 }
 
+static int spawn_psql_session(const char *psql, const char *user,
+                              const char *socket_dir, int port,
+                              const char *appname, struct pgwt_proc *proc)
+{
+    char port_str[16], dbspec[192];
+    snprintf(port_str, sizeof(port_str), "%d", port);
+    snprintf(dbspec, sizeof(dbspec),
+             "dbname=postgres application_name=%s", appname);
+    char *argv_with_socket[] = {
+        "runuser", "-u", (char *)user, "--", (char *)psql,
+        "-X", "-Atq", "-v", "ON_ERROR_STOP=1",
+        "-h", (char *)socket_dir, "-p", port_str,
+        "-d", dbspec, NULL,
+    };
+    char *argv_default_socket[] = {
+        "runuser", "-u", (char *)user, "--", (char *)psql,
+        "-X", "-Atq", "-v", "ON_ERROR_STOP=1",
+        "-p", port_str, "-d", dbspec, NULL,
+    };
+    return pgwt_proc_open_rw(proc, socket_dir[0] ? argv_with_socket
+                                                 : argv_default_socket);
+}
+
+static int send_psql(struct pgwt_proc *proc, const char *sql)
+{
+    if (!proc || !proc->in || fputs(sql, proc->in) == EOF ||
+        fputc('\n', proc->in) == EOF || fflush(proc->in) != 0)
+        return -1;
+    return 0;
+}
+
+static int wait_for_pid_exit(pid_t pid)
+{
+    if (pid <= 0)
+        return -1;
+    for (int attempt = 0; attempt < 100; attempt++) {
+        if (kill(pid, 0) != 0 && errno == ESRCH)
+            return 0;
+        usleep(50000);
+    }
+    return -1;
+}
+
 static int observe_controlled_backend(const char *psql, const char *user,
                                       const char *socket_dir, int port,
                                       const char *appname, int pg_major,
+                                      bool want_active,
                                       struct pgwt_pgbs_expected *expected)
 {
-    char sql[768];
+    char sql[1024];
     if (pg_major >= 14)
         snprintf(sql, sizeof(sql),
-                 "SELECT pid,datid,usesysid,COALESCE(query_id,0)::text "
+                 "WITH target AS (SELECT pid,datid,usesysid,query_id,state "
                  "FROM pg_stat_activity WHERE application_name='%s' "
-                 "AND state='active' ORDER BY backend_start DESC LIMIT 1",
-                 appname);
+                 "AND state='%s' ORDER BY backend_start DESC LIMIT 1) "
+                 "SELECT 'target',pid::text,datid::text,usesysid::text,"
+                 "COALESCE(query_id,0)::text,"
+                 "CASE WHEN state='active' THEN '1' ELSE '0' END FROM target "
+                 "UNION ALL SELECT 'observer',pg_backend_pid()::text,"
+                 "'0','0','0','0'",
+                 appname, want_active ? "active" : "idle");
     else
         snprintf(sql, sizeof(sql),
-                 "SELECT pid,datid,usesysid FROM pg_stat_activity "
-                 "WHERE application_name='%s' AND state='active' "
-                 "ORDER BY backend_start DESC LIMIT 1", appname);
+                 "WITH target AS (SELECT pid,datid,usesysid,state "
+                 "FROM pg_stat_activity WHERE application_name='%s' "
+                 "AND state='%s' ORDER BY backend_start DESC LIMIT 1) "
+                 "SELECT 'target',pid::text,datid::text,usesysid::text,'0',"
+                 "CASE WHEN state='active' THEN '1' ELSE '0' END FROM target "
+                 "UNION ALL SELECT 'observer',pg_backend_pid()::text,"
+                 "'0','0','0','0'",
+                 appname, want_active ? "active" : "idle");
 
-    for (int attempt = 0; attempt < 12; attempt++) {
+    for (int attempt = 0; attempt < 20; attempt++) {
         struct pgwt_proc observer;
         if (spawn_psql(psql, user, socket_dir, port, sql, &observer) != 0)
             return -1;
-        char line[256] = "";
-        bool got = fgets(line, sizeof(line), observer.out) != NULL;
+        pid_t target_pid = 0, observer_pid = 0;
+        uint32_t databaseid = 0, userid = 0;
+        long long query_id = 0;
+        int active = -1;
+        char line[256];
+        while (fgets(line, sizeof(line), observer.out)) {
+            if (sscanf(line, "target|%d|%u|%u|%lld|%d",
+                       &target_pid, &databaseid, &userid,
+                       &query_id, &active) == 5)
+                continue;
+            (void)sscanf(line, "observer|%d", &observer_pid);
+        }
         int status = pgwt_proc_close(&observer);
-        if (got && status == 0) {
-            char *save = NULL;
-            char *pid_s = strtok_r(line, "|\r\n", &save);
-            char *db_s = strtok_r(NULL, "|\r\n", &save);
-            char *user_s = strtok_r(NULL, "|\r\n", &save);
-            char *qid_s = pg_major >= 14
-                ? strtok_r(NULL, "|\r\n", &save) : NULL;
-            if (pid_s && db_s && user_s) {
-                expected->pid = (pid_t)strtol(pid_s, NULL, 10);
-                expected->databaseid = (uint32_t)strtoul(db_s, NULL, 10);
-                expected->userid = (uint32_t)strtoul(user_s, NULL, 10);
-                expected->require_running = true;
-                expected->state_shadow_available = true;
-                expected->state_active = true;
-                if (pg_major >= 14 && qid_s) {
-                    expected->query_id = (uint64_t)strtoll(qid_s, NULL, 10);
-                    expected->query_id_available = true;
-                }
-                if (expected->pid > 0 && expected->databaseid > 0 &&
-                    expected->userid > 0)
-                    return 0;
-            }
+        if (observer_pid > 0 && wait_for_pid_exit(observer_pid) != 0)
+            return -2;
+        bool qid_ok = pg_major < 14 || !want_active || query_id != 0;
+        if (status == 0 && target_pid > 0 && databaseid > 0 && userid > 0 &&
+            active == (want_active ? 1 : 0) && qid_ok) {
+            memset(expected, 0, sizeof(*expected));
+            expected->pid = target_pid;
+            expected->databaseid = databaseid;
+            expected->userid = userid;
+            expected->require_running = want_active;
+            expected->state_shadow_available = true;
+            expected->state_active = want_active;
+            expected->query_id = (uint64_t)query_id;
+            expected->query_id_available = pg_major >= 14 && query_id != 0;
+            return 0;
         }
         usleep(50000);
     }
     return -1;
+}
+
+static uint64_t resolve_controlled_snapshot(
+    pid_t pid, uint64_t preferred_base, uint64_t my_be_entry_addr,
+    const struct PgBackendStatusLayout *layout,
+    const struct pgwt_pgbs_expected *expected, const char *activity_marker,
+    struct pgwt_pgbs_snapshot *snapshot)
+{
+    uint64_t base = preferred_base;
+    int mem_fd = open_mem(pid);
+    if (mem_fd >= 0) {
+        if (!base && my_be_entry_addr &&
+            pread_exact(mem_fd, &base, sizeof(base), my_be_entry_addr) < 0)
+            base = 0;
+        /* A readable nonzero MyBEEntry pointer is still only a candidate.
+         * Zero it on any incoherent/content mismatch so the unique shared
+         * mapping scan remains reachable. */
+        if (base && !candidate_ok(mem_fd, base, layout, expected,
+                                  activity_marker, snapshot))
+            base = 0;
+        close(mem_fd);
+    }
+    if (!base)
+        base = scan_shared_for_entry(pid, layout, expected, activity_marker,
+                                     snapshot);
+    return base;
 }
 
 static void degrade_unvalidated(struct PgBackendStatusLayout *layout,
@@ -1310,59 +1397,190 @@ int pgwt_pgbs_validate_runtime(struct PgBackendStatusLayout *layout,
     }
     snprintf(slash + 1, (size_t)(psql + sizeof(psql) - slash - 1), "psql");
 
-    char appname[96], controlled_sql[256];
-    snprintf(appname, sizeof(appname), "pgwt-layout-validation-%d",
-             postmaster_pid);
-    snprintf(controlled_sql, sizeof(controlled_sql),
-             "SET application_name='%s'; SELECT pg_sleep(5)", appname);
+    char appname[96], idle_marker[96], first_marker[96], second_marker[96];
+    snprintf(appname, sizeof(appname), "pgwt-layout-validation-%d-%d",
+             postmaster_pid, getpid());
+    snprintf(idle_marker, sizeof(idle_marker), "pgwt-layout-idle-%d",
+             getpid());
+    snprintf(first_marker, sizeof(first_marker), "pgwt-layout-active-a-%d",
+             getpid());
+    snprintf(second_marker, sizeof(second_marker), "pgwt-layout-active-b-%d",
+             getpid());
     struct pgwt_proc controlled;
-    if (spawn_psql(psql, user, socket_dir, port, controlled_sql,
-                   &controlled) != 0) {
+    if (spawn_psql_session(psql, user, socket_dir, port, appname,
+                           &controlled) != 0) {
         degrade_unvalidated(layout, "could not start controlled backend");
         return -1;
     }
 
-    struct pgwt_pgbs_expected expected;
-    memset(&expected, 0, sizeof(expected));
-    int observed = observe_controlled_backend(psql, user, socket_dir, port,
-                                              appname, layout->major,
-                                              &expected);
-    struct pgwt_pgbs_snapshot snapshot;
-    memset(&snapshot, 0, sizeof(snapshot));
-    uint64_t base = 0;
+    char command[256];
+    int observed = 0;
+    if (layout->major >= 14)
+        observed = send_psql(&controlled, "SET compute_query_id=on;");
+    snprintf(command, sizeof(command), "SELECT 1 /* %s */;", idle_marker);
+    if (observed == 0)
+        observed = send_psql(&controlled, command);
+
+    struct pgwt_pgbs_expected idle_expected, first_expected, second_expected;
+    memset(&idle_expected, 0, sizeof(idle_expected));
+    memset(&first_expected, 0, sizeof(first_expected));
+    memset(&second_expected, 0, sizeof(second_expected));
+    struct pgwt_pgbs_snapshot idle_snapshot, first_snapshot, second_snapshot;
+    memset(&idle_snapshot, 0, sizeof(idle_snapshot));
+    memset(&first_snapshot, 0, sizeof(first_snapshot));
+    memset(&second_snapshot, 0, sizeof(second_snapshot));
+    uint64_t idle_base = 0, first_base = 0, second_base = 0;
+
+    if (observed == 0)
+        observed = observe_controlled_backend(
+            psql, user, socket_dir, port, appname, layout->major, false,
+            &idle_expected);
     if (observed == 0) {
-        int mem_fd = open_mem(expected.pid);
-        if (mem_fd >= 0) {
-            if (my_be_entry_addr)
-                (void)pread_exact(mem_fd, &base, sizeof(base),
-                                  my_be_entry_addr);
-            if (base)
-                (void)read_snapshot_fd(mem_fd, base, layout, &snapshot,
-                                       (char[512]){0}, 512);
-            close(mem_fd);
-        }
-        if (!base)
-            base = scan_shared_for_entry(expected.pid, layout, &expected,
-                                         "pg_sleep",
-                                         &snapshot);
+        idle_expected.activity_marker_required = true;
+        idle_base = resolve_controlled_snapshot(
+            idle_expected.pid, 0, my_be_entry_addr, layout, &idle_expected,
+            idle_marker, &idle_snapshot);
+        if (!idle_base)
+            observed = -1;
     }
 
-    /* Terminate the short validation client.  If runuser does not forward the
-     * signal, pg_sleep bounds the reap to five seconds. */
-    kill(controlled.pid, SIGTERM);
-    (void)pgwt_proc_close(&controlled);
+    snprintf(command, sizeof(command),
+             "SELECT pg_sleep(0.25) /* %s */;", first_marker);
+    if (observed == 0)
+        observed = send_psql(&controlled, command);
+    if (observed == 0)
+        observed = observe_controlled_backend(
+            psql, user, socket_dir, port, appname, layout->major, true,
+            &first_expected);
+    if (observed == 0) {
+        first_expected.activity_marker_required = true;
+        first_base = resolve_controlled_snapshot(
+            first_expected.pid, idle_base, my_be_entry_addr, layout,
+            &first_expected, first_marker, &first_snapshot);
+        if (!first_base)
+            observed = -1;
+    }
 
-    if (observed != 0) {
+    /* Wait for the same backend to become idle before issuing the second,
+     * structurally distinct statement.  This prevents psql from queueing both
+     * commands and gives st_state an observed active->idle boundary. */
+    struct pgwt_pgbs_expected between_expected;
+    memset(&between_expected, 0, sizeof(between_expected));
+    if (observed == 0)
+        observed = observe_controlled_backend(
+            psql, user, socket_dir, port, appname, layout->major, false,
+            &between_expected);
+
+    snprintf(command, sizeof(command),
+             "SELECT 1 FROM pg_sleep(0.25) /* %s */;", second_marker);
+    if (observed == 0)
+        observed = send_psql(&controlled, command);
+    if (observed == 0)
+        observed = observe_controlled_backend(
+            psql, user, socket_dir, port, appname, layout->major, true,
+            &second_expected);
+    if (observed == 0) {
+        second_expected.activity_marker_required = true;
+        second_base = resolve_controlled_snapshot(
+            second_expected.pid, idle_base, my_be_entry_addr, layout,
+            &second_expected, second_marker, &second_snapshot);
+        if (!second_base)
+            observed = -1;
+    }
+
+    pid_t controlled_pid = idle_expected.pid;
+    /* Finish the final statement, then deliver EOF and drain psql's small
+     * result stream before reaping it.  Closing stdout first would give psql
+     * SIGPIPE after the validation had already succeeded. */
+    if (controlled.in) {
+        fclose(controlled.in);
+        controlled.in = NULL;
+    }
+    char discard[256];
+    while (fgets(discard, sizeof(discard), controlled.out))
+        ;
+    int controlled_status = pgwt_proc_close(&controlled);
+    bool retired = controlled_pid > 0 &&
+                   wait_for_pid_exit(controlled_pid) == 0;
+    if (!retired) {
+        char reason[192];
+        snprintf(reason, sizeof(reason),
+                 "controlled validation backend did not retire before capture "
+                 "(pid=%d observation=%d client_status=%d)",
+                 controlled_pid, observed, controlled_status);
+        degrade_unvalidated(layout, reason);
+        return -2;
+    }
+    if (observed == -2) {
+        degrade_unvalidated(layout,
+                            "validation observer did not retire before capture");
+        return -2;
+    }
+    if (observed != 0 || controlled_status != 0) {
         degrade_unvalidated(layout,
                             "controlled backend/auth unavailable; no offset accepted");
         return -1;
     }
-    if (!base) {
-        degrade_unvalidated(layout,
-                            "controlled backend entry was not uniquely resolved");
-        return -1;
+
+    bool same_backend = idle_expected.pid == first_expected.pid &&
+                        idle_expected.pid == between_expected.pid &&
+                        idle_expected.pid == second_expected.pid &&
+                        idle_expected.databaseid == first_expected.databaseid &&
+                        idle_expected.databaseid == second_expected.databaseid &&
+                        idle_expected.userid == first_expected.userid &&
+                        idle_expected.userid == second_expected.userid;
+    struct PgBackendStatusLayout first_result = *layout;
+    (void)pgwt_pgbs_validate_snapshot(&first_result, &first_snapshot,
+                                      &first_expected);
+    int rc = pgwt_pgbs_validate_snapshot(layout, &second_snapshot,
+                                         &second_expected);
+
+    bool idle_state = has_read(&idle_snapshot, PGWT_PGBS_READ_STATE) &&
+        idle_snapshot.state <= (uint32_t)layout->state_max &&
+        idle_snapshot.state != (uint32_t)layout->state_running &&
+        idle_snapshot.state != (uint32_t)layout->state_fastpath;
+    bool active_transition = same_backend && idle_state &&
+        first_result.st_state.validation == PGWT_PGBS_FIELD_VALIDATED &&
+        idle_snapshot.state != first_snapshot.state;
+    if (!active_transition) {
+        layout->st_state.validation = PGWT_PGBS_FIELD_INVALID;
+        layout->fallback_mask |= PGWT_PGBS_FALLBACK_STATE;
+        rc = -1;
     }
-    return pgwt_pgbs_validate_snapshot(layout, &snapshot, &expected);
+
+    bool query_varied = layout->major < 14 ||
+        (same_backend && first_expected.query_id_available &&
+         second_expected.query_id_available &&
+         first_expected.query_id != 0 && second_expected.query_id != 0 &&
+         first_expected.query_id != second_expected.query_id &&
+         first_result.st_query_id.validation == PGWT_PGBS_FIELD_VALIDATED &&
+         layout->st_query_id.validation == PGWT_PGBS_FIELD_VALIDATED);
+    if (!query_varied && layout->major >= 14) {
+        layout->st_query_id.validation = PGWT_PGBS_FIELD_INVALID;
+        layout->fallback_mask |= PGWT_PGBS_FALLBACK_QUERY_ID;
+        rc = -1;
+    }
+    layout->validation = layout->fallback_mask
+        ? PGWT_PGBS_VALIDATION_DEGRADED
+        : PGWT_PGBS_VALIDATION_VALIDATED;
+    if (layout->validation == PGWT_PGBS_VALIDATION_VALIDATED) {
+        if (layout->major < 14)
+            set_detail(layout,
+                       "controlled backend retired before capture; idle/active state and activity markers validated; query ID ABSENT");
+        else
+            set_detail(layout,
+                       "controlled backend retired before capture; idle/active state, activity markers and varying query IDs validated");
+    } else {
+        set_detail(layout,
+                   "controlled sequence failed: same_backend=%s state_transition=%s activity_marker=%s query_varied=%s",
+                   same_backend ? "yes" : "no",
+                   active_transition ? "yes" : "no",
+                   layout->st_activity_raw.validation ==
+                       PGWT_PGBS_FIELD_VALIDATED ? "yes" : "no",
+                   layout->major < 14 ? "n/a" :
+                       (query_varied ? "yes" : "no"));
+    }
+    return rc;
 }
 
 int pgwt_pgbs_validate_uprobe_shadow(struct PgBackendStatusLayout *layout,
@@ -1378,7 +1596,8 @@ int pgwt_pgbs_validate_uprobe_shadow(struct PgBackendStatusLayout *layout,
         .pid = backend_pid,
         .state_shadow_available = true,
         .state_active = cmd_open,
-        .query_id_available = layout->major >= 14 && query_id_available,
+        .query_id_available = layout->major >= 14 && query_id_available &&
+                              query_id != 0,
         .query_id = query_id,
     };
     struct pgwt_pgbs_snapshot snapshot;
@@ -1387,10 +1606,12 @@ int pgwt_pgbs_validate_uprobe_shadow(struct PgBackendStatusLayout *layout,
     int mem_fd = open_mem(backend_pid);
     if (mem_fd >= 0) {
         if (my_be_entry_addr)
-            (void)pread_exact(mem_fd, &base, sizeof(base), my_be_entry_addr);
-        if (base)
-            (void)read_snapshot_fd(mem_fd, base, layout, &snapshot,
-                                   (char[512]){0}, 512);
+            if (pread_exact(mem_fd, &base, sizeof(base),
+                            my_be_entry_addr) < 0)
+                base = 0;
+        if (base && !candidate_ok(mem_fd, base, layout, &expected, NULL,
+                                  &snapshot))
+            base = 0;
         close(mem_fd);
     }
     if (!base)
@@ -1399,6 +1620,74 @@ int pgwt_pgbs_validate_uprobe_shadow(struct PgBackendStatusLayout *layout,
     if (!base)
         return -1;
     return pgwt_pgbs_validate_snapshot(layout, &snapshot, &expected);
+}
+
+void pgwt_pgbs_warmup_note(struct pgwt_pgbs_warmup_evidence *evidence,
+                           const struct PgBackendStatusLayout *candidate,
+                           bool state_active,
+                           bool query_id_available,
+                           uint64_t query_id)
+{
+    if (!evidence || !candidate || !candidate->validated_pid)
+        return;
+    evidence->observations++;
+    if (state_active && candidate->st_state.validation ==
+                        PGWT_PGBS_FIELD_VALIDATED)
+        evidence->state_matches++;
+    if (candidate->st_activity_raw.validation == PGWT_PGBS_FIELD_VALIDATED)
+        evidence->activity_matches++;
+    if (query_id_available && query_id != 0 &&
+        candidate->st_query_id.validation == PGWT_PGBS_FIELD_VALIDATED) {
+        evidence->query_matches++;
+        if (!evidence->query_id_seen) {
+            evidence->query_id_seen = true;
+            evidence->first_query_id = query_id;
+        } else if (query_id != evidence->first_query_id) {
+            evidence->query_id_varied = true;
+        }
+    }
+}
+
+bool pgwt_pgbs_warmup_complete(
+    const struct pgwt_pgbs_warmup_evidence *evidence, int pg_major)
+{
+    if (!evidence || evidence->state_matches < 3 ||
+        evidence->activity_matches < 3)
+        return false;
+    return pg_major < 14 ||
+           (evidence->query_matches >= 3 && evidence->query_id_varied);
+}
+
+void pgwt_pgbs_warmup_apply(struct PgBackendStatusLayout *layout,
+                            const struct pgwt_pgbs_warmup_evidence *evidence)
+{
+    if (!layout || !evidence)
+        return;
+    bool state_ok = evidence->state_matches >= 3;
+    bool activity_ok = evidence->activity_matches >= 3;
+    bool query_ok = layout->major < 14 ||
+        (evidence->query_matches >= 3 && evidence->query_id_varied);
+
+    layout->st_state.validation = state_ok
+        ? PGWT_PGBS_FIELD_VALIDATED : PGWT_PGBS_FIELD_INVALID;
+    layout->st_activity_raw.validation = activity_ok
+        ? PGWT_PGBS_FIELD_VALIDATED : PGWT_PGBS_FIELD_INVALID;
+    if (layout->major >= 14)
+        layout->st_query_id.validation = query_ok
+            ? PGWT_PGBS_FIELD_VALIDATED : PGWT_PGBS_FIELD_INVALID;
+    else
+        layout->st_query_id.validation = PGWT_PGBS_FIELD_ABSENT;
+
+    layout->fallback_mask = 0;
+    if (!state_ok)
+        layout->fallback_mask |= PGWT_PGBS_FALLBACK_STATE;
+    if (!activity_ok)
+        layout->fallback_mask |= PGWT_PGBS_FALLBACK_ACTIVITY_RAW;
+    if (!query_ok)
+        layout->fallback_mask |= PGWT_PGBS_FALLBACK_QUERY_ID;
+    layout->validation = layout->fallback_mask
+        ? PGWT_PGBS_VALIDATION_DEGRADED
+        : PGWT_PGBS_VALIDATION_VALIDATED;
 }
 
 /* ── Reporting ────────────────────────────────────────────── */

--- a/src/backend_status_layout.h
+++ b/src/backend_status_layout.h
@@ -1,0 +1,169 @@
+/* backend_status_layout.h -- PgBackendStatus discovery and validation.
+ *
+ * Stage 1 is deliberately observational: this descriptor is discovered,
+ * validated and reported, but no sampler or BPF path consumes it yet. */
+#ifndef PGWT_BACKEND_STATUS_LAYOUT_H
+#define PGWT_BACKEND_STATUS_LAYOUT_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <sys/types.h>
+
+enum pgwt_pgbs_arch {
+    PGWT_PGBS_ARCH_UNKNOWN = 0,
+    PGWT_PGBS_ARCH_X86_64,
+    PGWT_PGBS_ARCH_ARM64,
+};
+
+enum pgwt_pgbs_abi {
+    PGWT_PGBS_ABI_UNKNOWN = 0,
+    PGWT_PGBS_ABI_SYSV_LP64,
+    PGWT_PGBS_ABI_AAPCS64_LP64,
+};
+
+enum pgwt_pgbs_source {
+    PGWT_PGBS_SOURCE_NONE = 0,
+    PGWT_PGBS_SOURCE_DWARF,
+    PGWT_PGBS_SOURCE_HARD_TABLE,
+};
+
+enum pgwt_pgbs_validation {
+    PGWT_PGBS_VALIDATION_NOT_RUN = 0,
+    PGWT_PGBS_VALIDATION_VALIDATED,
+    PGWT_PGBS_VALIDATION_DEGRADED,
+    PGWT_PGBS_VALIDATION_REJECTED,
+};
+
+enum pgwt_pgbs_field_validation {
+    PGWT_PGBS_FIELD_NOT_RUN = 0,
+    PGWT_PGBS_FIELD_VALIDATED,
+    PGWT_PGBS_FIELD_ABSENT,
+    PGWT_PGBS_FIELD_INVALID,
+};
+
+struct pgwt_pgbs_field {
+    uint32_t offset;
+    uint8_t  width;
+    bool     present;
+    enum pgwt_pgbs_field_validation validation;
+};
+
+enum pgwt_pgbs_fallback {
+    PGWT_PGBS_FALLBACK_STATE        = 1u << 0,
+    PGWT_PGBS_FALLBACK_ACTIVITY_RAW = 1u << 1,
+    PGWT_PGBS_FALLBACK_QUERY_ID     = 1u << 2,
+};
+
+struct PgBackendStatusLayout {
+    int major;
+    enum pgwt_pgbs_arch arch;
+    enum pgwt_pgbs_abi abi;
+    uint8_t pointer_width;
+    uint32_t struct_size;
+
+    struct pgwt_pgbs_field st_changecount;
+    struct pgwt_pgbs_field st_procpid;
+    struct pgwt_pgbs_field st_databaseid;
+    struct pgwt_pgbs_field st_userid;
+    struct pgwt_pgbs_field st_state;
+    struct pgwt_pgbs_field st_activity_raw;
+    struct pgwt_pgbs_field st_query_id;
+    bool st_query_id_signed;
+
+    int state_running;
+    int state_fastpath;
+    int state_max;
+
+    enum pgwt_pgbs_source source;
+    enum pgwt_pgbs_validation validation;
+    uint32_t fallback_mask;
+    pid_t validated_pid;
+    char detail[192];
+};
+
+/* A coherent copy of the fields used by the runtime validator.  read_mask
+ * uses the internal field order exposed by PGWT_PGBS_READ_* below so tests
+ * can inject short reads without touching another process. */
+enum pgwt_pgbs_read_mask {
+    PGWT_PGBS_READ_CHANGECOUNT = 1u << 0,
+    PGWT_PGBS_READ_PROCPID     = 1u << 1,
+    PGWT_PGBS_READ_DATABASEID  = 1u << 2,
+    PGWT_PGBS_READ_USERID      = 1u << 3,
+    PGWT_PGBS_READ_STATE       = 1u << 4,
+    PGWT_PGBS_READ_ACTIVITY    = 1u << 5,
+    PGWT_PGBS_READ_QUERY_ID    = 1u << 6,
+};
+
+struct pgwt_pgbs_snapshot {
+    uint32_t changecount_before;
+    uint32_t changecount_after;
+    uint32_t procpid;
+    uint32_t databaseid;
+    uint32_t userid;
+    uint32_t state;
+    uint64_t activity_raw;
+    uint64_t query_id;
+    uint32_t read_mask;
+    bool activity_readable;
+};
+
+struct pgwt_pgbs_expected {
+    pid_t pid;
+    uint32_t databaseid; /* 0 means plausibility check only */
+    uint32_t userid;     /* 0 means plausibility check only */
+    bool require_running;
+    bool state_shadow_available;
+    bool state_active;
+    bool query_id_available;
+    uint64_t query_id;
+};
+
+enum pgwt_pgbs_arch pgwt_pgbs_arch_from_name(const char *name);
+enum pgwt_pgbs_abi pgwt_pgbs_abi_for_arch(enum pgwt_pgbs_arch arch,
+                                           unsigned pointer_width);
+const char *pgwt_pgbs_arch_name(enum pgwt_pgbs_arch arch);
+const char *pgwt_pgbs_abi_name(enum pgwt_pgbs_abi abi);
+const char *pgwt_pgbs_source_name(enum pgwt_pgbs_source source);
+const char *pgwt_pgbs_validation_name(enum pgwt_pgbs_validation validation);
+
+/* Parse readelf --debug-dump=info --wide text.  Exposed for deterministic
+ * fixture tests; production reaches it through pgwt_pgbs_discover(). */
+int pgwt_pgbs_parse_dwarf(FILE *fp, int pg_major, unsigned pointer_width,
+                          struct PgBackendStatusLayout *out,
+                          char *why, size_t why_sz);
+
+/* Exact hard-table lookup.  No architecture, pointer-width or ABI default is
+ * applied: an unknown key returns -1 and leaves out zeroed. */
+int pgwt_pgbs_hard_table_lookup(int pg_major, enum pgwt_pgbs_arch arch,
+                                unsigned pointer_width,
+                                enum pgwt_pgbs_abi abi,
+                                struct PgBackendStatusLayout *out);
+
+/* DWARF first, exact hard table second. */
+int pgwt_pgbs_discover(const char *pg_binary, int pg_major,
+                       struct PgBackendStatusLayout *out);
+
+/* Pure validation core and live controlled-backend wrapper. */
+int pgwt_pgbs_validate_snapshot(struct PgBackendStatusLayout *layout,
+                                const struct pgwt_pgbs_snapshot *snapshot,
+                                const struct pgwt_pgbs_expected *expected);
+int pgwt_pgbs_validate_runtime(struct PgBackendStatusLayout *layout,
+                               pid_t postmaster_pid,
+                               uint64_t my_be_entry_addr,
+                               const char *pg_binary);
+/* Auth-free fallback used only when the controlled backend could not be
+ * created.  It compares a coherent memory snapshot with the already-running
+ * activity/query uprobes; callers repeat it during a bounded warmup. */
+int pgwt_pgbs_validate_uprobe_shadow(struct PgBackendStatusLayout *layout,
+                                     pid_t backend_pid,
+                                     uint64_t my_be_entry_addr,
+                                     bool cmd_open,
+                                     bool query_id_available,
+                                     uint64_t query_id);
+
+unsigned pgwt_pgbs_fallback_count(const struct PgBackendStatusLayout *layout);
+void pgwt_pgbs_log(const struct PgBackendStatusLayout *layout);
+
+#endif /* PGWT_BACKEND_STATUS_LAYOUT_H */

--- a/src/backend_status_layout.h
+++ b/src/backend_status_layout.h
@@ -107,6 +107,7 @@ struct pgwt_pgbs_snapshot {
     uint64_t query_id;
     uint32_t read_mask;
     bool activity_readable;
+    bool activity_marker_matched;
 };
 
 struct pgwt_pgbs_expected {
@@ -116,8 +117,22 @@ struct pgwt_pgbs_expected {
     bool require_running;
     bool state_shadow_available;
     bool state_active;
+    bool activity_marker_required;
     bool query_id_available;
     uint64_t query_id;
+};
+
+/* Pure aggregation state for the auth-free bounded warmup.  A field needs
+ * three independent positive matches; state matches are active-only, and a
+ * PG14+ query-id proof additionally needs two distinct nonzero IDs. */
+struct pgwt_pgbs_warmup_evidence {
+    unsigned observations;
+    unsigned state_matches;
+    unsigned activity_matches;
+    unsigned query_matches;
+    bool query_id_seen;
+    bool query_id_varied;
+    uint64_t first_query_id;
 };
 
 enum pgwt_pgbs_arch pgwt_pgbs_arch_from_name(const char *name);
@@ -152,7 +167,7 @@ int pgwt_pgbs_validate_snapshot(struct PgBackendStatusLayout *layout,
 int pgwt_pgbs_validate_runtime(struct PgBackendStatusLayout *layout,
                                pid_t postmaster_pid,
                                uint64_t my_be_entry_addr,
-                               const char *pg_binary);
+                               const char *pg_binary); /* -2: session not retired */
 /* Auth-free fallback used only when the controlled backend could not be
  * created.  It compares a coherent memory snapshot with the already-running
  * activity/query uprobes; callers repeat it during a bounded warmup. */
@@ -162,6 +177,16 @@ int pgwt_pgbs_validate_uprobe_shadow(struct PgBackendStatusLayout *layout,
                                      bool cmd_open,
                                      bool query_id_available,
                                      uint64_t query_id);
+
+void pgwt_pgbs_warmup_note(struct pgwt_pgbs_warmup_evidence *evidence,
+                           const struct PgBackendStatusLayout *candidate,
+                           bool state_active,
+                           bool query_id_available,
+                           uint64_t query_id);
+bool pgwt_pgbs_warmup_complete(
+    const struct pgwt_pgbs_warmup_evidence *evidence, int pg_major);
+void pgwt_pgbs_warmup_apply(struct PgBackendStatusLayout *layout,
+                            const struct pgwt_pgbs_warmup_evidence *evidence);
 
 unsigned pgwt_pgbs_fallback_count(const struct PgBackendStatusLayout *layout);
 void pgwt_pgbs_log(const struct PgBackendStatusLayout *layout);

--- a/src/backend_status_layout.h
+++ b/src/backend_status_layout.h
@@ -130,9 +130,28 @@ struct pgwt_pgbs_warmup_evidence {
     unsigned state_matches;
     unsigned activity_matches;
     unsigned query_matches;
+    bool state_seen;
+    bool state_varied;
+    uint32_t first_state;
     bool query_id_seen;
     bool query_id_varied;
     uint64_t first_query_id;
+};
+
+/* Validation clients run before capture enrollment starts.  Keep their
+ * PostgreSQL server-process identities out of both the startup scan and the
+ * later fork/init paths.  start_time is field 22 of /proc/<pid>/stat, so a
+ * recycled numeric PID does not exclude an unrelated future backend. */
+#define PGWT_PGBS_MAX_EXCLUDED_PIDS 256
+
+struct pgwt_pgbs_excluded_pid {
+    pid_t pid;
+    uint64_t start_time;
+};
+
+struct pgwt_pgbs_exclusion_set {
+    struct pgwt_pgbs_excluded_pid entries[PGWT_PGBS_MAX_EXCLUDED_PIDS];
+    unsigned count;
 };
 
 enum pgwt_pgbs_arch pgwt_pgbs_arch_from_name(const char *name);
@@ -164,23 +183,33 @@ int pgwt_pgbs_discover(const char *pg_binary, int pg_major,
 int pgwt_pgbs_validate_snapshot(struct PgBackendStatusLayout *layout,
                                 const struct pgwt_pgbs_snapshot *snapshot,
                                 const struct pgwt_pgbs_expected *expected);
-int pgwt_pgbs_validate_runtime(struct PgBackendStatusLayout *layout,
-                               pid_t postmaster_pid,
-                               uint64_t my_be_entry_addr,
-                               const char *pg_binary); /* -2: session not retired */
+void pgwt_pgbs_validate_runtime(struct PgBackendStatusLayout *layout,
+                                pid_t postmaster_pid,
+                                uint64_t my_be_entry_addr,
+                                const char *pg_binary,
+                                struct pgwt_pgbs_exclusion_set *exclusions);
+int pgwt_pgbs_pid_start_time(pid_t pid, uint64_t *start_time);
+bool pgwt_pgbs_pid_is_original(pid_t pid, uint64_t start_time);
+int pgwt_pgbs_exclusion_add(struct pgwt_pgbs_exclusion_set *set, pid_t pid);
+bool pgwt_pgbs_exclusion_contains(const struct pgwt_pgbs_exclusion_set *set,
+                                  pid_t pid);
 /* Auth-free fallback used only when the controlled backend could not be
  * created.  It compares a coherent memory snapshot with the already-running
  * activity/query uprobes; callers repeat it during a bounded warmup. */
 int pgwt_pgbs_validate_uprobe_shadow(struct PgBackendStatusLayout *layout,
                                      pid_t backend_pid,
                                      uint64_t my_be_entry_addr,
+                                     uint64_t debug_query_string_addr,
                                      bool cmd_open,
                                      bool query_id_available,
-                                     uint64_t query_id);
+                                     uint64_t query_id,
+                                     uint32_t *observed_state);
 
 void pgwt_pgbs_warmup_note(struct pgwt_pgbs_warmup_evidence *evidence,
                            const struct PgBackendStatusLayout *candidate,
                            bool state_active,
+                           bool state_value_available,
+                           uint32_t state_value,
                            bool query_id_available,
                            uint64_t query_id);
 bool pgwt_pgbs_warmup_complete(

--- a/src/control.c
+++ b/src/control.c
@@ -109,6 +109,15 @@ static cJSON *build_status(const struct pgwt_daemon *d)
     cJSON_AddNumberToObject(root, "backends", count_backends(d));
     cJSON_AddNumberToObject(root, "pg_pid", d->postmaster_pid);
     cJSON_AddStringToObject(root, "version", PGWT_BUILD_VERSION);
+    cJSON_AddStringToObject(root, "pgbackend_layout_source",
+                            pgwt_pgbs_source_name(
+                                d->backend_status_layout.source));
+    cJSON_AddStringToObject(root, "pgbackend_layout_validation",
+                            pgwt_pgbs_validation_name(
+                                d->backend_status_layout.validation));
+    cJSON_AddNumberToObject(root, "pgbackend_layout_fallback_fields",
+                            pgwt_pgbs_fallback_count(
+                                &d->backend_status_layout));
 
     /* Current capture tier and escalation state (A4). "tier" is what is being
      * captured right now: in tiered mode it flips between "sampled" (always-on
@@ -197,6 +206,8 @@ static cJSON *build_metrics(const struct pgwt_daemon *d)
     cJSON_AddNumberToObject(root, "samples_per_sec", ctr->samples_per_sec);
     cjson_add_uint64(root, "sample_read_faults_total",
                      ctr->sample_read_faults_total);
+    cjson_add_uint64(root, "pgbackend_layout_fallbacks_total",
+                     ctr->pgbackend_layout_fallbacks_total);
     cjson_add_uint64(root, "sample_read_failures_total",
                      pm.sample_read_failures_total);
     cJSON_AddNumberToObject(root, "sample_read_targets",

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -108,6 +108,10 @@ static int handle_lifecycle_event(void *ctx, void *data, size_t data_sz)
 
     d->counters.lifecycle_events_total++;
 
+    if (pgwt_pgbs_exclusion_contains(&d->pgbs_validation_exclusions,
+                                     ev->pid))
+        return 0;
+
     const char *op = "lifecycle_unknown";
     uint64_t started_ns = pgwt_debug_block_begin(d);
     switch (ev->type) {
@@ -445,11 +449,12 @@ static void bump_rlimit_nofile(struct pgwt_daemon *d)
 /* If local authentication prevented the preferred controlled-backend check,
  * use the probes that are already attached as an independent shadow source.
  * This is bounded startup-only observation: the descriptor is still not read
- * by either capture tier.  Three coherent positive-active matches tolerate
- * races without blessing idle-state coincidence; PG14+ query-id validation
- * additionally requires nonzero values and observed variation.  Full mode
- * skips this delayed fallback so its watchpoint capture window cannot be
- * extended; Stage 2's prospective consumers are sampled/tiered only. */
+ * by either capture tier.  Three activity-marker matches plus observed state
+ * variation tolerate races without blessing readable-pointer or constant-
+ * state coincidences; PG14+ query-id validation additionally requires
+ * nonzero values and observed variation.  Full mode skips this delayed
+ * fallback so its watchpoint capture window cannot be extended; Stage 2's
+ * prospective consumers are sampled/tiered only. */
 static void pgwt_layout_uprobe_shadow_warmup(struct pgwt_daemon *d)
 {
     if (d->backend_status_layout.validation != PGWT_PGBS_VALIDATION_DEGRADED ||
@@ -472,7 +477,13 @@ static void pgwt_layout_uprobe_shadow_warmup(struct pgwt_daemon *d)
          round++) {
         for (int i = 0; i < d->backends.count; i++) {
             const struct pgwt_backend *be = &d->backends.entries[i];
-            if (!be->is_alive)
+            /* PgBackendStatus/MyBEEntry describes client activity.  Auxiliary
+             * processes cannot provide the independent activity/query marker
+             * evidence this fallback requires; scanning their shared maps is
+             * both fruitless and capable of turning a one-second warmup into
+             * a long startup delay on a large shared-memory instance. */
+            if (!be->is_alive || !be->meta_parsed ||
+                be->meta.backend_type != PGWT_BT_CLIENT)
                 continue;
             uint32_t key = (uint32_t)be->pid;
             struct pgwt_pid_state state;
@@ -483,16 +494,20 @@ static void pgwt_layout_uprobe_shadow_warmup(struct pgwt_daemon *d)
                 d->backend_status_layout;
             bool qid_available = d->pg_major_version >= 14 &&
                                  state.last_query_id != 0;
+            uint32_t observed_state = UINT32_MAX;
             (void)pgwt_pgbs_validate_uprobe_shadow(
                 &candidate, be->pid, d->my_be_entry_addr,
+                d->debug_query_string_addr,
                 state.cmd_open != 0,
                 qid_available,
-                state.last_query_id);
+                state.last_query_id, &observed_state);
             if (!candidate.validated_pid)
                 continue;
             best = candidate;
             pgwt_pgbs_warmup_note(&evidence, &candidate,
-                                  state.cmd_open != 0, qid_available,
+                                  state.cmd_open != 0,
+                                  observed_state != UINT32_MAX,
+                                  observed_state, qid_available,
                                   state.last_query_id);
         }
         if (!pgwt_pgbs_warmup_complete(&evidence, d->pg_major_version))
@@ -505,15 +520,19 @@ static void pgwt_layout_uprobe_shadow_warmup(struct pgwt_daemon *d)
             snprintf(d->backend_status_layout.detail,
                      sizeof(d->backend_status_layout.detail),
                      "bounded uprobe shadow: observations=%u state=%u/3 "
+                     "state_varied=%s "
                      "activity=%u/3 query=n/a",
                      evidence.observations, evidence.state_matches,
+                     evidence.state_varied ? "yes" : "no",
                      evidence.activity_matches);
         else
             snprintf(d->backend_status_layout.detail,
                      sizeof(d->backend_status_layout.detail),
                      "bounded uprobe shadow: observations=%u state=%u/3 "
-                     "activity=%u/3 query=%u/3 varied=%s",
+                     "state_varied=%s "
+                     "activity=%u/3 query=%u/3 query_varied=%s",
                      evidence.observations, evidence.state_matches,
+                     evidence.state_varied ? "yes" : "no",
                      evidence.activity_matches, evidence.query_matches,
                      evidence.query_id_varied ? "yes" : "no");
         unsigned fallback_after =

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -442,6 +442,111 @@ static void bump_rlimit_nofile(struct pgwt_daemon *d)
             MAX_BACKENDS);
 }
 
+/* If local authentication prevented the preferred controlled-backend check,
+ * use the probes that are already attached as an independent shadow source.
+ * This is bounded startup-only observation: the descriptor is still not read
+ * by either capture tier.  Three coherent matches tolerate query/state races
+ * while refusing to bless a layout from a single coincidental value.  Full
+ * mode skips this delayed fallback so its watchpoint capture window cannot be
+ * extended; Stage 2's prospective consumers are sampled/tiered only. */
+static void pgwt_layout_uprobe_shadow_warmup(struct pgwt_daemon *d)
+{
+    if (d->backend_status_layout.validation != PGWT_PGBS_VALIDATION_DEGRADED ||
+        d->backend_status_layout.source == PGWT_PGBS_SOURCE_NONE ||
+        !d->cmd_gate_active || pgwt_mode_uses_watchpoints(d))
+        return;
+
+    bool query_shadow_available = d->pg_major_version < 14 ||
+        d->skel->links.on_report_query_id != NULL;
+    if (!query_shadow_available)
+        return;
+
+    int state_fd = bpf_map__fd(d->skel->maps.state_map);
+    unsigned observations = 0, state_matches = 0, activity_matches = 0;
+    unsigned query_matches = d->pg_major_version < 14 ? 3 : 0;
+    struct PgBackendStatusLayout best = d->backend_status_layout;
+    for (int round = 0; round < 10 &&
+         (state_matches < 3 || activity_matches < 3 || query_matches < 3);
+         round++) {
+        for (int i = 0; i < d->backends.count; i++) {
+            const struct pgwt_backend *be = &d->backends.entries[i];
+            if (!be->is_alive)
+                continue;
+            uint32_t key = (uint32_t)be->pid;
+            struct pgwt_pid_state state;
+            if (bpf_map_lookup_elem(state_fd, &key, &state) != 0)
+                continue;
+
+            struct PgBackendStatusLayout candidate =
+                d->backend_status_layout;
+            (void)pgwt_pgbs_validate_uprobe_shadow(
+                &candidate, be->pid, d->my_be_entry_addr,
+                state.cmd_open != 0,
+                d->pg_major_version >= 14,
+                state.last_query_id);
+            if (!candidate.validated_pid)
+                continue;
+            best = candidate;
+            observations++;
+            if (state_matches < 3 &&
+                candidate.st_state.validation == PGWT_PGBS_FIELD_VALIDATED)
+                state_matches++;
+            if (activity_matches < 3 &&
+                candidate.st_activity_raw.validation ==
+                PGWT_PGBS_FIELD_VALIDATED)
+                activity_matches++;
+            if (query_matches < 3 && d->pg_major_version >= 14 &&
+                candidate.st_query_id.validation == PGWT_PGBS_FIELD_VALIDATED)
+                query_matches++;
+        }
+        if (state_matches < 3 || activity_matches < 3 || query_matches < 3)
+            usleep(100000);
+    }
+    if (observations) {
+        best.st_state.validation = state_matches >= 3
+            ? PGWT_PGBS_FIELD_VALIDATED : PGWT_PGBS_FIELD_INVALID;
+        best.st_activity_raw.validation = activity_matches >= 3
+            ? PGWT_PGBS_FIELD_VALIDATED : PGWT_PGBS_FIELD_INVALID;
+        if (d->pg_major_version >= 14)
+            best.st_query_id.validation = query_matches >= 3
+                ? PGWT_PGBS_FIELD_VALIDATED : PGWT_PGBS_FIELD_INVALID;
+        best.fallback_mask = 0;
+        if (state_matches < 3)
+            best.fallback_mask |= PGWT_PGBS_FALLBACK_STATE;
+        if (activity_matches < 3)
+            best.fallback_mask |= PGWT_PGBS_FALLBACK_ACTIVITY_RAW;
+        if (d->pg_major_version >= 14 && query_matches < 3)
+            best.fallback_mask |= PGWT_PGBS_FALLBACK_QUERY_ID;
+        best.validation = best.fallback_mask
+            ? PGWT_PGBS_VALIDATION_DEGRADED
+            : PGWT_PGBS_VALIDATION_VALIDATED;
+        d->backend_status_layout = best;
+        if (d->pg_major_version < 14)
+            snprintf(d->backend_status_layout.detail,
+                     sizeof(d->backend_status_layout.detail),
+                     "bounded uprobe shadow: observations=%u state=%u/3 "
+                     "activity=%u/3 query=n/a",
+                     observations, state_matches, activity_matches);
+        else
+            snprintf(d->backend_status_layout.detail,
+                     sizeof(d->backend_status_layout.detail),
+                     "bounded uprobe shadow: observations=%u state=%u/3 "
+                     "activity=%u/3 query=%u/3",
+                     observations, state_matches, activity_matches,
+                     query_matches);
+        fprintf(stderr,
+                "INFO: PgBackendStatus bounded uprobe shadow validation "
+                "completed after controlled-backend validation was "
+                "unavailable\n");
+        pgwt_pgbs_log(&d->backend_status_layout);
+    } else {
+        fprintf(stderr,
+                "WARN: PgBackendStatus bounded uprobe shadow validation did "
+                "not reach 3 coherent matches — existing per-field "
+                "fallbacks remain active\n");
+    }
+}
+
 static void handle_signal(struct pgwt_daemon *d)
 {
     struct signalfd_siginfo si;
@@ -1009,6 +1114,10 @@ int pgwt_daemon_init(struct pgwt_daemon *d)
      * it would trace garbage (or nothing) labeled as real. */
     if (pgwt_confirm_wait_offset(d) != 0)
         goto fail;
+
+    /* Auth-free second validation route.  Normally the controlled backend in
+     * discovery.c has already validated the descriptor and this is a no-op. */
+    pgwt_layout_uprobe_shadow_warmup(d);
 
     /* Straddle-race recovery at startup. The one-shot scan above can miss a
      * pre-existing backend (its /proc read raced) or leave it in bootstrap

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -445,9 +445,10 @@ static void bump_rlimit_nofile(struct pgwt_daemon *d)
 /* If local authentication prevented the preferred controlled-backend check,
  * use the probes that are already attached as an independent shadow source.
  * This is bounded startup-only observation: the descriptor is still not read
- * by either capture tier.  Three coherent matches tolerate query/state races
- * while refusing to bless a layout from a single coincidental value.  Full
- * mode skips this delayed fallback so its watchpoint capture window cannot be
+ * by either capture tier.  Three coherent positive-active matches tolerate
+ * races without blessing idle-state coincidence; PG14+ query-id validation
+ * additionally requires nonzero values and observed variation.  Full mode
+ * skips this delayed fallback so its watchpoint capture window cannot be
  * extended; Stage 2's prospective consumers are sampled/tiered only. */
 static void pgwt_layout_uprobe_shadow_warmup(struct pgwt_daemon *d)
 {
@@ -462,11 +463,12 @@ static void pgwt_layout_uprobe_shadow_warmup(struct pgwt_daemon *d)
         return;
 
     int state_fd = bpf_map__fd(d->skel->maps.state_map);
-    unsigned observations = 0, state_matches = 0, activity_matches = 0;
-    unsigned query_matches = d->pg_major_version < 14 ? 3 : 0;
+    unsigned fallback_before =
+        pgwt_pgbs_fallback_count(&d->backend_status_layout);
+    struct pgwt_pgbs_warmup_evidence evidence = {0};
     struct PgBackendStatusLayout best = d->backend_status_layout;
     for (int round = 0; round < 10 &&
-         (state_matches < 3 || activity_matches < 3 || query_matches < 3);
+         !pgwt_pgbs_warmup_complete(&evidence, d->pg_major_version);
          round++) {
         for (int i = 0; i < d->backends.count; i++) {
             const struct pgwt_backend *be = &d->backends.entries[i];
@@ -479,61 +481,49 @@ static void pgwt_layout_uprobe_shadow_warmup(struct pgwt_daemon *d)
 
             struct PgBackendStatusLayout candidate =
                 d->backend_status_layout;
+            bool qid_available = d->pg_major_version >= 14 &&
+                                 state.last_query_id != 0;
             (void)pgwt_pgbs_validate_uprobe_shadow(
                 &candidate, be->pid, d->my_be_entry_addr,
                 state.cmd_open != 0,
-                d->pg_major_version >= 14,
+                qid_available,
                 state.last_query_id);
             if (!candidate.validated_pid)
                 continue;
             best = candidate;
-            observations++;
-            if (state_matches < 3 &&
-                candidate.st_state.validation == PGWT_PGBS_FIELD_VALIDATED)
-                state_matches++;
-            if (activity_matches < 3 &&
-                candidate.st_activity_raw.validation ==
-                PGWT_PGBS_FIELD_VALIDATED)
-                activity_matches++;
-            if (query_matches < 3 && d->pg_major_version >= 14 &&
-                candidate.st_query_id.validation == PGWT_PGBS_FIELD_VALIDATED)
-                query_matches++;
+            pgwt_pgbs_warmup_note(&evidence, &candidate,
+                                  state.cmd_open != 0, qid_available,
+                                  state.last_query_id);
         }
-        if (state_matches < 3 || activity_matches < 3 || query_matches < 3)
+        if (!pgwt_pgbs_warmup_complete(&evidence, d->pg_major_version))
             usleep(100000);
     }
-    if (observations) {
-        best.st_state.validation = state_matches >= 3
-            ? PGWT_PGBS_FIELD_VALIDATED : PGWT_PGBS_FIELD_INVALID;
-        best.st_activity_raw.validation = activity_matches >= 3
-            ? PGWT_PGBS_FIELD_VALIDATED : PGWT_PGBS_FIELD_INVALID;
-        if (d->pg_major_version >= 14)
-            best.st_query_id.validation = query_matches >= 3
-                ? PGWT_PGBS_FIELD_VALIDATED : PGWT_PGBS_FIELD_INVALID;
-        best.fallback_mask = 0;
-        if (state_matches < 3)
-            best.fallback_mask |= PGWT_PGBS_FALLBACK_STATE;
-        if (activity_matches < 3)
-            best.fallback_mask |= PGWT_PGBS_FALLBACK_ACTIVITY_RAW;
-        if (d->pg_major_version >= 14 && query_matches < 3)
-            best.fallback_mask |= PGWT_PGBS_FALLBACK_QUERY_ID;
-        best.validation = best.fallback_mask
-            ? PGWT_PGBS_VALIDATION_DEGRADED
-            : PGWT_PGBS_VALIDATION_VALIDATED;
+    if (evidence.observations) {
+        pgwt_pgbs_warmup_apply(&best, &evidence);
         d->backend_status_layout = best;
         if (d->pg_major_version < 14)
             snprintf(d->backend_status_layout.detail,
                      sizeof(d->backend_status_layout.detail),
                      "bounded uprobe shadow: observations=%u state=%u/3 "
                      "activity=%u/3 query=n/a",
-                     observations, state_matches, activity_matches);
+                     evidence.observations, evidence.state_matches,
+                     evidence.activity_matches);
         else
             snprintf(d->backend_status_layout.detail,
                      sizeof(d->backend_status_layout.detail),
                      "bounded uprobe shadow: observations=%u state=%u/3 "
-                     "activity=%u/3 query=%u/3",
-                     observations, state_matches, activity_matches,
-                     query_matches);
+                     "activity=%u/3 query=%u/3 varied=%s",
+                     evidence.observations, evidence.state_matches,
+                     evidence.activity_matches, evidence.query_matches,
+                     evidence.query_id_varied ? "yes" : "no");
+        unsigned fallback_after =
+            pgwt_pgbs_fallback_count(&d->backend_status_layout);
+        if (d->counters.pgbackend_layout_fallbacks_total >= fallback_before)
+            d->counters.pgbackend_layout_fallbacks_total =
+                d->counters.pgbackend_layout_fallbacks_total -
+                fallback_before + fallback_after;
+        else
+            d->counters.pgbackend_layout_fallbacks_total = fallback_after;
         fprintf(stderr,
                 "INFO: PgBackendStatus bounded uprobe shadow validation "
                 "completed after controlled-backend validation was "
@@ -542,7 +532,7 @@ static void pgwt_layout_uprobe_shadow_warmup(struct pgwt_daemon *d)
     } else {
         fprintf(stderr,
                 "WARN: PgBackendStatus bounded uprobe shadow validation did "
-                "not reach 3 coherent matches — existing per-field "
+                "not reach strong coherent evidence — existing per-field "
                 "fallbacks remain active\n");
     }
 }

--- a/src/daemon.h
+++ b/src/daemon.h
@@ -14,6 +14,7 @@
 #include "escalation.h"
 #include "anomaly.h"
 #include "effective_cores.h"
+#include "backend_status_layout.h"
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -40,6 +41,8 @@ struct pgwt_counters {
     uint64_t prev_samples_total;       /* samples_total at previous timer tick */
     double   samples_per_sec;          /* recent sample rate, refreshed each tick */
     uint64_t sample_read_faults_total; /* process_vm_readv partial/EFAULT fallbacks */
+    uint64_t pgbackend_layout_fallbacks_total; /* fields rejected by Stage 1
+                                                 * layout validation */
 
     /* Capture hardening (T4). All of these mean "something the operator
      * must know about is happening" — each is paired with a loud log. */
@@ -148,6 +151,9 @@ struct pgwt_daemon {
     int         pg_major_version;   /* 14, 15, 16, 17, or 18 */
     int         st_query_id_offset; /* 0 = not available */
     int         st_activity_offset; /* st_activity_raw in PgBackendStatus, 0 = N/A */
+    /* Stage 1 shadow descriptor.  Existing st_*_offset fields above remain
+     * the only offsets consumed by the sampler/BPF paths until Stage 2. */
+    struct PgBackendStatusLayout backend_status_layout;
 
     /* PG13 query attribution (Route B1 via pg_stat_statements). PG13 has no
      * in-core query_id; when pgss is loaded its post_parse_analyze hook

--- a/src/daemon.h
+++ b/src/daemon.h
@@ -154,6 +154,7 @@ struct pgwt_daemon {
     /* Stage 1 shadow descriptor.  Existing st_*_offset fields above remain
      * the only offsets consumed by the sampler/BPF paths until Stage 2. */
     struct PgBackendStatusLayout backend_status_layout;
+    struct pgwt_pgbs_exclusion_set pgbs_validation_exclusions;
 
     /* PG13 query attribution (Route B1 via pg_stat_statements). PG13 has no
      * in-core query_id; when pgss is loaded its post_parse_analyze hook

--- a/src/discovery.c
+++ b/src/discovery.c
@@ -1067,15 +1067,9 @@ int pgwt_discover(struct pgwt_daemon *d)
      * Stage 2 change. */
     (void)pgwt_pgbs_discover(binary, d->pg_major_version,
                              &d->backend_status_layout);
-    int layout_validation = pgwt_pgbs_validate_runtime(
-        &d->backend_status_layout, pm_pid, d->my_be_entry_addr, binary);
-    if (layout_validation == -2) {
-        fprintf(stderr,
-                "FATAL: PgBackendStatus validation session did not retire; "
-                "capture will not start (%s)\n",
-                d->backend_status_layout.detail);
-        return -1;
-    }
+    pgwt_pgbs_validate_runtime(&d->backend_status_layout, pm_pid,
+                               d->my_be_entry_addr, binary,
+                               &d->pgbs_validation_exclusions);
     d->counters.pgbackend_layout_fallbacks_total +=
         pgwt_pgbs_fallback_count(&d->backend_status_layout);
     pgwt_pgbs_log(&d->backend_status_layout);

--- a/src/discovery.c
+++ b/src/discovery.c
@@ -1067,8 +1067,15 @@ int pgwt_discover(struct pgwt_daemon *d)
      * Stage 2 change. */
     (void)pgwt_pgbs_discover(binary, d->pg_major_version,
                              &d->backend_status_layout);
-    (void)pgwt_pgbs_validate_runtime(&d->backend_status_layout, pm_pid,
-                                     d->my_be_entry_addr, binary);
+    int layout_validation = pgwt_pgbs_validate_runtime(
+        &d->backend_status_layout, pm_pid, d->my_be_entry_addr, binary);
+    if (layout_validation == -2) {
+        fprintf(stderr,
+                "FATAL: PgBackendStatus validation session did not retire; "
+                "capture will not start (%s)\n",
+                d->backend_status_layout.detail);
+        return -1;
+    }
     d->counters.pgbackend_layout_fallbacks_total +=
         pgwt_pgbs_fallback_count(&d->backend_status_layout);
     pgwt_pgbs_log(&d->backend_status_layout);

--- a/src/discovery.c
+++ b/src/discovery.c
@@ -1061,6 +1061,18 @@ int pgwt_discover(struct pgwt_daemon *d)
                 (unsigned long)d->my_be_entry_addr);
     }
 
+    /* Stage 1: discover and validate the complete PgBackendStatus layout in
+     * shadow mode.  Do not copy any of these offsets into the legacy fields
+     * below: those remain the sampler/BPF inputs until the separately-gated
+     * Stage 2 change. */
+    (void)pgwt_pgbs_discover(binary, d->pg_major_version,
+                             &d->backend_status_layout);
+    (void)pgwt_pgbs_validate_runtime(&d->backend_status_layout, pm_pid,
+                                     d->my_be_entry_addr, binary);
+    d->counters.pgbackend_layout_fallbacks_total +=
+        pgwt_pgbs_fallback_count(&d->backend_status_layout);
+    pgwt_pgbs_log(&d->backend_status_layout);
+
     /* Detect st_query_id offset (PG14+ in-core query_id path) */
     d->st_query_id_offset = pgwt_detect_query_id_offset(binary, d->pg_major_version);
 

--- a/src/discovery.c
+++ b/src/discovery.c
@@ -1067,6 +1067,7 @@ int pgwt_discover(struct pgwt_daemon *d)
      * Stage 2 change. */
     (void)pgwt_pgbs_discover(binary, d->pg_major_version,
                              &d->backend_status_layout);
+    d->pgbs_validation_exclusions.count = 0;
     pgwt_pgbs_validate_runtime(&d->backend_status_layout, pm_pid,
                                d->my_be_entry_addr, binary,
                                &d->pgbs_validation_exclusions);

--- a/src/pg_wait_tracer.c
+++ b/src/pg_wait_tracer.c
@@ -293,6 +293,12 @@ static struct option long_opts[] = {
 
 int main(int argc, char **argv)
 {
+    /* Validation uses pipes to best-effort psql clients.  Authentication or
+     * connection failure may close a client before the next command write;
+     * that is a degradable validation result, never authority to SIGPIPE the
+     * capture process. */
+    (void)signal(SIGPIPE, SIG_IGN);
+
     /* Heap-allocate: pgwt_daemon is ~27 MB due to accumulator arrays */
     struct pgwt_daemon *d = calloc(1, sizeof(*d));
     if (!d) {

--- a/src/spawn.c
+++ b/src/spawn.c
@@ -2,64 +2,107 @@
 #define _GNU_SOURCE   /* pipe2 */
 #include "spawn.h"
 
+#include <stdbool.h>
 #include <stdlib.h>
 #include <unistd.h>
 #include <fcntl.h>
 #include <errno.h>
 #include <sys/wait.h>
 
-int pgwt_proc_open(struct pgwt_proc *p, char *const argv[])
+static int proc_open(struct pgwt_proc *p, char *const argv[], bool writable)
 {
     p->out = NULL;
+    p->in = NULL;
     p->pid = -1;
 
-    int fds[2];
-    if (pipe2(fds, O_CLOEXEC) != 0)
+    int out_fds[2];
+    int in_fds[2] = {-1, -1};
+    if (pipe2(out_fds, O_CLOEXEC) != 0)
         return -1;
+    if (writable && pipe2(in_fds, O_CLOEXEC) != 0) {
+        close(out_fds[0]);
+        close(out_fds[1]);
+        return -1;
+    }
 
     pid_t pid = fork();
     if (pid < 0) {
-        close(fds[0]);
-        close(fds[1]);
+        close(out_fds[0]);
+        close(out_fds[1]);
+        if (writable) {
+            close(in_fds[0]);
+            close(in_fds[1]);
+        }
         return -1;
     }
 
     if (pid == 0) {
-        /* Child: stdout -> pipe; stdin/stderr -> /dev/null (matches the
-         * "2>/dev/null" the old popen command lines used). dup2 clears
-         * O_CLOEXEC on the duplicated fd, so stdout survives the exec. */
+        /* Child: stdout -> pipe and stderr -> /dev/null.  The read-only
+         * variant also maps stdin to /dev/null; the bidirectional variant
+         * maps it to the parent's input pipe.  dup2 clears O_CLOEXEC on the
+         * duplicated fd, so the selected descriptors survive exec. */
         int devnull = open("/dev/null", O_RDWR);
         if (devnull >= 0) {
-            dup2(devnull, STDIN_FILENO);
+            if (!writable)
+                dup2(devnull, STDIN_FILENO);
             dup2(devnull, STDERR_FILENO);
             if (devnull > STDERR_FILENO)
                 close(devnull);
         }
-        if (dup2(fds[1], STDOUT_FILENO) < 0)
+        if (writable && dup2(in_fds[0], STDIN_FILENO) < 0)
+            _exit(127);
+        if (dup2(out_fds[1], STDOUT_FILENO) < 0)
             _exit(127);
         execvp(argv[0], argv);
         _exit(127);   /* exec failed */
     }
 
-    close(fds[1]);
-    FILE *f = fdopen(fds[0], "r");
-    if (!f) {
-        close(fds[0]);
+    close(out_fds[1]);
+    if (writable)
+        close(in_fds[0]);
+    FILE *out = fdopen(out_fds[0], "r");
+    FILE *in = writable ? fdopen(in_fds[1], "w") : NULL;
+    if (!out || (writable && !in)) {
+        if (out)
+            fclose(out);
+        else
+            close(out_fds[0]);
+        if (writable) {
+            if (in)
+                fclose(in);
+            else
+                close(in_fds[1]);
+        }
         /* Reap the child we can no longer talk to. */
         int st;
         while (waitpid(pid, &st, 0) < 0 && errno == EINTR)
             ;
         return -1;
     }
-    p->out = f;
+    p->out = out;
+    p->in = in;
     p->pid = pid;
     return 0;
+}
+
+int pgwt_proc_open(struct pgwt_proc *p, char *const argv[])
+{
+    return proc_open(p, argv, false);
+}
+
+int pgwt_proc_open_rw(struct pgwt_proc *p, char *const argv[])
+{
+    return proc_open(p, argv, true);
 }
 
 int pgwt_proc_close(struct pgwt_proc *p)
 {
     if (!p->out)
         return -1;
+    if (p->in) {
+        fclose(p->in);
+        p->in = NULL;
+    }
     fclose(p->out);
     p->out = NULL;
 

--- a/src/spawn.h
+++ b/src/spawn.h
@@ -7,7 +7,7 @@
  * the child directly via fork+execvp with an argv array: no shell, nothing
  * to quote.
  *
- * Semantics mirror popen(cmd, "r") with "2>/dev/null":
+ * pgwt_proc_open() mirrors popen(cmd, "r") with "2>/dev/null":
  *   - child's stdout is piped to p->out (read with stdio as before)
  *   - child's stdin and stderr are /dev/null
  *   - pgwt_proc_close() waits and returns the raw wait(2) status
@@ -21,6 +21,7 @@
 
 struct pgwt_proc {
     FILE *out;   /* child's stdout (read end) */
+    FILE *in;    /* child's stdin (write end), NULL for pgwt_proc_open() */
     pid_t pid;
 };
 
@@ -28,6 +29,12 @@ struct pgwt_proc {
  * argument vector (NULL-terminated). Returns 0 on success (p->out readable),
  * -1 on failure. exec failure in the child surfaces as exit status 127. */
 int pgwt_proc_open(struct pgwt_proc *p, char *const argv[]);
+
+/* Bidirectional variant used for a long-lived command session.  stdout is
+ * exposed through p->out as above; writes to p->in feed the child's stdin.
+ * Closing the process closes stdin first, so an interactive child receives
+ * EOF and can retire its external session before it is reaped. */
+int pgwt_proc_open_rw(struct pgwt_proc *p, char *const argv[]);
 
 /* Close p->out, reap the child. Returns the raw wait status (0 for a clean
  * exit-0), or -1 on error. Safe to call after reading only part of the

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -14,6 +14,7 @@ TESTS     = test_wait_event test_cmdline test_event_writer test_event_reader \
             test_trace_v2 test_sampler test_anomaly test_escalation_budget \
             test_effective_cores \
             test_coop test_bucket \
+            test_backend_status_layout \
             test_pg13_resolve test_discovery_pie test_discovery_nopie \
             test_replay_fidelity test_durability test_query_text \
             test_golden_fixture \
@@ -47,7 +48,7 @@ test_event_writer: test_event_writer.c $(BUILD)/event_writer.o
 
 test_event_reader: test_event_reader.c $(BUILD)/event_reader.o $(BUILD)/event_writer.o \
                    $(BUILD)/map_reader.o $(BUILD)/wait_event.o $(BUILD)/spawn.o $(BUILD)/cJSON.o \
-                   $(BUILD)/discovery.o
+                   $(BUILD)/discovery.o $(BUILD)/backend_status_layout.o
 	$(CC) $(CFLAGS) -o $@ $^ -llz4 $(LIBBPF_LIB) -lelf -lz
 
 test_bucket: test_bucket.c
@@ -58,6 +59,7 @@ test_bucket: test_bucket.c
 # under test are BPF-free; discovery.c only needs libelf). Runs anywhere — no
 # live PostgreSQL, no BPF skeleton.
 test_pg13_resolve: test_pg13_resolve.c ../src/discovery.c ../src/spawn.c \
+                   ../src/backend_status_layout.c \
                    $(BUILD)/wait_event.o $(BUILD)/cJSON.o
 	$(CC) $(CFLAGS) -o $@ $^ -lelf -lz
 
@@ -73,6 +75,7 @@ test_pg13_resolve: test_pg13_resolve.c ../src/discovery.c ../src/spawn.c \
 # default to non-PIE on EL toolchains (R_X86_64_32S relocations), which fails
 # the `-pie` link. Building them here inherits this target's -fPIE/-fno-pie.
 DISCOVERY_TEST_DEPS = test_discovery.c ../src/discovery.c ../src/spawn.c \
+                      ../src/backend_status_layout.c \
                       ../src/wait_event.c ../src/cJSON.c
 
 test_discovery_pie: $(DISCOVERY_TEST_DEPS)
@@ -113,6 +116,13 @@ test_escalation_budget: test_escalation_budget.c ../src/escalation_budget.c
 # target committed fixtures and affinity is injected; it never inspects or
 # modifies the host's cgroup configuration.
 test_effective_cores: test_effective_cores.c ../src/effective_cores.c
+	$(CC) $(CFLAGS) -o $@ $^
+
+# Stage 1 PgBackendStatus discovery is BPF-free.  The test feeds synthetic
+# readelf streams into the strict parser and exercises both architecture
+# tables plus the pure coherency/degrade validator.
+test_backend_status_layout: test_backend_status_layout.c \
+                            ../src/backend_status_layout.c ../src/spawn.c
 	$(CC) $(CFLAGS) -o $@ $^
 
 # test_coop: cooperative provider stub (A6 interface freeze) — registers,
@@ -176,7 +186,7 @@ gen_bench_traces: gen_bench_traces.c $(SERVER_OBJS)
 
 test_concurrent_rw: test_concurrent_rw.c $(BUILD)/event_reader.o $(BUILD)/event_writer.o \
                     $(BUILD)/map_reader.o $(BUILD)/wait_event.o $(BUILD)/spawn.o $(BUILD)/cJSON.o \
-                    $(BUILD)/discovery.o
+                    $(BUILD)/discovery.o $(BUILD)/backend_status_layout.o
 	$(CC) $(CFLAGS) -o $@ $^ -llz4 $(LIBBPF_LIB) -lelf -lz
 
 # cross_validate: A4 sampled-vs-exact comparison tool. Server build

--- a/tests/test_backend_status_layout.c
+++ b/tests/test_backend_status_layout.c
@@ -255,6 +255,7 @@ static struct pgwt_pgbs_snapshot good_snapshot(void)
                      PGWT_PGBS_READ_STATE | PGWT_PGBS_READ_ACTIVITY |
                      PGWT_PGBS_READ_QUERY_ID,
         .activity_readable = true,
+        .activity_marker_matched = true,
     };
 }
 
@@ -268,7 +269,8 @@ static void test_validation(void)
     struct pgwt_pgbs_expected expected = {
         .pid = 4242, .databaseid = 16384, .userid = 10,
         .require_running = true, .state_shadow_available = true,
-        .state_active = true, .query_id_available = true,
+        .state_active = true, .activity_marker_required = true,
+        .query_id_available = true,
         .query_id = 0xf123456789abcdefULL,
     };
     struct pgwt_pgbs_snapshot snapshot = good_snapshot();
@@ -307,10 +309,39 @@ static void test_validation(void)
 
     layout = base;
     snapshot = good_snapshot();
+    snapshot.query_id = 0;
+    expected.query_id = 0;
+    CHECK(pgwt_pgbs_validate_snapshot(&layout, &snapshot, &expected) != 0 &&
+          layout.st_query_id.validation == PGWT_PGBS_FIELD_INVALID &&
+          layout.fallback_mask == PGWT_PGBS_FALLBACK_QUERY_ID,
+          "coincidental query-id 0==0 never validates a field offset");
+    expected.query_id = 0xf123456789abcdefULL;
+
+    layout = base;
+    snapshot = good_snapshot();
+    snapshot.state = 0;
+    expected.require_running = false;
+    expected.state_active = false;
+    CHECK(pgwt_pgbs_validate_snapshot(&layout, &snapshot, &expected) != 0 &&
+          layout.st_state.validation == PGWT_PGBS_FIELD_INVALID &&
+          layout.fallback_mask == PGWT_PGBS_FALLBACK_STATE,
+          "idle-only state agreement never validates a field offset");
+    expected.require_running = true;
+    expected.state_active = true;
+
+    layout = base;
+    snapshot = good_snapshot();
     snapshot.activity_readable = false;
     CHECK(pgwt_pgbs_validate_snapshot(&layout, &snapshot, &expected) != 0 &&
           layout.fallback_mask == PGWT_PGBS_FALLBACK_ACTIVITY_RAW,
           "unreadable activity pointer degrades independently");
+
+    layout = base;
+    snapshot = good_snapshot();
+    snapshot.activity_marker_matched = false;
+    CHECK(pgwt_pgbs_validate_snapshot(&layout, &snapshot, &expected) != 0 &&
+          layout.fallback_mask == PGWT_PGBS_FALLBACK_ACTIVITY_RAW,
+          "readable pointer without the controlled marker is rejected");
 
     layout = base;
     layout.st_query_id.present = false;
@@ -322,12 +353,58 @@ static void test_validation(void)
           "missing field records fallback and never invents an offset");
 }
 
+static void test_warmup_aggregation(void)
+{
+    printf("--- bounded warmup coincidence resistance ---\n");
+    struct PgBackendStatusLayout base;
+    CHECK(pgwt_pgbs_hard_table_lookup(17, PGWT_PGBS_ARCH_X86_64, 8,
+                                      PGWT_PGBS_ABI_SYSV_LP64, &base) == 0,
+          "warmup fixture row");
+    struct PgBackendStatusLayout candidate = base;
+    candidate.validated_pid = 4242;
+    candidate.st_state.validation = PGWT_PGBS_FIELD_VALIDATED;
+    candidate.st_activity_raw.validation = PGWT_PGBS_FIELD_VALIDATED;
+    candidate.st_query_id.validation = PGWT_PGBS_FIELD_VALIDATED;
+
+    struct pgwt_pgbs_warmup_evidence evidence = {0};
+    for (int i = 0; i < 3; i++)
+        pgwt_pgbs_warmup_note(&evidence, &candidate, false, true, 0);
+    CHECK(evidence.observations == 3 && evidence.state_matches == 0 &&
+          evidence.query_matches == 0 &&
+          !pgwt_pgbs_warmup_complete(&evidence, 17),
+          "three idle/zero coincidences do not satisfy warmup");
+
+    memset(&evidence, 0, sizeof(evidence));
+    for (int i = 0; i < 3; i++)
+        pgwt_pgbs_warmup_note(&evidence, &candidate, true, true, 111);
+    struct PgBackendStatusLayout result = base;
+    pgwt_pgbs_warmup_apply(&result, &evidence);
+    CHECK(evidence.state_matches == 3 && evidence.query_matches == 3 &&
+          !evidence.query_id_varied &&
+          result.st_state.validation == PGWT_PGBS_FIELD_VALIDATED &&
+          result.st_query_id.validation == PGWT_PGBS_FIELD_INVALID &&
+          result.fallback_mask == PGWT_PGBS_FALLBACK_QUERY_ID,
+          "three identical nonzero query IDs still need variation");
+
+    memset(&evidence, 0, sizeof(evidence));
+    const uint64_t qids[] = {111, 222, 111};
+    for (size_t i = 0; i < sizeof(qids) / sizeof(qids[0]); i++)
+        pgwt_pgbs_warmup_note(&evidence, &candidate, true, true, qids[i]);
+    result = base;
+    pgwt_pgbs_warmup_apply(&result, &evidence);
+    CHECK(pgwt_pgbs_warmup_complete(&evidence, 17) &&
+          result.validation == PGWT_PGBS_VALIDATION_VALIDATED &&
+          result.fallback_mask == 0,
+          "three positive matches with varying nonzero IDs validate warmup");
+}
+
 int main(void)
 {
     printf("=== test_backend_status_layout ===\n");
     test_dwarf();
     test_hard_table();
     test_validation();
+    test_warmup_aggregation();
     printf("\n%d/%d tests passed\n", ok, run);
     return ok == run ? 0 : 1;
 }

--- a/tests/test_backend_status_layout.c
+++ b/tests/test_backend_status_layout.c
@@ -1,0 +1,333 @@
+/* test_backend_status_layout.c -- Stage 1 layout discovery/validation tests. */
+#define _GNU_SOURCE
+#include "backend_status_layout.h"
+
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+#include <unistd.h>
+
+static int run = 0, ok = 0;
+#define CHECK(c, ...) do { \
+        run++; \
+        if (c) ok++; \
+        else { printf("  FAIL: "); printf(__VA_ARGS__); printf("\n"); } \
+    } while (0)
+
+/* Emit the subset of `readelf --debug-dump=info --wide` used by the parser.
+ * Type references deliberately point forward, exercising typedef/type
+ * following rather than relying on declaration order. */
+static void emit_layout(FILE *fp, unsigned base, int major, unsigned query_off,
+                        int bad_location, int omit_activity, int overlap,
+                        int anonymous_struct, unsigned size_override)
+{
+    int running = major >= 18 ? 3 : 2;
+    int fastpath = major >= 18 ? 5 : 4;
+    int disabled = major >= 18 ? 7 : 6;
+    unsigned struct_size = major >= 18 ? 440 : (major >= 14 ? 432 : 424);
+
+    fprintf(fp, " <1><%x>: Abbrev Number: 1 (DW_TAG_structure_type)\n",
+            base);
+    if (!anonymous_struct)
+        fprintf(fp, "    <%x> DW_AT_name : PgBackendStatus\n", base + 1);
+    fprintf(fp, "    <%x> DW_AT_byte_size : %u\n", base + 2,
+            size_override ? size_override : struct_size);
+#define MEMBER(id_, name_, type_, off_) do { \
+        fprintf(fp, \
+                " <2><%x>: Abbrev Number: 2 (DW_TAG_member)\n" \
+                "    <%x> DW_AT_name : %s\n" \
+                "    <%x> DW_AT_type : <0x%x>\n", \
+                base + (id_), base + (id_) + 1, (name_), \
+                base + (id_) + 2, base + (type_)); \
+        if (bad_location && strcmp((name_), "st_state") == 0) \
+            fprintf(fp, "    <%x> DW_AT_data_member_location: " \
+                    "1 byte block: 23 (DW_OP_plus_uconst: %u)\n", \
+                    base + (id_) + 3, (unsigned)(off_)); \
+        else \
+            fprintf(fp, "    <%x> DW_AT_data_member_location: %u\n", \
+                    base + (id_) + 3, (unsigned)(off_)); \
+    } while (0)
+    MEMBER(0x10, "st_changecount", 0x300, 0);
+    MEMBER(0x20, "st_procpid", 0x300, 4);
+    MEMBER(0x30, "st_databaseid", 0x300, 48);
+    MEMBER(0x40, "st_userid", 0x300, 52);
+    MEMBER(0x50, "st_state", 0x200, overlap ? 52 : 232);
+    if (!omit_activity)
+        MEMBER(0x60, "st_activity_raw", 0x310, 248);
+    if (major >= 14)
+        MEMBER(0x70, "st_query_id", 0x320, query_off);
+#undef MEMBER
+
+    fprintf(fp,
+            " <1><%x>: Abbrev Number: 3 (DW_TAG_enumeration_type)\n"
+            "    <%x> DW_AT_byte_size : 4\n"
+            " <2><%x>: Abbrev Number: 4 (DW_TAG_enumerator)\n"
+            "    <%x> DW_AT_name : STATE_RUNNING\n"
+            "    <%x> DW_AT_const_value : %d\n"
+            " <2><%x>: Abbrev Number: 4 (DW_TAG_enumerator)\n"
+            "    <%x> DW_AT_name : STATE_FASTPATH\n"
+            "    <%x> DW_AT_const_value : %d\n"
+            " <2><%x>: Abbrev Number: 4 (DW_TAG_enumerator)\n"
+            "    <%x> DW_AT_name : STATE_DISABLED\n"
+            "    <%x> DW_AT_const_value : %d\n",
+            base + 0x200, base + 0x201,
+            base + 0x210, base + 0x211, base + 0x212, running,
+            base + 0x220, base + 0x221, base + 0x222, fastpath,
+            base + 0x230, base + 0x231, base + 0x232, disabled);
+    fprintf(fp,
+            " <1><%x>: Abbrev Number: 5 (DW_TAG_base_type)\n"
+            "    <%x> DW_AT_byte_size : 4\n"
+            "    <%x> DW_AT_encoding : 5 (signed)\n"
+            " <1><%x>: Abbrev Number: 6 (DW_TAG_pointer_type)\n"
+            "    <%x> DW_AT_byte_size : 8\n"
+            " <1><%x>: Abbrev Number: 5 (DW_TAG_base_type)\n"
+            "    <%x> DW_AT_byte_size : 8\n"
+            "    <%x> DW_AT_encoding : %d (%s)\n"
+            " <1><%x>: Abbrev Number: 7 (DW_TAG_typedef)\n"
+            "    <%x> DW_AT_name : PgBackendStatus\n"
+            "    <%x> DW_AT_type : <0x%x>\n",
+            base + 0x300, base + 0x301, base + 0x302,
+            base + 0x310, base + 0x311,
+            base + 0x320, base + 0x321, base + 0x322,
+            major >= 18 ? 5 : 7, major >= 18 ? "signed" : "unsigned",
+            base + 0x400, base + 0x401, base + 0x402, base);
+}
+
+static int parse_one(int major, int bad_location, int omit_activity,
+                     int overlap, struct PgBackendStatusLayout *layout)
+{
+    FILE *fp = tmpfile();
+    if (!fp)
+        return -1;
+    emit_layout(fp, 0x1000, major, 424, bad_location, omit_activity, overlap,
+                0, 0);
+    rewind(fp);
+    char why[192];
+    int rc = pgwt_pgbs_parse_dwarf(fp, major, 8, layout, why, sizeof(why));
+    fclose(fp);
+    return rc;
+}
+
+static void test_dwarf(void)
+{
+    printf("--- strict DWARF member resolution ---\n");
+    struct PgBackendStatusLayout layout;
+    CHECK(parse_one(17, 0, 0, 0, &layout) == 0,
+          "constant member offsets accepted");
+    CHECK(layout.source == PGWT_PGBS_SOURCE_DWARF,
+          "accepted layout source is DWARF");
+    CHECK(layout.st_state.offset == 232 && layout.st_state.width == 4,
+          "st_state offset/width resolved");
+    CHECK(layout.st_activity_raw.offset == 248 &&
+          layout.st_activity_raw.width == 8,
+          "st_activity_raw offset/width resolved");
+    CHECK(layout.st_query_id.offset == 424 &&
+          layout.st_query_id.width == 8 && !layout.st_query_id_signed,
+          "PG17 unsigned st_query_id resolved");
+    CHECK(layout.state_running == 2 && layout.state_fastpath == 4 &&
+          layout.state_max == 6, "BackendState constants resolved");
+
+    FILE *typedef_fp = tmpfile();
+    CHECK(typedef_fp != NULL, "anonymous typedef fixture created");
+    if (typedef_fp) {
+        emit_layout(typedef_fp, 0x1000, 17, 424, 0, 0, 0, 1, 0);
+        rewind(typedef_fp);
+        char why[192];
+        CHECK(pgwt_pgbs_parse_dwarf(typedef_fp, 17, 8, &layout,
+                                    why, sizeof(why)) == 0 &&
+              layout.st_query_id.offset == 424,
+              "PgBackendStatus typedef followed to anonymous struct");
+        fclose(typedef_fp);
+    }
+
+    CHECK(parse_one(18, 0, 0, 0, &layout) == 0 &&
+          layout.st_query_id_signed && layout.state_running == 3 &&
+          layout.state_fastpath == 5,
+          "PG18 signed query id and shifted enum resolved");
+    CHECK(parse_one(13, 0, 0, 0, &layout) == 0 &&
+          !layout.st_query_id.present &&
+          layout.st_query_id.validation == PGWT_PGBS_FIELD_ABSENT,
+          "PG13 query id is explicitly ABSENT");
+
+    CHECK(parse_one(17, 1, 0, 0, &layout) != 0,
+          "location expression rejected");
+    CHECK(parse_one(17, 0, 1, 0, &layout) != 0,
+          "missing mandatory member rejected");
+    CHECK(parse_one(17, 0, 0, 1, &layout) != 0,
+          "overlapping members rejected");
+
+    FILE *small_fp = tmpfile();
+    CHECK(small_fp != NULL, "implausible-size fixture created");
+    if (small_fp) {
+        emit_layout(small_fp, 0x1000, 17, 424, 0, 0, 0, 0, 16);
+        rewind(small_fp);
+        char why[192];
+        CHECK(pgwt_pgbs_parse_dwarf(small_fp, 17, 8, &layout,
+                                    why, sizeof(why)) != 0,
+              "implausible struct size rejected");
+        fclose(small_fp);
+    }
+
+    FILE *fp = tmpfile();
+    CHECK(fp != NULL, "ambiguous fixture created");
+    if (fp) {
+        emit_layout(fp, 0x1000, 17, 424, 0, 0, 0, 0, 0);
+        emit_layout(fp, 0x2000, 17, 416, 0, 0, 0, 0, 0);
+        rewind(fp);
+        char why[192];
+        CHECK(pgwt_pgbs_parse_dwarf(fp, 17, 8, &layout,
+                                    why, sizeof(why)) != 0 &&
+              strstr(why, "ambiguous") != NULL,
+              "conflicting duplicate structs rejected as ambiguous");
+        fclose(fp);
+    }
+}
+
+static void test_hard_table(void)
+{
+    printf("--- per-major/architecture hard table ---\n");
+    const enum pgwt_pgbs_arch arches[] = {
+        PGWT_PGBS_ARCH_X86_64, PGWT_PGBS_ARCH_ARM64
+    };
+    const enum pgwt_pgbs_abi abis[] = {
+        PGWT_PGBS_ABI_SYSV_LP64, PGWT_PGBS_ABI_AAPCS64_LP64
+    };
+    for (size_t a = 0; a < 2; a++) {
+        for (int major = 13; major <= 18; major++) {
+            struct PgBackendStatusLayout layout;
+            CHECK(pgwt_pgbs_hard_table_lookup(major, arches[a], 8, abis[a],
+                                               &layout) == 0,
+                  "PG%d %s row exists", major, pgwt_pgbs_arch_name(arches[a]));
+            CHECK(layout.st_changecount.offset == 0 &&
+                  layout.st_changecount.width == 4 &&
+                  layout.st_procpid.offset == 4 &&
+                  layout.st_procpid.width == 4 &&
+                  layout.st_databaseid.offset == 48 &&
+                  layout.st_databaseid.width == 4 &&
+                  layout.st_userid.offset == 52 &&
+                  layout.st_userid.width == 4 &&
+                  layout.st_state.offset == 232 &&
+                  layout.st_state.width == 4 &&
+                  layout.st_activity_raw.offset == 248 &&
+                  layout.st_activity_raw.width == 8,
+                  "PG%d %s common fields match derived layout",
+                  major, pgwt_pgbs_arch_name(arches[a]));
+            CHECK((major == 13 && !layout.st_query_id.present) ||
+                  (major >= 14 && layout.st_query_id.present &&
+                   layout.st_query_id.offset == 424 &&
+                   layout.st_query_id.width == 8),
+                  "PG%d %s query-id presence/shape", major,
+                  pgwt_pgbs_arch_name(arches[a]));
+            CHECK(layout.st_query_id_signed == (major >= 18),
+                  "PG%d %s query-id signedness", major,
+                  pgwt_pgbs_arch_name(arches[a]));
+            CHECK(layout.state_running == (major >= 18 ? 3 : 2) &&
+                  layout.state_fastpath == (major >= 18 ? 5 : 4),
+                  "PG%d %s state enum", major,
+                  pgwt_pgbs_arch_name(arches[a]));
+        }
+    }
+    struct PgBackendStatusLayout layout;
+    CHECK(pgwt_pgbs_hard_table_lookup(19, PGWT_PGBS_ARCH_X86_64, 8,
+                                      PGWT_PGBS_ABI_SYSV_LP64, &layout) != 0,
+          "unknown major has no row");
+    CHECK(pgwt_pgbs_hard_table_lookup(17, PGWT_PGBS_ARCH_X86_64, 4,
+                                      PGWT_PGBS_ABI_SYSV_LP64, &layout) != 0,
+          "wrong pointer width has no row");
+    CHECK(pgwt_pgbs_hard_table_lookup(17, PGWT_PGBS_ARCH_ARM64, 8,
+                                      PGWT_PGBS_ABI_SYSV_LP64, &layout) != 0,
+          "wrong ABI has no row");
+}
+
+static struct pgwt_pgbs_snapshot good_snapshot(void)
+{
+    return (struct pgwt_pgbs_snapshot) {
+        .changecount_before = 8,
+        .changecount_after = 8,
+        .procpid = 4242,
+        .databaseid = 16384,
+        .userid = 10,
+        .state = 2,
+        .activity_raw = 0x100000,
+        .query_id = 0xf123456789abcdefULL,
+        .read_mask = PGWT_PGBS_READ_CHANGECOUNT | PGWT_PGBS_READ_PROCPID |
+                     PGWT_PGBS_READ_DATABASEID | PGWT_PGBS_READ_USERID |
+                     PGWT_PGBS_READ_STATE | PGWT_PGBS_READ_ACTIVITY |
+                     PGWT_PGBS_READ_QUERY_ID,
+        .activity_readable = true,
+    };
+}
+
+static void test_validation(void)
+{
+    printf("--- coherency, shadow comparison and degrade paths ---\n");
+    struct PgBackendStatusLayout base;
+    CHECK(pgwt_pgbs_hard_table_lookup(17, PGWT_PGBS_ARCH_X86_64, 8,
+                                      PGWT_PGBS_ABI_SYSV_LP64, &base) == 0,
+          "validation fixture row");
+    struct pgwt_pgbs_expected expected = {
+        .pid = 4242, .databaseid = 16384, .userid = 10,
+        .require_running = true, .state_shadow_available = true,
+        .state_active = true, .query_id_available = true,
+        .query_id = 0xf123456789abcdefULL,
+    };
+    struct pgwt_pgbs_snapshot snapshot = good_snapshot();
+    struct PgBackendStatusLayout layout = base;
+    CHECK(pgwt_pgbs_validate_snapshot(&layout, &snapshot, &expected) == 0,
+          "stable even coherent snapshot validates");
+    CHECK(layout.validation == PGWT_PGBS_VALIDATION_VALIDATED &&
+          layout.fallback_mask == 0 && layout.validated_pid == 4242,
+          "fully validated descriptor has no fallback");
+
+    layout = base;
+    snapshot = good_snapshot();
+    snapshot.changecount_after = 9;
+    CHECK(pgwt_pgbs_validate_snapshot(&layout, &snapshot, &expected) != 0 &&
+          layout.fallback_mask ==
+              (PGWT_PGBS_FALLBACK_STATE |
+               PGWT_PGBS_FALLBACK_ACTIVITY_RAW |
+               PGWT_PGBS_FALLBACK_QUERY_ID),
+          "changed/odd changecount rejects dependent fields");
+
+    layout = base;
+    snapshot = good_snapshot();
+    snapshot.state = 99;
+    CHECK(pgwt_pgbs_validate_snapshot(&layout, &snapshot, &expected) != 0 &&
+          layout.fallback_mask == PGWT_PGBS_FALLBACK_STATE &&
+          layout.st_activity_raw.validation == PGWT_PGBS_FIELD_VALIDATED &&
+          layout.st_query_id.validation == PGWT_PGBS_FIELD_VALIDATED,
+          "invalid state degrades only the activity-state consumer");
+
+    layout = base;
+    snapshot = good_snapshot();
+    snapshot.query_id++;
+    CHECK(pgwt_pgbs_validate_snapshot(&layout, &snapshot, &expected) != 0 &&
+          layout.fallback_mask == PGWT_PGBS_FALLBACK_QUERY_ID,
+          "query shadow mismatch keeps query-id uprobe only");
+
+    layout = base;
+    snapshot = good_snapshot();
+    snapshot.activity_readable = false;
+    CHECK(pgwt_pgbs_validate_snapshot(&layout, &snapshot, &expected) != 0 &&
+          layout.fallback_mask == PGWT_PGBS_FALLBACK_ACTIVITY_RAW,
+          "unreadable activity pointer degrades independently");
+
+    layout = base;
+    layout.st_query_id.present = false;
+    layout.st_query_id.offset = 0;
+    snapshot = good_snapshot();
+    CHECK(pgwt_pgbs_validate_snapshot(&layout, &snapshot, &expected) != 0 &&
+          layout.fallback_mask == PGWT_PGBS_FALLBACK_QUERY_ID &&
+          layout.st_query_id.offset == 0,
+          "missing field records fallback and never invents an offset");
+}
+
+int main(void)
+{
+    printf("=== test_backend_status_layout ===\n");
+    test_dwarf();
+    test_hard_table();
+    test_validation();
+    printf("\n%d/%d tests passed\n", ok, run);
+    return ok == run ? 0 : 1;
+}

--- a/tests/test_backend_status_layout.c
+++ b/tests/test_backend_status_layout.c
@@ -4,7 +4,9 @@
 
 #include <stdio.h>
 #include <stdint.h>
+#include <signal.h>
 #include <string.h>
+#include <sys/wait.h>
 #include <unistd.h>
 
 static int run = 0, ok = 0;
@@ -368,7 +370,8 @@ static void test_warmup_aggregation(void)
 
     struct pgwt_pgbs_warmup_evidence evidence = {0};
     for (int i = 0; i < 3; i++)
-        pgwt_pgbs_warmup_note(&evidence, &candidate, false, true, 0);
+        pgwt_pgbs_warmup_note(&evidence, &candidate, false, true, 0,
+                              true, 0);
     CHECK(evidence.observations == 3 && evidence.state_matches == 0 &&
           evidence.query_matches == 0 &&
           !pgwt_pgbs_warmup_complete(&evidence, 17),
@@ -376,26 +379,99 @@ static void test_warmup_aggregation(void)
 
     memset(&evidence, 0, sizeof(evidence));
     for (int i = 0; i < 3; i++)
-        pgwt_pgbs_warmup_note(&evidence, &candidate, true, true, 111);
+        pgwt_pgbs_warmup_note(&evidence, &candidate, true, true, 2,
+                              true, 111);
     struct PgBackendStatusLayout result = base;
     pgwt_pgbs_warmup_apply(&result, &evidence);
     CHECK(evidence.state_matches == 3 && evidence.query_matches == 3 &&
-          !evidence.query_id_varied &&
-          result.st_state.validation == PGWT_PGBS_FIELD_VALIDATED &&
+          !evidence.state_varied && !evidence.query_id_varied &&
+          result.st_state.validation == PGWT_PGBS_FIELD_INVALID &&
           result.st_query_id.validation == PGWT_PGBS_FIELD_INVALID &&
-          result.fallback_mask == PGWT_PGBS_FALLBACK_QUERY_ID,
-          "three identical nonzero query IDs still need variation");
+          result.fallback_mask == (PGWT_PGBS_FALLBACK_STATE |
+                                   PGWT_PGBS_FALLBACK_QUERY_ID),
+          "constant running state and identical query ID remain untrusted");
 
     memset(&evidence, 0, sizeof(evidence));
     const uint64_t qids[] = {111, 222, 111};
+    pgwt_pgbs_warmup_note(&evidence, &candidate, false, true, 0,
+                          false, 0);
     for (size_t i = 0; i < sizeof(qids) / sizeof(qids[0]); i++)
-        pgwt_pgbs_warmup_note(&evidence, &candidate, true, true, qids[i]);
+        pgwt_pgbs_warmup_note(&evidence, &candidate, true, true, 2,
+                              true, qids[i]);
     result = base;
     pgwt_pgbs_warmup_apply(&result, &evidence);
-    CHECK(pgwt_pgbs_warmup_complete(&evidence, 17) &&
+    CHECK(evidence.state_varied &&
+          pgwt_pgbs_warmup_complete(&evidence, 17) &&
           result.validation == PGWT_PGBS_VALIDATION_VALIDATED &&
           result.fallback_mask == 0,
-          "three positive matches with varying nonzero IDs validate warmup");
+          "state transition plus three marker/query matches validate warmup");
+
+    memset(&evidence, 0, sizeof(evidence));
+    struct PgBackendStatusLayout markerless = candidate;
+    markerless.st_activity_raw.validation = PGWT_PGBS_FIELD_INVALID;
+    pgwt_pgbs_warmup_note(&evidence, &markerless, false, true, 0,
+                          false, 0);
+    for (size_t i = 0; i < sizeof(qids) / sizeof(qids[0]); i++)
+        pgwt_pgbs_warmup_note(&evidence, &markerless, true, true, 2,
+                              true, qids[i]);
+    result = base;
+    pgwt_pgbs_warmup_apply(&result, &evidence);
+    CHECK(evidence.state_varied && evidence.activity_matches == 0 &&
+          result.st_activity_raw.validation == PGWT_PGBS_FIELD_INVALID &&
+          result.fallback_mask == PGWT_PGBS_FALLBACK_ACTIVITY_RAW,
+          "warmup never blesses activity without content-marker matches");
+}
+
+static void test_fail_safe_and_pid_exclusion(void)
+{
+    printf("--- fail-safe policy, PID exclusion and retirement identity ---\n");
+    struct PgBackendStatusLayout layout;
+    CHECK(pgwt_pgbs_hard_table_lookup(17, PGWT_PGBS_ARCH_X86_64, 8,
+                                      PGWT_PGBS_ABI_SYSV_LP64, &layout) == 0,
+          "fail-safe fixture row");
+    struct pgwt_pgbs_exclusion_set exclusions = {0};
+    pid_t unknown_identity = (pid_t)2147483647;
+    CHECK(pgwt_pgbs_exclusion_add(&exclusions, unknown_identity) == 0 &&
+          pgwt_pgbs_exclusion_contains(&exclusions, unknown_identity),
+          "missing /proc identity remains conservatively excluded");
+    struct pgwt_pgbs_exclusion_set full = {
+        .count = PGWT_PGBS_MAX_EXCLUDED_PIDS,
+    };
+    CHECK(pgwt_pgbs_exclusion_add(&full, unknown_identity) != 0,
+          "full exclusion set refuses an unrecorded validation PID");
+    bool capture_proceeded = false;
+    pgwt_pgbs_validate_runtime(&layout, 0, 0, NULL, &exclusions);
+    capture_proceeded = true;
+    CHECK(capture_proceeded &&
+          layout.validation == PGWT_PGBS_VALIDATION_DEGRADED &&
+          layout.fallback_mask == (PGWT_PGBS_FALLBACK_STATE |
+                                   PGWT_PGBS_FALLBACK_ACTIVITY_RAW |
+                                   PGWT_PGBS_FALLBACK_QUERY_ID),
+          "validation failure degrades layout and has no capture-abort result");
+
+    pid_t child = fork();
+    CHECK(child >= 0, "retirement fixture fork");
+    if (child == 0) {
+        for (;;)
+            pause();
+    }
+    if (child > 0) {
+        uint64_t start_time = 0;
+        CHECK(pgwt_pgbs_pid_start_time(child, &start_time) == 0 &&
+              start_time != 0,
+              "reads /proc start time for backend identity");
+        CHECK(pgwt_pgbs_exclusion_add(&exclusions, child) == 0 &&
+              pgwt_pgbs_exclusion_contains(&exclusions, child),
+              "live validation PID is excluded from capture enrollment");
+        CHECK(pgwt_pgbs_pid_is_original(child, start_time) &&
+              !pgwt_pgbs_pid_is_original(child, start_time + 1),
+              "retirement predicate distinguishes a recycled PID identity");
+        kill(child, SIGTERM);
+        (void)waitpid(child, NULL, 0);
+        CHECK(!pgwt_pgbs_pid_is_original(child, start_time) &&
+              !pgwt_pgbs_exclusion_contains(&exclusions, child),
+              "retired validation identity no longer excludes a future PID");
+    }
 }
 
 int main(void)
@@ -405,6 +481,7 @@ int main(void)
     test_hard_table();
     test_validation();
     test_warmup_aggregation();
+    test_fail_safe_and_pid_exclusion();
     printf("\n%d/%d tests passed\n", ok, run);
     return ok == run ? 0 : 1;
 }

--- a/tests/test_discovery.c
+++ b/tests/test_discovery.c
@@ -23,9 +23,11 @@
  * against toolchain defaults silently overriding the -pie/-no-pie flags).
  */
 #include "discovery.h"
+#include "daemon.h"
 
 #include <stdio.h>
 #include <stdint.h>
+#include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
 #include <libgen.h>
@@ -41,6 +43,11 @@ static int run = 0, ok = 0;
 /* A global with external linkage in .data: the self-resolution target.
  * volatile + non-zero init keep it present and unmergeable. */
 volatile uint32_t pgwt_test_fixture_symbol = 0xC0FFEE42u;
+
+/* pgwt_discover() resolves these globals from a PG17+ postmaster.  They make
+ * this test binary a sufficient discovery fixture without a live database. */
+uint32_t *my_wait_event_info;
+void *MyBEEntry;
 
 /* Locate tests/fixtures/ relative to this binary (cwd-independent). */
 static void fixture_path(char *out, size_t outsz, const char *name)
@@ -72,8 +79,44 @@ static int elf_type(const char *path)
     return eh.e_type;
 }
 
-int main(void)
+static void test_validation_exclusions_reset_per_discovery_cycle(void)
 {
+    struct pgwt_daemon *d = calloc(1, sizeof(*d));
+    pid_t reused_pid = (pid_t)2147483647;
+
+    CHECK(d != NULL, "allocate discovery fixture");
+    if (!d)
+        return;
+    CHECK(pgwt_pgbs_exclusion_add(&d->pgbs_validation_exclusions,
+                                  reused_pid) == 0 &&
+          d->pgbs_validation_exclusions.count == 1 &&
+          d->pgbs_validation_exclusions.entries[0].start_time == 0 &&
+          pgwt_pgbs_exclusion_contains(&d->pgbs_validation_exclusions,
+                                       reused_pid),
+          "prior discovery cycle retains a conservative numeric-PID exclusion");
+
+    d->postmaster_pid = getpid();
+    CHECK(setenv("PGWT_TEST_PGBS_VALIDATION_FAIL", "1", 1) == 0,
+          "set forced validation failure hook");
+    int rc = pgwt_discover(d);
+    CHECK(unsetenv("PGWT_TEST_PGBS_VALIDATION_FAIL") == 0,
+          "clear forced validation failure hook");
+
+    CHECK(rc == 0 && d->pgbs_validation_exclusions.count == 0 &&
+          !pgwt_pgbs_exclusion_contains(&d->pgbs_validation_exclusions,
+                                        reused_pid),
+          "new discovery cycle clears stale numeric-PID exclusions before validation");
+    free(d->pg_binary_saved);
+    free(d);
+}
+
+int main(int argc, char **argv)
+{
+    if (argc == 2 && strcmp(argv[1], "--version") == 0) {
+        puts("postgres (PostgreSQL) 17.0");
+        return 0;
+    }
+
     printf("=== test_discovery (%s build) ===\n",
            PGWT_TEST_EXPECT_PIE ? "PIE" : "non-PIE");
 
@@ -251,6 +294,9 @@ int main(void)
             fclose(ef);
         }
     }
+
+    /* A daemon re-enters pgwt_discover() after each PostgreSQL restart. */
+    test_validation_exclusions_reset_per_discovery_cycle();
 
     printf("\n%d/%d tests passed\n", ok, run);
     return (ok == run) ? 0 : 1;

--- a/tests/unit_tests.list
+++ b/tests/unit_tests.list
@@ -17,6 +17,7 @@ test_sampler
 test_anomaly
 test_escalation_budget
 test_effective_cores
+test_backend_status_layout
 test_coop
 test_concurrent_rw
 test_durability


### PR DESCRIPTION
## Summary

- add a PgBackendStatusLayout descriptor with strict DWARF discovery and exact PG13-18 x86_64/ARM64 hard-table fallback
- validate coherent live snapshots against a short controlled backend, including PostgreSQL 14+ query-id shadow comparison; retain per-field uprobe fallbacks on any failure
- report layout source, validation, fallback fields, and a fallback counter without wiring the descriptor into the sampler
- add focused parser, table, coherency, and degrade-path unit coverage

## Hetzner validation

- make BPFTOOL=/root/pgwt/build/bpftool/src/bpftool: passed
- make -C tests check: passed (20 unit binaries)
- new layout tests: 88/88 passed
- PG13: state 232/4, activity_raw 248/8, query_id ABSENT; validated
- PG17: state 232/4, activity_raw 248/8, query_id 424/8 unsigned; validated
- PG18: state 232/4, activity_raw 248/8, query_id 424/8 signed; validated
- ARM64 rows are present and unit-tested; no ARM64 host was available for live validation

Stage 1 is shadow-only: existing sampler offsets, uprobes, BPF rodata, and output paths are unchanged.