### PR TITLE
Use at-tick sampled query attribution

### DIFF
--- a/docs/ROADMAP_AND_STATUS.md
+++ b/docs/ROADMAP_AND_STATUS.md
@@ -84,10 +84,16 @@
 > <0.5% goal). PG13 (no in-core query_id, gate measured ~15–23%) uses
 > `st_activity_raw` + a synthetic normalized-text grouping key; sampled query TEXT
 > becomes pgss-normalized (accepted). **Progress:** stage 1 (offset discovery +
-> fail-safe validation) **merged (#83)**; stages 2–5 (at-tick reader/gate swap →
-> tiered attach lifecycle → PG13 text path → permanent sampled-overhead A/B gate)
-> in progress. The "≈0%" claims elsewhere in this doc are **stale** pending those
-> stages — see this note.
+> fail-safe validation) **merged (#83)**; stage 2 (at-tick reader + authoritative
+> gate swap) is implemented; stages 3–5 (tiered attach lifecycle → PG13 text
+> path → permanent sampled-overhead A/B gate) remain. Stage 2 deliberately
+> defines idle attribution as `query_id=0`:
+> `cmd_open` is true only for `STATE_RUNNING`/`STATE_FASTPATH`, and only an open
+> command exposes `st_query_id`. This differs from the old state-map path's
+> retained last query id for an idle backend; idle `Client:ClientRead` samples
+> are excluded from AAS/DB Time and are no longer assigned to a completed query.
+> The "≈0%" claims elsewhere in this doc are **stale** pending those stages — see
+> this note.
 
 **Real feature gaps (defined, never built):**
 - **PostgreSQL 14 / 15 / 16** — only PG13 shipped; README says "14-16 not yet".

--- a/src/backend_status_layout.c
+++ b/src/backend_status_layout.c
@@ -1121,6 +1121,7 @@ int pgwt_pgbs_derive_sampled_attr(
     out->state = snapshot->state;
     out->cmd_open = snapshot->state == (uint32_t)layout->state_running ||
                     snapshot->state == (uint32_t)layout->state_fastpath;
+    /* Idle is query-less by design: drilldowns assign it to SESSION, not the finished query. */
     out->query_id = out->cmd_open ? snapshot->query_id : 0;
     return 0;
 }

--- a/src/backend_status_layout.c
+++ b/src/backend_status_layout.c
@@ -1,8 +1,8 @@
-/* backend_status_layout.c -- strict PgBackendStatus layout discovery.
+/* backend_status_layout.c -- strict PgBackendStatus layout discovery and
+ * coherent sampled-attribution reads.
  *
- * This is Stage 1 shadow machinery.  Nothing in the BPF program, sampler or
- * query attribution path reads this descriptor.  A candidate layout is useful
- * only after both structural checks and a live coherent read accept it. */
+ * A candidate layout becomes authoritative for PG14+ sampled attribution only
+ * after both structural checks and a live coherent read accept it. */
 #define _GNU_SOURCE
 #include "backend_status_layout.h"
 #include "spawn.h"
@@ -986,6 +986,7 @@ static int read_field_value(int fd, uint64_t base,
 
 static int read_snapshot_fd(int fd, uint64_t base,
                             const struct PgBackendStatusLayout *layout,
+                            uint32_t wanted_mask,
                             struct pgwt_pgbs_snapshot *snapshot,
                             char *activity, size_t activity_sz)
 {
@@ -1008,12 +1009,18 @@ static int read_snapshot_fd(int fd, uint64_t base,
                 snapshot->read_mask |= (bit_); \
             } \
         } while (0)
-        READ_VALUE(st_procpid, procpid, PGWT_PGBS_READ_PROCPID);
-        READ_VALUE(st_databaseid, databaseid, PGWT_PGBS_READ_DATABASEID);
-        READ_VALUE(st_userid, userid, PGWT_PGBS_READ_USERID);
-        READ_VALUE(st_state, state, PGWT_PGBS_READ_STATE);
-        READ_VALUE(st_activity_raw, activity_raw, PGWT_PGBS_READ_ACTIVITY);
-        if (layout->st_query_id.present)
+        if (wanted_mask & PGWT_PGBS_READ_PROCPID)
+            READ_VALUE(st_procpid, procpid, PGWT_PGBS_READ_PROCPID);
+        if (wanted_mask & PGWT_PGBS_READ_DATABASEID)
+            READ_VALUE(st_databaseid, databaseid, PGWT_PGBS_READ_DATABASEID);
+        if (wanted_mask & PGWT_PGBS_READ_USERID)
+            READ_VALUE(st_userid, userid, PGWT_PGBS_READ_USERID);
+        if (wanted_mask & PGWT_PGBS_READ_STATE)
+            READ_VALUE(st_state, state, PGWT_PGBS_READ_STATE);
+        if (wanted_mask & PGWT_PGBS_READ_ACTIVITY)
+            READ_VALUE(st_activity_raw, activity_raw, PGWT_PGBS_READ_ACTIVITY);
+        if ((wanted_mask & PGWT_PGBS_READ_QUERY_ID) &&
+            layout->st_query_id.present)
             READ_VALUE(st_query_id, query_id, PGWT_PGBS_READ_QUERY_ID);
 #undef READ_VALUE
 
@@ -1024,7 +1031,8 @@ static int read_snapshot_fd(int fd, uint64_t base,
             (snapshot->changecount_after & 1u))
             continue;
 
-        if (snapshot->activity_raw && activity && activity_sz) {
+        if ((wanted_mask & PGWT_PGBS_READ_ACTIVITY) &&
+            snapshot->activity_raw && activity && activity_sz) {
             ssize_t n = pread(fd, activity, activity_sz - 1,
                               (off_t)snapshot->activity_raw);
             if (n > 0) {
@@ -1051,7 +1059,7 @@ static int candidate_ok(int fd, uint64_t base,
                         struct pgwt_pgbs_snapshot *snapshot)
 {
     char activity[512];
-    if (read_snapshot_fd(fd, base, layout, snapshot,
+    if (read_snapshot_fd(fd, base, layout, UINT32_MAX, snapshot,
                          activity, sizeof(activity)) != 0)
         return 0;
     snapshot->activity_marker_matched =
@@ -1071,6 +1079,83 @@ static int candidate_ok(int fd, uint64_t base,
             return 0;
     }
     return 1;
+}
+
+/* ── Sampled-tier coherent attribution (Stage 2) ──────────── */
+
+bool pgwt_pgbs_sampled_attr_enabled(
+    const struct PgBackendStatusLayout *layout)
+{
+    return layout && layout->major >= 14 &&
+           layout->validation == PGWT_PGBS_VALIDATION_VALIDATED &&
+           layout->st_changecount.validation == PGWT_PGBS_FIELD_VALIDATED &&
+           layout->st_procpid.validation == PGWT_PGBS_FIELD_VALIDATED &&
+           layout->st_state.validation == PGWT_PGBS_FIELD_VALIDATED &&
+           layout->st_query_id.validation == PGWT_PGBS_FIELD_VALIDATED &&
+           layout->st_query_id.present;
+}
+
+int pgwt_pgbs_derive_sampled_attr(
+    const struct PgBackendStatusLayout *layout,
+    const struct pgwt_pgbs_snapshot *snapshot, pid_t expected_pid,
+    struct pgwt_pgbs_sampled_attr *out)
+{
+    if (!out)
+        return -1;
+    memset(out, 0, sizeof(*out));
+    if (!pgwt_pgbs_sampled_attr_enabled(layout) || !snapshot ||
+        expected_pid <= 0)
+        return -1;
+
+    const uint32_t required = PGWT_PGBS_READ_CHANGECOUNT |
+                              PGWT_PGBS_READ_PROCPID |
+                              PGWT_PGBS_READ_STATE |
+                              PGWT_PGBS_READ_QUERY_ID;
+    if ((snapshot->read_mask & required) != required ||
+        snapshot->changecount_before != snapshot->changecount_after ||
+        (snapshot->changecount_after & 1u) != 0 ||
+        snapshot->procpid != (uint32_t)expected_pid ||
+        snapshot->state > (uint32_t)layout->state_max)
+        return -1;
+
+    out->state = snapshot->state;
+    out->cmd_open = snapshot->state == (uint32_t)layout->state_running ||
+                    snapshot->state == (uint32_t)layout->state_fastpath;
+    out->query_id = out->cmd_open ? snapshot->query_id : 0;
+    return 0;
+}
+
+int pgwt_pgbs_read_sampled_attr(
+    pid_t backend_pid, uint64_t my_be_entry_addr,
+    const struct PgBackendStatusLayout *layout,
+    struct pgwt_pgbs_sampled_attr *out)
+{
+    if (!out)
+        return -1;
+    memset(out, 0, sizeof(*out));
+    if (!pgwt_pgbs_sampled_attr_enabled(layout) || backend_pid <= 0 ||
+        my_be_entry_addr == 0)
+        return -1;
+
+    int mem_fd = open_mem(backend_pid);
+    if (mem_fd < 0)
+        return -1;
+
+    uint64_t base = 0;
+    int rc = -1;
+    if (pread_exact(mem_fd, &base, sizeof(base), my_be_entry_addr) >= 0 &&
+        base != 0) {
+        struct pgwt_pgbs_snapshot snapshot;
+        const uint32_t wanted = PGWT_PGBS_READ_PROCPID |
+                                PGWT_PGBS_READ_STATE |
+                                PGWT_PGBS_READ_QUERY_ID;
+        if (read_snapshot_fd(mem_fd, base, layout, wanted, &snapshot,
+                             NULL, 0) == 0)
+            rc = pgwt_pgbs_derive_sampled_attr(layout, &snapshot,
+                                               backend_pid, out);
+    }
+    close(mem_fd);
+    return rc;
 }
 
 static uint64_t scan_shared_for_entry(pid_t pid,
@@ -2070,7 +2155,12 @@ void pgwt_pgbs_log(const struct PgBackendStatusLayout *layout)
         fprintf(stderr, " (fallback_fields=%u; no offset guessed)\n",
                 pgwt_pgbs_fallback_count(layout));
     }
-    fprintf(stderr,
-            "INFO: PgBackendStatus layout is shadow-only (Stage 1); "
-            "sampler and uprobe paths are unchanged\n");
+    if (pgwt_pgbs_sampled_attr_enabled(layout))
+        fprintf(stderr,
+                "INFO: PgBackendStatus st_state/st_query_id are authoritative "
+                "for sampled attribution; idle query_id is normalized to 0\n");
+    else
+        fprintf(stderr,
+                "INFO: sampled attribution remains on the uprobe state-map "
+                "fallback\n");
 }

--- a/src/backend_status_layout.h
+++ b/src/backend_status_layout.h
@@ -1,7 +1,4 @@
-/* backend_status_layout.h -- PgBackendStatus discovery and validation.
- *
- * Stage 1 is deliberately observational: this descriptor is discovered,
- * validated and reported, but no sampler or BPF path consumes it yet. */
+/* backend_status_layout.h -- PgBackendStatus discovery and validation. */
 #ifndef PGWT_BACKEND_STATUS_LAYOUT_H
 #define PGWT_BACKEND_STATUS_LAYOUT_H
 
@@ -110,6 +107,15 @@ struct pgwt_pgbs_snapshot {
     bool activity_marker_matched;
 };
 
+/* The PG14+ sampled-tier fields derived from one coherent PgBackendStatus
+ * snapshot.  state is retained for shadow diagnostics; query_id is already
+ * normalized to zero outside RUNNING/FASTPATH. */
+struct pgwt_pgbs_sampled_attr {
+    uint64_t query_id;
+    uint32_t state;
+    bool cmd_open;
+};
+
 struct pgwt_pgbs_expected {
     pid_t pid;
     uint32_t databaseid; /* 0 means plausibility check only */
@@ -183,6 +189,23 @@ int pgwt_pgbs_discover(const char *pg_binary, int pg_major,
 int pgwt_pgbs_validate_snapshot(struct PgBackendStatusLayout *layout,
                                 const struct pgwt_pgbs_snapshot *snapshot,
                                 const struct pgwt_pgbs_expected *expected);
+
+/* Stage 2 sampled attribution.  The path is available only for PG14+ after
+ * whole-layout validation and per-field validation of every field used by
+ * the coherent read.  The pure derivation helper and live reader both zero
+ * `out` before validation, so an incoherent/short/identity-mismatched read can
+ * never return command state from a prior tick. */
+bool pgwt_pgbs_sampled_attr_enabled(
+    const struct PgBackendStatusLayout *layout);
+int pgwt_pgbs_derive_sampled_attr(
+    const struct PgBackendStatusLayout *layout,
+    const struct pgwt_pgbs_snapshot *snapshot, pid_t expected_pid,
+    struct pgwt_pgbs_sampled_attr *out);
+int pgwt_pgbs_read_sampled_attr(
+    pid_t backend_pid, uint64_t my_be_entry_addr,
+    const struct PgBackendStatusLayout *layout,
+    struct pgwt_pgbs_sampled_attr *out);
+
 void pgwt_pgbs_validate_runtime(struct PgBackendStatusLayout *layout,
                                 pid_t postmaster_pid,
                                 uint64_t my_be_entry_addr,

--- a/src/control.c
+++ b/src/control.c
@@ -118,6 +118,11 @@ static cJSON *build_status(const struct pgwt_daemon *d)
     cJSON_AddNumberToObject(root, "pgbackend_layout_fallback_fields",
                             pgwt_pgbs_fallback_count(
                                 &d->backend_status_layout));
+    cJSON_AddStringToObject(root, "sampled_attr_source",
+                            pgwt_pgbs_sampled_attr_enabled(
+                                &d->backend_status_layout)
+                                ? "pgbackend_status"
+                                : "uprobe_state_map");
 
     /* Current capture tier and escalation state (A4). "tier" is what is being
      * captured right now: in tiered mode it flips between "sampled" (always-on
@@ -208,6 +213,20 @@ static cJSON *build_metrics(const struct pgwt_daemon *d)
                      ctr->sample_read_faults_total);
     cjson_add_uint64(root, "pgbackend_layout_fallbacks_total",
                      ctr->pgbackend_layout_fallbacks_total);
+    cjson_add_uint64(root, "sampled_attr_tick_read_failures_total",
+                     ctr->sampled_attr_tick_read_failures_total);
+    cjson_add_uint64(root, "sampled_attr_shadow_total",
+                     ctr->sampled_attr_shadow_total);
+    cjson_add_uint64(root, "sampled_attr_shadow_mismatch_total",
+                     ctr->sampled_attr_shadow_mismatch_total);
+    cjson_add_uint64(root, "sampled_attr_shadow_active_total",
+                     ctr->sampled_attr_shadow_active_total);
+    cjson_add_uint64(root, "sampled_attr_shadow_active_mismatch_total",
+                     ctr->sampled_attr_shadow_active_mismatch_total);
+    cjson_add_uint64(root, "sampled_attr_shadow_cmd_open_mismatch_total",
+                     ctr->sampled_attr_shadow_cmd_open_mismatch_total);
+    cjson_add_uint64(root, "sampled_attr_shadow_query_id_mismatch_total",
+                     ctr->sampled_attr_shadow_query_id_mismatch_total);
     cjson_add_uint64(root, "sample_read_failures_total",
                      pm.sample_read_failures_total);
     cJSON_AddNumberToObject(root, "sample_read_targets",

--- a/src/daemon.h
+++ b/src/daemon.h
@@ -43,6 +43,15 @@ struct pgwt_counters {
     uint64_t sample_read_faults_total; /* process_vm_readv partial/EFAULT fallbacks */
     uint64_t pgbackend_layout_fallbacks_total; /* fields rejected by Stage 1
                                                  * layout validation */
+    uint64_t sampled_attr_tick_read_failures_total; /* validated-layout
+                                                      * coherent reads dropped */
+    uint64_t sampled_attr_shadow_total; /* coherent tick/map pairs compared */
+    uint64_t sampled_attr_shadow_mismatch_total; /* effective tuples differing */
+    uint64_t sampled_attr_shadow_active_total; /* at-tick cmd_open comparisons */
+    uint64_t sampled_attr_shadow_active_mismatch_total; /* active st_query_id !=
+                                                          * raw last_query_id */
+    uint64_t sampled_attr_shadow_cmd_open_mismatch_total;
+    uint64_t sampled_attr_shadow_query_id_mismatch_total;
 
     /* Capture hardening (T4). All of these mean "something the operator
      * must know about is happening" — each is paired with a loud log. */

--- a/src/sampler.c
+++ b/src/sampler.c
@@ -240,6 +240,60 @@ int pgwt_cpu_sample_recordable(enum pgwt_backend_type bt, int cmd_open)
     }
 }
 
+enum pgwt_sampled_attr_source pgwt_sampler_select_attr(
+    int tick_source_enabled, int tick_read_ok,
+    const struct pgwt_sampled_attr_value *tick,
+    const struct pgwt_sampled_attr_value *uprobe,
+    struct pgwt_sample_target *target)
+{
+    if (!target)
+        return PGWT_SAMPLED_ATTR_DROP;
+
+    target->query_id = 0;
+    target->cmd_open = 0;
+    if (!tick_source_enabled) {
+        if (uprobe) {
+            target->query_id = uprobe->query_id;
+            target->cmd_open = uprobe->cmd_open;
+        }
+        return PGWT_SAMPLED_ATTR_UPROBE;
+    }
+    if (!tick_read_ok || !tick)
+        return PGWT_SAMPLED_ATTR_DROP;
+
+    target->query_id = tick->query_id;
+    target->cmd_open = tick->cmd_open;
+    return PGWT_SAMPLED_ATTR_TICK;
+}
+
+unsigned pgwt_sampled_attr_compare(
+    const struct pgwt_sampled_attr_value *tick,
+    const struct pgwt_sampled_attr_value *uprobe)
+{
+    if (!tick || !uprobe)
+        return PGWT_SAMPLED_ATTR_MISMATCH_CMD_OPEN |
+               PGWT_SAMPLED_ATTR_MISMATCH_QUERY_ID;
+    unsigned mismatch = 0;
+    if (!!tick->cmd_open != !!uprobe->cmd_open)
+        mismatch |= PGWT_SAMPLED_ATTR_MISMATCH_CMD_OPEN;
+    /* Compare EFFECTIVE attribution.  PgBackendStatus and the state map both
+     * retain the last query id after a command closes; sampled attribution
+     * deliberately exposes neither one while idle. */
+    uint64_t tick_query_id = tick->cmd_open ? tick->query_id : 0;
+    uint64_t uprobe_query_id = uprobe->cmd_open ? uprobe->query_id : 0;
+    if (tick_query_id != uprobe_query_id)
+        mismatch |= PGWT_SAMPLED_ATTR_MISMATCH_QUERY_ID;
+    return mismatch;
+}
+
+int pgwt_sampled_attr_active_query_mismatch(
+    const struct pgwt_sampled_attr_value *tick,
+    const struct pgwt_sampled_attr_value *uprobe)
+{
+    return tick && uprobe && tick->cmd_open &&
+           tick->query_id != uprobe->query_id;
+}
+
 int pgwt_sampler_build_batch(const struct pgwt_sample_target *targets,
                              const uint32_t *vals, const uint8_t *valid,
                              int n, uint64_t tick_ts,
@@ -713,13 +767,21 @@ int pgwt_sampler_poll(struct pgwt_daemon *d)
     s->last_tick_ns = tick_ts;
 
     /* SMP-4: one batched state_map dump per tick for the query_id join.
-     * Falls back to per-pid lookups on kernels without batch support. */
+     * Falls back to per-pid lookups on kernels without batch support.  Stage
+     * 2 keeps this source live as a shadow after PgBackendStatus becomes
+     * authoritative; the uprobes intentionally remain attached until Stage
+     * 3. */
     struct pgwt_qid_entry qidx_buf[MAX_BACKENDS];
     int qidx_n = dump_qid_index(d, s, qidx_buf);
 
+    const bool tick_source_enabled =
+        pgwt_pgbs_sampled_attr_enabled(&d->backend_status_layout);
+
     /* Reuse a stack target array sized to the live count; MAX_BACKENDS cap. */
     static struct pgwt_sample_target targets[MAX_BACKENDS];
+    static uint8_t attr_valid[MAX_BACKENDS];
     int n = 0;
+    int attr_errno = 0;
     for (int i = 0; i < d->backends.count && n < MAX_BACKENDS; i++) {
         struct pgwt_backend *be = &d->backends.entries[i];
         if (!be->is_alive || be->pid <= 0)
@@ -775,18 +837,95 @@ int pgwt_sampler_poll(struct pgwt_daemon *d)
         targets[n].is_shared       = be->wp_addr_shared;
         targets[n].backend_type    = be->meta_parsed ? be->meta.backend_type
                                                      : PGWT_BT_UNKNOWN;
+        /* The syslogger is not a PostgreSQL backend: it has no MyBEEntry or
+         * PgBackendStatus slot, and its on-CPU samples are already excluded
+         * by policy.  Keep its irrelevant zero attribution on the legacy
+         * source instead of manufacturing a permanent coverage hole. */
+        const bool target_tick_enabled = tick_source_enabled &&
+            targets[n].backend_type != PGWT_BT_LOGGER;
+        struct pgwt_sampled_attr_value uprobe_attr = {0};
         if (qidx_n >= 0) {
             const struct pgwt_qid_entry *qe =
                 pgwt_qid_index_get(qidx_buf, qidx_n, (uint32_t)be->pid);
-            targets[n].query_id = qe ? qe->query_id : 0;
-            targets[n].cmd_open = qe ? qe->cmd_open : 0;
+            if (qe) {
+                uprobe_attr.query_id = qe->query_id;
+                uprobe_attr.cmd_open = qe->cmd_open;
+            }
         } else {
-            uint64_t qid = 0;
-            int cmd_open = 0;
-            lookup_pid_state(d, be->pid, &qid, &cmd_open);
-            targets[n].query_id = qid;
-            targets[n].cmd_open = cmd_open;
+            lookup_pid_state(d, be->pid, &uprobe_attr.query_id,
+                             &uprobe_attr.cmd_open);
         }
+
+        struct pgwt_pgbs_sampled_attr tick_raw;
+        struct pgwt_sampled_attr_value tick_attr = {0};
+        int tick_ok = 0;
+        if (target_tick_enabled) {
+            errno = 0;
+            tick_ok = pgwt_pgbs_read_sampled_attr(
+                be->pid, d->my_be_entry_addr, &d->backend_status_layout,
+                &tick_raw) == 0;
+            if (tick_ok) {
+                tick_attr.query_id = tick_raw.query_id;
+                tick_attr.cmd_open = tick_raw.cmd_open;
+                unsigned mismatch = pgwt_sampled_attr_compare(&tick_attr,
+                                                               &uprobe_attr);
+                d->counters.sampled_attr_shadow_total++;
+                if (tick_attr.cmd_open)
+                    d->counters.sampled_attr_shadow_active_total++;
+                if (pgwt_sampled_attr_active_query_mismatch(&tick_attr,
+                                                             &uprobe_attr))
+                    d->counters
+                        .sampled_attr_shadow_active_mismatch_total++;
+                if (mismatch) {
+                    d->counters.sampled_attr_shadow_mismatch_total++;
+                    if (mismatch & PGWT_SAMPLED_ATTR_MISMATCH_CMD_OPEN)
+                        d->counters
+                            .sampled_attr_shadow_cmd_open_mismatch_total++;
+                    if (mismatch & PGWT_SAMPLED_ATTR_MISMATCH_QUERY_ID)
+                        d->counters
+                            .sampled_attr_shadow_query_id_mismatch_total++;
+                    if (getenv("PGWT_DEBUG_SAMPLED_ATTR_SHADOW"))
+                        fprintf(stderr,
+                                "SAMPLED-ATTR-SHADOW-MISMATCH: pid=%d "
+                                "active=%d fields=%s%s "
+                                "uprobe=(last_query_id=0x%llx,cmd_open=%d,"
+                                "effective_query_id=0x%llx) "
+                                "tick=(st_query_id=0x%llx,cmd_open=%d,"
+                                "state=%u,effective_query_id=0x%llx)\n",
+                                be->pid,
+                                tick_attr.cmd_open,
+                                mismatch &
+                                    PGWT_SAMPLED_ATTR_MISMATCH_CMD_OPEN
+                                    ? "cmd_open" : "",
+                                mismatch &
+                                    PGWT_SAMPLED_ATTR_MISMATCH_QUERY_ID
+                                    ? (mismatch &
+                                       PGWT_SAMPLED_ATTR_MISMATCH_CMD_OPEN
+                                       ? ",query_id" : "query_id") : "",
+                                (unsigned long long)uprobe_attr.query_id,
+                                uprobe_attr.cmd_open,
+                                (unsigned long long)(uprobe_attr.cmd_open
+                                    ? uprobe_attr.query_id : 0),
+                                (unsigned long long)tick_attr.query_id,
+                                tick_attr.cmd_open, tick_raw.state,
+                                (unsigned long long)(tick_attr.cmd_open
+                                    ? tick_attr.query_id : 0));
+                }
+            } else {
+                d->counters.sampled_attr_tick_read_failures_total++;
+                if (!attr_errno)
+                    attr_errno = errno ? errno : EAGAIN;
+                if (getenv("PGWT_DEBUG_SAMPLED_ATTR_SHADOW"))
+                    fprintf(stderr,
+                            "SAMPLED-ATTR-TICK-INVALID: pid=%d error=%s\n",
+                            be->pid, strerror(errno ? errno : EAGAIN));
+            }
+        }
+
+        enum pgwt_sampled_attr_source source = pgwt_sampler_select_attr(
+            target_tick_enabled, tick_ok,
+            &tick_attr, &uprobe_attr, &targets[n]);
+        attr_valid[n] = source != PGWT_SAMPLED_ATTR_DROP;
         n++;
     }
     if (n == 0) {
@@ -800,9 +939,22 @@ int pgwt_sampler_poll(struct pgwt_daemon *d)
                                         s->read_valid,
                                         &s->read_faults_total);
     int read_errno = errno;
-    pgwt_sampler_note_coverage(s, n, got);
     d->counters.sample_read_faults_total +=
         (s->read_faults_total - faults_before);
+
+    /* A validated-layout tick read is part of the target observation.  If it
+     * failed, invalidate the target even when wait_event_info succeeded: the
+     * batch must neither reuse stale command state nor admit a CPU sample.
+     * The existing anomaly coverage path then sees the same incomplete tick. */
+    for (int i = 0; i < n; i++) {
+        if (!attr_valid[i] && s->read_valid[i]) {
+            s->read_valid[i] = 0;
+            got--;
+        }
+    }
+    if (got == 0 && attr_errno)
+        read_errno = attr_errno;
+    pgwt_sampler_note_coverage(s, n, got);
 
     /* Debug-only evidence for the anomaly CPU-coverage gate. Keep each failed
      * target attributable: aggregate coverage alone cannot distinguish a
@@ -867,7 +1019,7 @@ int pgwt_sampler_poll(struct pgwt_daemon *d)
      * the common steady state (edge already open, or not on CPU) does zero
      * extra reads. When ground truth says "in a command", also refresh the
      * query_id the edge-uprobe likewise missed. */
-    if (d->debug_query_string_addr) {
+    if (!tick_source_enabled && d->debug_query_string_addr) {
         for (int i = 0; i < n; i++) {
             if (!s->read_valid[i] || s->read_vals[i] != 0
                 || targets[i].cmd_open)

--- a/src/sampler.c
+++ b/src/sampler.c
@@ -258,8 +258,15 @@ enum pgwt_sampled_attr_source pgwt_sampler_select_attr(
         }
         return PGWT_SAMPLED_ATTR_UPROBE;
     }
-    if (!tick_read_ok || !tick)
-        return PGWT_SAMPLED_ATTR_DROP;
+    if (!tick_read_ok || !tick) {
+        /* Only command-gated CLIENT/UNKNOWN targets must fail closed: stale
+         * cmd_open could admit false CPU.  Query-less types remain recordable
+         * without attribution, preserving their wait/CPU coverage. */
+        if (target->backend_type == PGWT_BT_CLIENT ||
+            target->backend_type == PGWT_BT_UNKNOWN)
+            return PGWT_SAMPLED_ATTR_DROP;
+        return PGWT_SAMPLED_ATTR_UNATTRIBUTED;
+    }
 
     target->query_id = tick->query_id;
     target->cmd_open = tick->cmd_open;

--- a/src/sampler.h
+++ b/src/sampler.h
@@ -71,6 +71,7 @@ struct pgwt_sampled_attr_value {
 enum pgwt_sampled_attr_source {
     PGWT_SAMPLED_ATTR_UPROBE = 0,
     PGWT_SAMPLED_ATTR_TICK,
+    PGWT_SAMPLED_ATTR_UNATTRIBUTED,
     PGWT_SAMPLED_ATTR_DROP,
 };
 

--- a/src/sampler.h
+++ b/src/sampler.h
@@ -61,6 +61,24 @@ struct pgwt_sample_target {
     int      cmd_open;
 };
 
+/* The two sampled-attribution sources use the same normalized shape.  The
+ * tick source supplies query_id=0 while its command gate is closed. */
+struct pgwt_sampled_attr_value {
+    uint64_t query_id;
+    int cmd_open;
+};
+
+enum pgwt_sampled_attr_source {
+    PGWT_SAMPLED_ATTR_UPROBE = 0,
+    PGWT_SAMPLED_ATTR_TICK,
+    PGWT_SAMPLED_ATTR_DROP,
+};
+
+enum pgwt_sampled_attr_mismatch {
+    PGWT_SAMPLED_ATTR_MISMATCH_CMD_OPEN = 1u << 0,
+    PGWT_SAMPLED_ATTR_MISMATCH_QUERY_ID = 1u << 1,
+};
+
 /* Sampler read-health tracking (SMP-1). Pure state machine (unit-testable):
  * a tick where n_targets > 0 but NOTHING could be read is a failure tick.
  * The first failure logs immediately; persistent failure re-logs
@@ -176,6 +194,31 @@ void pgwt_sampler_note_coverage(struct pgwt_sampler *s, int targets, int valid);
  * category tagging. */
 uint32_t pgwt_backend_type_flag(enum pgwt_backend_type bt);
 int      pgwt_cpu_sample_recordable(enum pgwt_backend_type bt, int cmd_open);
+
+/* Stage 2 source gate.  A degraded/disabled layout selects the existing
+ * uprobe value.  A validated layout selects the coherent tick value, and a
+ * failed tick read selects DROP with zeroed outputs — never the previous
+ * tick or the uprobe shadow. */
+enum pgwt_sampled_attr_source pgwt_sampler_select_attr(
+    int tick_source_enabled, int tick_read_ok,
+    const struct pgwt_sampled_attr_value *tick,
+    const struct pgwt_sampled_attr_value *uprobe,
+    struct pgwt_sample_target *target);
+
+/* Compare one coherent at-tick value with its uprobe-map shadow after each
+ * source applies cmd_open ? query_id : 0.  Retained idle query ids therefore
+ * agree at zero instead of producing false shadow mismatches. */
+unsigned pgwt_sampled_attr_compare(
+    const struct pgwt_sampled_attr_value *tick,
+    const struct pgwt_sampled_attr_value *uprobe);
+
+/* Load-bearing shadow proof: only an at-tick active backend participates,
+ * and its st_query_id is compared with the state map's raw last_query_id.
+ * cmd_open boundary disagreement remains visible in the total tuple counters
+ * but does not turn equal active query ids into false active mismatches. */
+int pgwt_sampled_attr_active_query_mismatch(
+    const struct pgwt_sampled_attr_value *tick,
+    const struct pgwt_sampled_attr_value *uprobe);
 
 /* T2 (EL9 fix): read a backend's OWN authoritative command state, bypassing
  * the transition-edge state_map. The on_report_activity/on_report_query_id

--- a/tests/mock_server.py
+++ b/tests/mock_server.py
@@ -536,6 +536,13 @@ class DaemonState:
             "samples_total": 540000,
             "samples_per_sec": 60.0,
             "sample_read_faults_total": 0,
+            "sampled_attr_tick_read_failures_total": 0,
+            "sampled_attr_shadow_total": 0,
+            "sampled_attr_shadow_mismatch_total": 0,
+            "sampled_attr_shadow_active_total": 0,
+            "sampled_attr_shadow_active_mismatch_total": 0,
+            "sampled_attr_shadow_cmd_open_mismatch_total": 0,
+            "sampled_attr_shadow_query_id_mismatch_total": 0,
             # Capture hardening counters (T4): non-zero = loudly-logged
             # degradation (CAP-1/2/5/6, SMP-1/3).
             "sampler_ticks_missed_total": 0,

--- a/tests/test_backend_status_layout.c
+++ b/tests/test_backend_status_layout.c
@@ -1,4 +1,4 @@
-/* test_backend_status_layout.c -- Stage 1 layout discovery/validation tests. */
+/* test_backend_status_layout.c -- PgBackendStatus discovery/runtime tests. */
 #define _GNU_SOURCE
 #include "backend_status_layout.h"
 
@@ -355,6 +355,120 @@ static void test_validation(void)
           "missing field records fallback and never invents an offset");
 }
 
+static void validate_sampled_fields(struct PgBackendStatusLayout *layout)
+{
+    layout->validation = PGWT_PGBS_VALIDATION_VALIDATED;
+    layout->st_changecount.validation = PGWT_PGBS_FIELD_VALIDATED;
+    layout->st_procpid.validation = PGWT_PGBS_FIELD_VALIDATED;
+    layout->st_state.validation = PGWT_PGBS_FIELD_VALIDATED;
+    layout->st_query_id.validation = PGWT_PGBS_FIELD_VALIDATED;
+}
+
+static void test_sampled_attr(void)
+{
+    printf("--- Stage 2 coherent sampled attribution ---\n");
+    struct PgBackendStatusLayout layout;
+    CHECK(pgwt_pgbs_hard_table_lookup(18, PGWT_PGBS_ARCH_X86_64, 8,
+                                      PGWT_PGBS_ABI_SYSV_LP64,
+                                      &layout) == 0,
+          "PG18 sampled-attribution fixture row");
+    validate_sampled_fields(&layout);
+    CHECK(pgwt_pgbs_sampled_attr_enabled(&layout),
+          "validated PG18 layout enables at-tick source");
+
+    struct pgwt_pgbs_snapshot snapshot = {
+        .changecount_before = 12,
+        .changecount_after = 12,
+        .procpid = (uint32_t)getpid(),
+        .state = 3,                 /* PG18 STATE_RUNNING */
+        .query_id = 0xf123456789abcdefULL,
+        .read_mask = PGWT_PGBS_READ_CHANGECOUNT |
+                     PGWT_PGBS_READ_PROCPID |
+                     PGWT_PGBS_READ_STATE |
+                     PGWT_PGBS_READ_QUERY_ID,
+    };
+    struct pgwt_pgbs_sampled_attr attr = {0};
+    CHECK(pgwt_pgbs_derive_sampled_attr(&layout, &snapshot, getpid(),
+                                        &attr) == 0 &&
+          attr.cmd_open && attr.state == 3 &&
+          attr.query_id == snapshot.query_id,
+          "PG18 RUNNING=3 admits CPU and preserves signed query-id bits");
+
+    snapshot.state = 5;             /* PG18 STATE_FASTPATH */
+    CHECK(pgwt_pgbs_derive_sampled_attr(&layout, &snapshot, getpid(),
+                                        &attr) == 0 &&
+          attr.cmd_open && attr.state == 5 &&
+          attr.query_id == snapshot.query_id,
+          "PG18 FASTPATH=5 is command-open");
+
+    snapshot.state = 1;             /* any validated idle state */
+    CHECK(pgwt_pgbs_derive_sampled_attr(&layout, &snapshot, getpid(),
+                                        &attr) == 0 &&
+          !attr.cmd_open && attr.query_id == 0,
+          "idle state closes admission and normalizes query-id to zero");
+
+    /* A failed derivation starts by clearing the destination.  Seed it with
+     * stale command state to prove an incoherent tick cannot reuse it. */
+    attr.cmd_open = true;
+    attr.query_id = UINT64_MAX;
+    snapshot.state = 3;
+    snapshot.changecount_after = 14;
+    CHECK(pgwt_pgbs_derive_sampled_attr(&layout, &snapshot, getpid(),
+                                        &attr) != 0 &&
+          !attr.cmd_open && attr.query_id == 0,
+          "incoherent read drops state instead of reusing the prior tick");
+    snapshot.changecount_after = snapshot.changecount_before;
+
+    attr.cmd_open = true;
+    attr.query_id = UINT64_MAX;
+    snapshot.procpid++;
+    CHECK(pgwt_pgbs_derive_sampled_attr(&layout, &snapshot, getpid(),
+                                        &attr) != 0 &&
+          !attr.cmd_open && attr.query_id == 0,
+          "PID identity mismatch drops state");
+    snapshot.procpid = (uint32_t)getpid();
+
+    /* Exercise the live /proc/<pid>/mem wrapper against a synthetic
+     * PgBackendStatus row in this process. */
+    uint8_t row[440];
+    memset(row, 0, sizeof(row));
+    uint32_t changecount = 20;
+    uint32_t pid = (uint32_t)getpid();
+    uint32_t state = 5;
+    uint64_t query_id = 0x7123456789abcdefULL;
+    memcpy(row + layout.st_changecount.offset, &changecount,
+           sizeof(changecount));
+    memcpy(row + layout.st_procpid.offset, &pid, sizeof(pid));
+    memcpy(row + layout.st_state.offset, &state, sizeof(state));
+    memcpy(row + layout.st_query_id.offset, &query_id, sizeof(query_id));
+    uint64_t my_be_entry = (uint64_t)(uintptr_t)row;
+    CHECK(pgwt_pgbs_read_sampled_attr(getpid(),
+                                      (uint64_t)(uintptr_t)&my_be_entry,
+                                      &layout, &attr) == 0 &&
+          attr.cmd_open && attr.state == 5 && attr.query_id == query_id,
+          "live reader dereferences MyBEEntry and reuses coherent helper");
+
+    layout.validation = PGWT_PGBS_VALIDATION_DEGRADED;
+    CHECK(!pgwt_pgbs_sampled_attr_enabled(&layout),
+          "degraded layout keeps the uprobe-map fallback");
+    layout.validation = PGWT_PGBS_VALIDATION_VALIDATED;
+    layout.st_state.validation = PGWT_PGBS_FIELD_INVALID;
+    CHECK(!pgwt_pgbs_sampled_attr_enabled(&layout),
+          "invalid st_state field keeps the uprobe-map fallback");
+    layout.st_state.validation = PGWT_PGBS_FIELD_VALIDATED;
+    layout.st_query_id.validation = PGWT_PGBS_FIELD_INVALID;
+    CHECK(!pgwt_pgbs_sampled_attr_enabled(&layout),
+          "invalid st_query_id field keeps the uprobe-map fallback");
+
+    CHECK(pgwt_pgbs_hard_table_lookup(13, PGWT_PGBS_ARCH_X86_64, 8,
+                                      PGWT_PGBS_ABI_SYSV_LP64,
+                                      &layout) == 0,
+          "PG13 fallback fixture row");
+    layout.validation = PGWT_PGBS_VALIDATION_VALIDATED;
+    CHECK(!pgwt_pgbs_sampled_attr_enabled(&layout),
+          "PG13 remains unchanged on the uprobe/activity-text route");
+}
+
 static void test_warmup_aggregation(void)
 {
     printf("--- bounded warmup coincidence resistance ---\n");
@@ -480,6 +594,7 @@ int main(void)
     test_dwarf();
     test_hard_table();
     test_validation();
+    test_sampled_attr();
     test_warmup_aggregation();
     test_fail_safe_and_pid_exclusion();
     printf("\n%d/%d tests passed\n", ok, run);

--- a/tests/test_control.sh
+++ b/tests/test_control.sh
@@ -132,6 +132,7 @@ assert isinstance(r['uptime_s'], (int, float)) and r['uptime_s'] >= 0, r
 assert isinstance(r['backends'], int) and r['backends'] >= 0, r
 assert r['pg_pid'] == $PM_PID, r
 assert isinstance(r['version'], str) and r['version'], r
+assert r['sampled_attr_source'] in ('pgbackend_status', 'uprobe_state_map'), r
 # T4/SMP-1: sampler health must be present and healthy on a working box
 assert r['sampler_healthy'] is True, r
 assert r['sampler_unhealthy_reason'] == '', r
@@ -155,6 +156,14 @@ for k in ('events_total', 'events_per_sec', 'lifecycle_events_total',
           'state_map_full_total', 'seen_query_ids_full_total',
           'invalid_wait_reads_total', 'sampler_ticks_missed_total',
           'state_reseeds_total',
+          # Stage 2 sampled-attribution source/shadow observability.
+          'sampled_attr_tick_read_failures_total',
+          'sampled_attr_shadow_total',
+          'sampled_attr_shadow_mismatch_total',
+          'sampled_attr_shadow_active_total',
+          'sampled_attr_shadow_active_mismatch_total',
+          'sampled_attr_shadow_cmd_open_mismatch_total',
+          'sampled_attr_shadow_query_id_mismatch_total',
           # AAS-1 Stage 3 CPU-saturation rule counter/state.
           'anomaly_cpu_saturation_fires_total', 'anomaly_cpu_cusum',
           # T8 measured-CPU counters (§5.6). Present + numeric here; the exact

--- a/tests/test_sampler.c
+++ b/tests/test_sampler.c
@@ -584,6 +584,67 @@ static void test_qid_index(void)
     CHECK(pgwt_qid_index_lookup(e, 0, 100) == 0, "empty index -> 0");
 }
 
+static void test_sampled_attr_source_gate(void)
+{
+    printf("--- Stage 2 sampled-attribution source gate + shadow compare ---\n");
+    struct pgwt_sampled_attr_value uprobe = {
+        .query_id = 111, .cmd_open = 1,
+    };
+    struct pgwt_sampled_attr_value tick = {
+        .query_id = 222, .cmd_open = 1,
+    };
+    struct pgwt_sample_target target = {
+        .query_id = UINT64_MAX, .cmd_open = 1,
+    };
+
+    CHECK(pgwt_sampler_select_attr(0, 1, &tick, &uprobe, &target) ==
+              PGWT_SAMPLED_ATTR_UPROBE &&
+          target.query_id == 111 && target.cmd_open == 1,
+          "degraded/PG13 gate preserves the existing uprobe source");
+    CHECK(pgwt_sampler_select_attr(1, 1, &tick, &uprobe, &target) ==
+              PGWT_SAMPLED_ATTR_TICK &&
+          target.query_id == 222 && target.cmd_open == 1,
+          "validated coherent read selects the at-tick source");
+
+    /* Seed stale values before a failed validated-layout read.  DROP must
+     * clear both fields instead of falling back to the shadow map. */
+    target.query_id = UINT64_MAX;
+    target.cmd_open = 1;
+    CHECK(pgwt_sampler_select_attr(1, 0, &tick, &uprobe, &target) ==
+              PGWT_SAMPLED_ATTR_DROP &&
+          target.query_id == 0 && target.cmd_open == 0,
+          "incoherent tick drops and zeroes attribution; no stale fallback");
+
+    CHECK(pgwt_sampled_attr_compare(&uprobe, &uprobe) == 0,
+          "identical sources agree");
+    unsigned mismatch = pgwt_sampled_attr_compare(&tick, &uprobe);
+    CHECK(mismatch == PGWT_SAMPLED_ATTR_MISMATCH_QUERY_ID,
+          "query-id-only mismatch is split by field");
+    tick.cmd_open = 0;
+    mismatch = pgwt_sampled_attr_compare(&tick, &uprobe);
+    CHECK((mismatch & PGWT_SAMPLED_ATTR_MISMATCH_CMD_OPEN) &&
+          (mismatch & PGWT_SAMPLED_ATTR_MISMATCH_QUERY_ID),
+          "tuple mismatch reports both fields");
+
+    tick.query_id = 0xaaaa;
+    tick.cmd_open = 0;
+    uprobe.query_id = 0xbbbb; /* retained last query while idle */
+    uprobe.cmd_open = 0;
+    CHECK(pgwt_sampled_attr_compare(&tick, &uprobe) == 0,
+          "idle sources compare effective query-id zero, not retained ids");
+    CHECK(!pgwt_sampled_attr_active_query_mismatch(&tick, &uprobe),
+          "idle backend is excluded from the active query-id proof");
+
+    tick.query_id = uprobe.query_id;
+    tick.cmd_open = 1;
+    uprobe.cmd_open = 0;
+    CHECK(!pgwt_sampled_attr_active_query_mismatch(&tick, &uprobe),
+          "equal raw active query ids pass despite a gate-boundary straddle");
+    uprobe.query_id++;
+    CHECK(pgwt_sampled_attr_active_query_mismatch(&tick, &uprobe),
+          "active st_query_id disagreement fails the load-bearing proof");
+}
+
 int main(void)
 {
     test_self_read();
@@ -597,6 +658,7 @@ int main(void)
     test_health();
     test_effective_period();
     test_qid_index();
+    test_sampled_attr_source_gate();
 
     printf("\n%d/%d checks passed\n", tests_passed, tests_run);
     return tests_passed == tests_run ? 0 : 1;

--- a/tests/test_sampler.c
+++ b/tests/test_sampler.c
@@ -606,14 +606,54 @@ static void test_sampled_attr_source_gate(void)
           target.query_id == 222 && target.cmd_open == 1,
           "validated coherent read selects the at-tick source");
 
-    /* Seed stale values before a failed validated-layout read.  DROP must
-     * clear both fields instead of falling back to the shadow map. */
+    /* Seed stale values before a failed validated-layout read.  A CLIENT must
+     * fail closed instead of falling back to the shadow map. */
+    target.backend_type = PGWT_BT_CLIENT;
     target.query_id = UINT64_MAX;
     target.cmd_open = 1;
     CHECK(pgwt_sampler_select_attr(1, 0, &tick, &uprobe, &target) ==
               PGWT_SAMPLED_ATTR_DROP &&
           target.query_id == 0 && target.cmd_open == 0,
-          "incoherent tick drops and zeroes attribution; no stale fallback");
+          "incoherent CLIENT tick drops and zeroes attribution");
+
+    target.backend_type = PGWT_BT_UNKNOWN;
+    target.query_id = UINT64_MAX;
+    target.cmd_open = 1;
+    CHECK(pgwt_sampler_select_attr(1, 0, &tick, &uprobe, &target) ==
+              PGWT_SAMPLED_ATTR_DROP &&
+          target.query_id == 0 && target.cmd_open == 0,
+          "incoherent UNKNOWN tick remains command-gated and drops");
+
+    /* An io_worker has no meaningful query attribution and its CPU admission
+     * is cmd_open-independent.  Preserve the observation without consulting
+     * the stale uprobe shadow; the poll loop therefore keeps it covered. */
+    target.backend_type = PGWT_BT_IO_WORKER;
+    target.query_id = UINT64_MAX;
+    target.cmd_open = 1;
+    enum pgwt_sampled_attr_source source = pgwt_sampler_select_attr(
+        1, 0, &tick, &uprobe, &target);
+    CHECK(source == PGWT_SAMPLED_ATTR_UNATTRIBUTED &&
+          target.query_id == 0 && target.cmd_open == 0,
+          "incoherent io_worker tick records without attribution");
+
+    uint32_t we = 0;
+    uint8_t valid = source != PGWT_SAMPLED_ATTR_DROP;
+    struct pgwt_trace_event sample = {0};
+    CHECK(pgwt_sampler_build_batch(&target, &we, &valid, 1, 123,
+                                   &sample, NULL, NULL) == 1 &&
+          sample.query_id == 0 &&
+          sample.flags == PGWT_EVENT_FLAG_IO_WORKER &&
+          sample.new_event == 0,
+          "failed-attribution io_worker CPU observation is admitted");
+
+    struct pgwt_sampler coverage = {0};
+    pgwt_sampler_note_coverage(&coverage, 1, valid);
+    CHECK(coverage.read_valid_last == 1 && coverage.read_invalid_last == 0,
+          "recorded io_worker remains covered after an incoherent tick read");
+
+    pgwt_sampler_note_coverage(&coverage, 2, 0);
+    CHECK(coverage.read_valid_last == 0 && coverage.read_invalid_last == 2,
+          "dropped CLIENT/UNKNOWN targets leave coverage incomplete");
 
     CHECK(pgwt_sampled_attr_compare(&uprobe, &uprobe) == 0,
           "identical sources agree");

--- a/tests/test_state_map_loud.py
+++ b/tests/test_state_map_loud.py
@@ -165,6 +165,13 @@ def main():
         # mirrors them; protocol drift between the two is caught here).
         for key in ("state_map_full_total", "seen_query_ids_full_total",
                     "invalid_wait_reads_total", "sampler_ticks_missed_total",
+                    "sampled_attr_tick_read_failures_total",
+                    "sampled_attr_shadow_total",
+                    "sampled_attr_shadow_mismatch_total",
+                    "sampled_attr_shadow_active_total",
+                    "sampled_attr_shadow_active_mismatch_total",
+                    "sampled_attr_shadow_cmd_open_mismatch_total",
+                    "sampled_attr_shadow_query_id_mismatch_total",
                     "sampler_healthy"):
             check(metrics is not None and key in metrics,
                   f"metrics carries '{key}'")


### PR DESCRIPTION
## Summary

- make coherent `PgBackendStatus.st_state` / `st_query_id` reads authoritative for sampled attribution when the stage-1 layout and required fields are validated
- implement the deliberate idle→0 rule: `cmd_open` is `RUNNING`/`FASTPATH`, and `query_id` is exposed only while that gate is open
- fail closed on incoherent/failed tick reads by dropping the target and marking coverage incomplete, without reusing stale state or falling back to the shadow
- retain the uprobe state map as a per-tick shadow and expose total, active, field-level, and read-failure counters; PG13/degraded layouts remain on the existing source
- document the semantic refinement and add focused derivation, source-selection, normalization, and failure-path tests

Uprobes remain attached in this stage and were observed firing. Attachment-overhead reduction is intentionally deferred to stage 3.

## Shadow comparison

Mixed CPU, timed-wait, idle, and repeated-command workloads ran at 100 Hz on the Hetzner validation host. Active comparisons are the load-bearing raw `st_query_id` vs state-map `last_query_id` check; total comparisons use each source's effective `cmd_open ? query_id : 0` attribution.

- PG17: 2 / 10,946 active mismatches (0.0183%); 3 / 28,419 total effective mismatches; 0 tick-read failures. The two residuals were one-tick command-boundary straddles.
- PG18: 0 / 10,959 active mismatches (0%); 1 / 36,509 total effective mismatches; 0 tick-read failures.

Both layouts reported `validated` and `sampled_attr_source=pgbackend_status`.

## Validation

All builds and tests ran only on the remote Hetzner box in `/root/pgwt-stage2`.

- clean userspace + BPF build
- `make -C tests check` green
  - `test_sampler`: 109/109
  - `test_backend_status_layout`: 118/118
  - `test_anomaly`: 189/189
- `tests/test_control.sh --pid 1178855`: 20/20
- full `tests/ci_smoke.sh` green with hardware watchpoints on PG13, PG17, and PG18
  - tiered capture: 55/55 on each major
  - full capture: 57/57 on each major
  - deterministic accuracy: 11/11 on each major
- `phase_cpu_storm_escalation` fired on all three majors with sampled AAS matching `pg_stat_activity` and no tier-switch AAS step

No query-attribution assertion depended on idle last-query retention, so no assertion was relaxed or changed.
