### PR TITLE
Add a permanent sampled-overhead regression gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,7 +168,7 @@ jobs:
 
       - name: Characterize paired sampled overhead
         run: |
-          PM_PID=$(head -1 /var/lib/postgresql/17/main/postmaster.pid)
+          PM_PID=$(sudo head -1 /var/lib/postgresql/17/main/postmaster.pid)
           sudo env "PATH=/usr/lib/postgresql/17/bin:$PATH" \
             "BPFTOOL=$BPFTOOL" \
             python3 tests/sampled_overhead_gate.py \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,9 @@
 # CI safety net (Phase B1 of docs/ROADMAP_AND_STATUS.md)
 #
-# Three jobs:
+# Core jobs:
 #   build-and-unit  — full build (BPF tracer + pgwt-server), C unit tests,
 #                     Python synthetic-data correctness tests
+#   sampled-overhead — paired sampled/no-tracer catastrophic-regression gate
 #   web-ui          — Playwright suite against tests/mock_server.py; any
 #                     browser console error fails the test that caused it
 #   protocol-drift  — same JSON-line commands against the real pgwt-server
@@ -101,6 +102,87 @@ jobs:
         env:
           PGWT_BRIDGE_TEST_REQUIRE: "1"
         run: cd web && go test -race ./...
+
+  sampled-overhead:
+    # Stage 5: timing on a shared runner is deliberately coarse.  The paired
+    # median catches the historical 20-30% trap/scan regressions; deterministic
+    # lifecycle/resolver tests retain the sub-1% implementation invariants.
+    # During threshold characterization this reports but does not timing-fail.
+    name: sampled-overhead (PG 17, characterize)
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Record runner capacity
+        run: |
+          nproc
+          grep -m1 'model name' /proc/cpuinfo || true
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang llvm libbpf-dev libelf-dev \
+            zlib1g-dev liblz4-dev linux-tools-common
+          if bpftool version >/dev/null 2>&1; then
+            BPFTOOL=$(command -v bpftool)
+          else
+            git clone --depth 1 --branch v7.5.0 --recurse-submodules \
+              https://github.com/libbpf/bpftool.git /tmp/bpftool
+            make -C /tmp/bpftool/src -j"$(nproc)"
+            BPFTOOL=/tmp/bpftool/src/bpftool
+          fi
+          "$BPFTOOL" version
+          echo "BPFTOOL=$BPFTOOL" >> "$GITHUB_ENV"
+          test -r /sys/kernel/btf/vmlinux
+
+      - name: Install PostgreSQL 17 (PGDG apt)
+        run: |
+          set -x
+          sudo systemctl stop postgresql || true
+          sudo apt-get install -y postgresql-common
+          pg_lsclusters -h | awk '{print $1, $2}' | while read -r ver name; do
+            sudo pg_dropcluster --stop "$ver" "$name" || true
+          done
+          sudo /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -y
+          sudo apt-get install -y postgresql-17 postgresql-contrib-17
+
+      - name: Configure PostgreSQL 17
+        run: |
+          set -ex
+          if ! pg_lsclusters -h | awk '$1 == 17 && $2 == "main"' | grep -q .; then
+            sudo pg_createcluster 17 main
+          fi
+          sudo pg_conftool 17 main set port 5432
+          sudo pg_conftool 17 main set shared_preload_libraries pg_stat_statements
+          sudo pg_conftool 17 main set compute_query_id on
+          sudo sed -i -E 's/(peer|scram-sha-256|md5)$/trust/' \
+            /etc/postgresql/17/main/pg_hba.conf
+          sudo pg_ctlcluster 17 main start
+          psql -U postgres -d postgres -c \
+            "CREATE EXTENSION IF NOT EXISTS pg_stat_statements"
+          psql -U postgres -d postgres -tAc "SELECT version()"
+
+      - name: Build tracer
+        run: make
+
+      - name: Characterize paired sampled overhead
+        run: |
+          PM_PID=$(head -1 /var/lib/postgresql/17/main/postmaster.pid)
+          sudo env "PATH=/usr/lib/postgresql/17/bin:$PATH" \
+            "BPFTOOL=$BPFTOOL" \
+            python3 tests/sampled_overhead_gate.py \
+              --pid "$PM_PID" --pg-version 17 --port 5432 \
+              --reps 7 --duration 10 --warmup 2 --characterize \
+              --output-json sampled-overhead.json
+
+      - name: Upload characterization data
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: sampled-overhead-characterization
+          path: sampled-overhead.json
+          if-no-files-found: warn
 
   capture-smoke:
     # Phase T0 (Trust Milestone, TST-1/2): run the REAL capture path against

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,10 +107,12 @@ jobs:
     # Stage 5: timing on a shared runner is deliberately coarse.  The paired
     # median catches the historical 20-30% trap/scan regressions. A candidate
     # hard failure gets seven more pairs so the final 14 are AB/BA-balanced.
+    # The fixed budget is 21 primary plus at most 21 confirmation pairs; the
+    # 60-minute timeout leaves headroom above a conservative 40-minute budget.
     # Deterministic lifecycle/resolver tests retain implementation invariants.
     name: sampled-overhead (PG 17)
     runs-on: ubuntu-latest
-    timeout-minutes: 35
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,10 +105,10 @@ jobs:
 
   sampled-overhead:
     # Stage 5: timing on a shared runner is deliberately coarse.  The paired
-    # median catches the historical 20-30% trap/scan regressions; deterministic
-    # lifecycle/resolver tests retain the sub-1% implementation invariants.
-    # During threshold characterization this reports but does not timing-fail.
-    name: sampled-overhead (PG 17, characterize)
+    # median catches the historical 20-30% trap/scan regressions. A candidate
+    # hard failure gets seven more pairs so the final 14 are AB/BA-balanced.
+    # Deterministic lifecycle/resolver tests retain implementation invariants.
+    name: sampled-overhead (PG 17)
     runs-on: ubuntu-latest
     timeout-minutes: 35
     steps:
@@ -166,21 +166,32 @@ jobs:
       - name: Build tracer
         run: make
 
-      - name: Characterize paired sampled overhead
+      - name: Run sampled-overhead structural unit gates
+        run: |
+          make -C tests test_exact_probe test_pgss_resolver test_query_text
+          tests/test_exact_probe
+          tests/test_pgss_resolver
+          tests/test_query_text
+
+      - name: Gate paired sampled overhead
         run: |
           PM_PID=$(sudo head -1 /var/lib/postgresql/17/main/postmaster.pid)
           sudo env "PATH=/usr/lib/postgresql/17/bin:$PATH" \
             "BPFTOOL=$BPFTOOL" \
             python3 tests/sampled_overhead_gate.py \
               --pid "$PM_PID" --pg-version 17 --port 5432 \
-              --reps 7 --duration 10 --warmup 2 --characterize \
+              --reps 7 --confirm-reps 7 --duration 10 --warmup 2 \
+              --clients 4 --jobs 4 --scale 10 \
+              --high-cardinality-shapes 256 --min-distinct-shapes 231 \
+              --warn-overhead-pct 10 --max-overhead-pct 15 \
+              --max-pgss-scans-per-sec 1 \
               --output-json sampled-overhead.json
 
-      - name: Upload characterization data
+      - name: Upload sampled-overhead data
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: sampled-overhead-characterization
+          name: sampled-overhead
           path: sampled-overhead.json
           if-no-files-found: warn
 

--- a/README.md
+++ b/README.md
@@ -1226,6 +1226,10 @@ sudo tests/run_all.sh --pg-version 18
 | **Web UI** | `test_web_ui.py` | Python + playwright + websockets | 108 checks: tabs, tables, sorting, drill-down, breadcrumbs, Sankey transitions, concurrency overlay, auto-refresh, reconnection |
 | **Performance** | `bench_server.py` + `gen_bench_traces` | `pgwt-server` | Compute throughput: 10.8M events/sec on 10M event trace |
 
+The blocking sampled-overhead A/B gate, its shared-runner noise data, and the
+dedicated-box precision profile are documented in
+[`docs/SAMPLED_OVERHEAD_GATE.md`](docs/SAMPLED_OVERHEAD_GATE.md).
+
 ### Running individual layers
 
 ```bash

--- a/docs/ROADMAP_AND_STATUS.md
+++ b/docs/ROADMAP_AND_STATUS.md
@@ -110,8 +110,11 @@
 > permission limits, eviction, disabled IDs, and retry exhaustion are ordinary
 > text-unavailable outcomes. Sidecar precedence is context-aware and
 > `full/raw > PG13 synthetic > pgss normalized`, so sampled text never consumes
-> the exact first-seen slot. Stage 5 (permanent sampled-overhead A/B CI gate)
-> remains. Stage 2 deliberately
+> the exact first-seen slot. Stage 5 is implemented as the permanent paired
+> sampled/no-tracer CI gate, with standard RO/RW plus a mandatory 256-shape
+> workload, a noise-derived 15% catastrophic-regression boundary, adaptive
+> 14-pair confirmation, and timing-independent probe/resolver/PG13 guards; see
+> `docs/SAMPLED_OVERHEAD_GATE.md`. Stage 2 deliberately
 > defines idle attribution as `query_id=0`:
 > `cmd_open` is true only for `STATE_RUNNING`/`STATE_FASTPATH`, and only an open
 > command exposes `st_query_id`. This differs from the old state-map path's
@@ -125,8 +128,9 @@
 > firing counts **0/0** and attached mask 0. Negative overhead is benchmark
 > noise, not a claimed speedup. PG13's pinned fallback probes were separately
 > confirmed still firing before Stage 4. Stage 4's PG13 and reconfirmation
-> measurements are recorded with its implementation PR. A permanent Stage 5
-> A/B CI gate still remains.
+> measurements are recorded with its implementation PR. Stage 5's permanent
+> A/B CI gate and 2026-08-15 noise characterization are recorded in
+> `docs/SAMPLED_OVERHEAD_GATE.md`.
 
 **Real feature gaps (defined, never built):**
 - **PostgreSQL 14 / 15 / 16** — only PG13 shipped; README says "14-16 not yet".

--- a/docs/SAMPLED_OVERHEAD_GATE.md
+++ b/docs/SAMPLED_OVERHEAD_GATE.md
@@ -3,7 +3,13 @@
 This is the permanent Stage 5 guard for the sampled tier. It is intentionally
 two-layered: noisy timing catches catastrophic performance changes, while live
 and synthetic structural assertions catch their mechanisms without depending
-on timing.
+on timing. The timing threshold bounds catastrophic regressions at or above
+15%, and the counters structurally cover the two known exact-uprobe and
+`pg_stat_statements` scan mechanisms. It does **not** bound a novel sub-15%
+overhead source that routes through neither counter.
+
+The A/B timing gate covers `--mode sampled`. Tiered-baseline timing is not gated
+here; the C structural test does cover its zero-exact-link invariant.
 
 ## Root cause and test gap
 
@@ -36,6 +42,15 @@ pairs moved by as much as 3.74pp and one individual RO pair exceeded 15%.
 Consequently a seven-pair candidate failure is never accepted as final: the
 gate adds seven pairs and hard-fails only if the combined, exactly AB/BA-balanced
 14-pair median remains at or above 15%. Normal PRs pay only for seven pairs.
+Seven is odd, so the primary phase intentionally has four AB and three BA pairs;
+the extra AB is the safe-direction bias, and confirmation supplies three AB plus
+four BA pairs to make the final fourteen exactly balanced.
+
+The CI job has a fixed maximum of 42 pairs: 21 primary pairs (seven for each of
+three workloads) plus at most 21 confirmation pairs. The measured happy path is
+about 20 minutes. Conservatively doubling that whole duration gives a 40-minute
+worst-case budget even though setup is not repeated, so the job timeout is 60
+minutes rather than 35.
 
 The allocated hosted runner had four vCPUs, so no claim is made about a 2-vCPU
 runner. Shared-runner noise is already too large for a credible sub-1% blocking
@@ -61,14 +76,18 @@ test even at four vCPUs.
   `pg_stat_statements_reset` to its run-owned database; and force-drops only
   that unique database.
 
-Every sampled timing run also requires a validated layout, the requested
+Every sampled timing pair strictly requires a validated layout, the requested
 postmaster PID, pure sampled mode/tier, a healthy `pgbackend_status` sampler,
-positive samples, and zero attached/fired exact query/activity uprobes. The
-high-cardinality run additionally requires actual resolver scans and resolved
-keys, and bounds actual `pg_stat_statements(true)` scans to at most one per
-second plus one edge allowance. Synthetic tests pin zero sampled probe links
-for validated PG13–18, scheduler throttling/fairness, and PG13 persistence in
-the async worker rather than the sampler tick.
+positive samples, and zero attached/fired exact query/activity uprobes. Every
+high-cardinality pair also strictly bounds actual
+`pg_stat_statements(true)` scans to at most one per second plus one edge
+allowance. These deterministic checks remain per-pair failures. The
+load-dependent liveness checks (enough distinct shapes, at least one actual
+scan, and at least one resolved key) are aggregated across the workload: each
+must be observed in at least one pair, so an asynchronously starved pair cannot
+false-fail an otherwise exercised run. Synthetic tests pin zero sampled probe
+links for validated PG13–18, scheduler throttling/fairness, and PG13 persistence
+in the async worker rather than the sampler tick.
 
 ## Reproduction
 
@@ -85,6 +104,9 @@ sudo env PATH=/usr/pgsql-17/bin:$PATH \
     --high-cardinality-shapes 256 --min-distinct-shapes 231 \
     --characterize --output-json sampled-overhead-box.json
 ```
+
+`--characterize` suppresses only the timing threshold and its confirmation
+phase. All structural invariants still hard-fail.
 
 `PGWT_TEST_SAMPLED_UPROBES=1` and `PGWT_TEST_PGSS_UNTHROTTLED=1` are loud,
 test-only fault-injection hooks used to prove both the timing and structural

--- a/docs/SAMPLED_OVERHEAD_GATE.md
+++ b/docs/SAMPLED_OVERHEAD_GATE.md
@@ -1,0 +1,91 @@
+# Sampled-overhead regression gate
+
+This is the permanent Stage 5 guard for the sampled tier. It is intentionally
+two-layered: noisy timing catches catastrophic performance changes, while live
+and synthetic structural assertions catch their mechanisms without depending
+on timing.
+
+## Root cause and test gap
+
+The historical sampled path attached per-query query-id and activity uprobes.
+Their trap cost ran in PostgreSQL backends and reduced throughput by roughly
+20–30%, while the old overhead test measured only `--mode full` with ordinary
+pgbench. A later unthrottled `pg_stat_statements(true)` resolver regression cost
+about 28% only under many distinct query shapes, which ordinary pgbench also
+hid. The permanent gate therefore tests sampled versus no tracer and includes a
+256-shape workload.
+
+## Noise characterization (2026-08-15)
+
+Each number below is a paired TPS loss. Pairs alternate baseline→sampled and
+sampled→baseline; the statistic is the paired median.
+
+| Host / workload | Pairs | Median | IQR | Observed range |
+|---|---:|---:|---:|---:|
+| Rocky 8.10 dedicated 4-core box, RO | 9 | +0.63% | 1.44pp | -2.04% … +3.97% |
+| Rocky 8.10 dedicated 4-core box, RW | 9 | +0.24% | 1.49pp | -2.31% … +2.96% |
+| Rocky 8.10 dedicated 4-core box, 256 shapes | 9 | -0.36% | 2.03pp | -2.30% … +7.14% |
+| GitHub `ubuntu-latest` 4-vCPU runner, RO | 7 | +1.99% | 11.02pp | -12.75% … +19.38% |
+| GitHub `ubuntu-latest` 4-vCPU runner, RW | 7 | +3.47% | 9.84pp | -7.77% … +7.11% |
+| GitHub `ubuntu-latest` 4-vCPU runner, 256 shapes | 7 | +3.25% | 5.78pp | -3.74% … +11.56% |
+
+On the dedicated box the prefix median was already useful at seven pairs; the
+largest seven-to-nine-pair movement was 1.33pp. Nine pairs are retained for the
+manual precision profile. On the hosted runner, prefix medians through seven
+pairs moved by as much as 3.74pp and one individual RO pair exceeded 15%.
+Consequently a seven-pair candidate failure is never accepted as final: the
+gate adds seven pairs and hard-fails only if the combined, exactly AB/BA-balanced
+14-pair median remains at or above 15%. Normal PRs pay only for seven pairs.
+
+The allocated hosted runner had four vCPUs, so no claim is made about a 2-vCPU
+runner. Shared-runner noise is already too large for a credible sub-1% blocking
+test even at four vCPUs.
+
+## Permanent design
+
+- Workloads: standard pgbench read-only, standard read-write, and 256 genuinely
+  distinct high-cardinality point-query shapes. At least 231 shapes must be
+  observed.
+- Statistic: median of seven alternating paired A/B losses. A candidate 15%
+  hard failure automatically expands to a balanced 14-pair median.
+- Thresholds: 10% emits a nonblocking GitHub warning; 15% hard-fails. The worst
+  hosted null median was 3.47%, leaving 11.53pp of headroom. A multiplicative
+  20% regression applied to the observed null medians lands at 21.6–22.8%; a
+  28% regression lands at 29.4–30.5%.
+- Placement: every pull request runs the coarse GitHub-hosted blocking job.
+  The dedicated-box command below is the manual precision profile for the
+  sampled tier's sub-1% target; it reports rather than pretending that 1% is a
+  reliable hard boundary.
+- Safety: the harness cross-checks SQL port/version, `data_directory`, and
+  `postmaster.pid`; refuses to replace an existing database; scopes
+  `pg_stat_statements_reset` to its run-owned database; and force-drops only
+  that unique database.
+
+Every sampled timing run also requires a validated layout, the requested
+postmaster PID, pure sampled mode/tier, a healthy `pgbackend_status` sampler,
+positive samples, and zero attached/fired exact query/activity uprobes. The
+high-cardinality run additionally requires actual resolver scans and resolved
+keys, and bounds actual `pg_stat_statements(true)` scans to at most one per
+second plus one edge allowance. Synthetic tests pin zero sampled probe links
+for validated PG13–18, scheduler throttling/fairness, and PG13 persistence in
+the async worker rather than the sampler tick.
+
+## Reproduction
+
+The CI command is explicit in `.github/workflows/ci.yml`. For a quieter manual
+profile on the dedicated box, use longer samples and keep timing informational:
+
+```bash
+sudo env PATH=/usr/pgsql-17/bin:$PATH \
+  BPFTOOL=/root/pgwt/build/bpftool/src/bpftool \
+  python3 tests/sampled_overhead_gate.py \
+    --pid "$(head -1 /var/lib/pgsql/17/data/postmaster.pid)" \
+    --pg-version 17 --port 5417 --reps 9 --confirm-reps 0 \
+    --duration 30 --warmup 2 --clients 4 --jobs 4 --scale 10 \
+    --high-cardinality-shapes 256 --min-distinct-shapes 231 \
+    --characterize --output-json sampled-overhead-box.json
+```
+
+`PGWT_TEST_SAMPLED_UPROBES=1` and `PGWT_TEST_PGSS_UNTHROTTLED=1` are loud,
+test-only fault-injection hooks used to prove both the timing and structural
+halves of the gate go red. They are not production options.

--- a/docs/SAMPLED_OVERHEAD_GATE.md
+++ b/docs/SAMPLED_OVERHEAD_GATE.md
@@ -88,4 +88,7 @@ sudo env PATH=/usr/pgsql-17/bin:$PATH \
 
 `PGWT_TEST_SAMPLED_UPROBES=1` and `PGWT_TEST_PGSS_UNTHROTTLED=1` are loud,
 test-only fault-injection hooks used to prove both the timing and structural
-halves of the gate go red. They are not production options.
+halves of the gate go red. The latter drives the pre-fix 32-key unthrottled
+resolver and synchronous persistence with five real pgss scans per admitted
+batch, reproducing the historical scan-storm intensity without synthetic
+sleeps. They are not production options.

--- a/src/control.c
+++ b/src/control.c
@@ -258,6 +258,9 @@ static cJSON *build_metrics(const struct pgwt_daemon *d)
     cjson_add_uint64(root, "sampled_text_retry_exhausted_total",
                      __atomic_load_n(&ctr->sampled_text_retry_exhausted_total,
                                      __ATOMIC_RELAXED));
+    cjson_add_uint64(root, "sampled_text_pgss_scans_total",
+                     __atomic_load_n(&ctr->sampled_text_pgss_scans_total,
+                                     __ATOMIC_RELAXED));
     cjson_add_uint64(root, "exact_query_uprobe_fires_total",
                      pgwt_exact_uprobe_fire_count(
                          (struct pgwt_daemon *)d, PGWT_UPROBE_FIRE_QUERY));

--- a/src/daemon.h
+++ b/src/daemon.h
@@ -62,6 +62,8 @@ struct pgwt_counters {
     uint64_t sampled_text_evicted_total;
     uint64_t sampled_text_error_total;
     uint64_t sampled_text_retry_exhausted_total;
+    /* Actual pg_stat_statements(true) lookup scans. */
+    uint64_t sampled_text_pgss_scans_total;
 
     /* Capture hardening (T4). All of these mean "something the operator
      * must know about is happening" — each is paired with a loud log. */

--- a/src/exact_probe.c
+++ b/src/exact_probe.c
@@ -308,6 +308,14 @@ int pgwt_exact_probe_startup(struct pgwt_daemon *d)
     uint32_t mask = pgwt_exact_probe_startup_mask(
         d->mode, d->pg_major_version, &d->backend_status_layout,
         d->lightweight_mode != 0, d->skip_usdt != 0);
+    bool test_sampled_uprobes =
+        getenv("PGWT_TEST_SAMPLED_UPROBES") != NULL &&
+        (d->mode == PGWT_MODE_SAMPLED || d->mode == PGWT_MODE_TIERED);
+    if (test_sampled_uprobes) {
+        mask |= PGWT_EXACT_PROBE_ATTR_MASK;
+        fprintf(stderr, "WARN: PGWT_TEST_SAMPLED_UPROBES -- restoring "
+                "always-on sampled attribution traps (TEST ONLY)\n");
+    }
     uint64_t generation = d->mode == PGWT_MODE_FULL ? 1 : 0;
     if (set_config(d, generation, generation ? mono_ns() : 0, true) != 0)
         return -1;
@@ -364,6 +372,8 @@ void pgwt_exact_probe_reconcile_sampled(struct pgwt_daemon *d)
 {
     if ((d->mode != PGWT_MODE_SAMPLED && d->mode != PGWT_MODE_TIERED) ||
         !pgwt_pgbs_sampled_attr_enabled(&d->backend_status_layout))
+        return;
+    if (getenv("PGWT_TEST_SAMPLED_UPROBES"))
         return;
     uint32_t before = d->exact_probes.core.attached_mask;
     pgwt_exact_probe_core_unpin(&d->exact_probes.core,

--- a/src/pgss_resolver.c
+++ b/src/pgss_resolver.c
@@ -174,6 +174,7 @@ enum pgwt_pgss_miss_action pgwt_pgss_miss_action(unsigned attempts)
 #include <unistd.h>
 
 #define PGWT_PGSS_QUEUE_SIZE QT_HT_SIZE
+#define PGWT_PGSS_PRETHROTTLE_BATCH_MAX 32
 
 enum entry_state {
     ENTRY_EMPTY = 0,
@@ -194,6 +195,7 @@ struct pgwt_pgss_resolver {
     pthread_cond_t cond;
     bool stop;
     bool started;
+    bool test_unthrottled;
     uint64_t next_batch_at_ms;
     uint32_t last_batch_databaseid;
     struct resolver_entry entries[PGWT_PGSS_QUEUE_SIZE];
@@ -427,8 +429,10 @@ static size_t select_batch_locked(struct pgwt_pgss_resolver *r, uint64_t now,
                                                  : first_databaseid;
     if (!batch_databaseid)
         return 0;
-    for (int i = 0; i < PGWT_PGSS_QUEUE_SIZE &&
-                    count < PGWT_PGSS_BATCH_MAX; i++) {
+    size_t batch_max = r->test_unthrottled
+                     ? PGWT_PGSS_PRETHROTTLE_BATCH_MAX
+                     : PGWT_PGSS_BATCH_MAX;
+    for (int i = 0; i < PGWT_PGSS_QUEUE_SIZE && count < batch_max; i++) {
         struct resolver_entry *e = &r->entries[i];
         if (e->state != ENTRY_PENDING ||
             e->key.databaseid != batch_databaseid ||
@@ -441,12 +445,16 @@ static size_t select_batch_locked(struct pgwt_pgss_resolver *r, uint64_t now,
         /* Charge the 10 s scan budget in proportion to keys amortized by this
          * SRF call. Sparse databases no longer burn a full window, while the
          * floor keeps the expensive showtext scan at or below one per second. */
-        uint64_t delay = (PGWT_PGSS_BATCH_INTERVAL_MS * count +
-                          PGWT_PGSS_BATCH_MAX - 1) /
-                         PGWT_PGSS_BATCH_MAX;
-        if (delay < PGWT_PGSS_SCAN_MIN_INTERVAL_MS)
-            delay = PGWT_PGSS_SCAN_MIN_INTERVAL_MS;
-        r->next_batch_at_ms = now + delay;
+        if (r->test_unthrottled) {
+            r->next_batch_at_ms = now;
+        } else {
+            uint64_t delay = (PGWT_PGSS_BATCH_INTERVAL_MS * count +
+                              PGWT_PGSS_BATCH_MAX - 1) /
+                             PGWT_PGSS_BATCH_MAX;
+            if (delay < PGWT_PGSS_SCAN_MIN_INTERVAL_MS)
+                delay = PGWT_PGSS_SCAN_MIN_INTERVAL_MS;
+            r->next_batch_at_ms = now + delay;
+        }
         r->last_batch_databaseid = batch_databaseid;
     }
     return count;
@@ -537,8 +545,12 @@ static void *resolver_main(void *arg)
         char sql[65536], output[QT_MAX_TEXT];
         bool found[PGWT_PGSS_BATCH_MAX] = {0};
         int sql_ok = pgwt_pgss_build_lookup_sql(sql, sizeof(sql), schema,
-                                                 keys, count) == 0 &&
-                     run_sql(r, database, sql, output, sizeof(output)) == 0;
+                                                keys, count) == 0;
+        if (sql_ok) {
+            counter_add(&r->daemon->counters.sampled_text_pgss_scans_total,
+                        1);
+            sql_ok = run_sql(r, database, sql, output, sizeof(output)) == 0;
+        }
         if (!sql_ok)
             counter_add(&r->daemon->counters.sampled_text_error_total, count);
         if (sql_ok) {
@@ -595,6 +607,10 @@ int pgwt_pgss_resolver_start(struct pgwt_pgss_resolver **out,
     r->daemon = daemon;
     r->query_text = query_text;
     r->postmaster_pid = postmaster_pid;
+    r->test_unthrottled = getenv("PGWT_TEST_PGSS_UNTHROTTLED") != NULL;
+    if (r->test_unthrottled)
+        fprintf(stderr, "WARN: PGWT_TEST_PGSS_UNTHROTTLED -- restoring "
+                "pre-throttle 32-key pgss scans (TEST ONLY)\n");
     if (connection_info(r, postgres_binary) != 0 ||
         pthread_mutex_init(&r->mutex, NULL) != 0 ||
         pthread_cond_init(&r->cond, NULL) != 0) {

--- a/src/pgss_resolver.c
+++ b/src/pgss_resolver.c
@@ -547,9 +547,13 @@ static void *resolver_main(void *arg)
         int sql_ok = pgwt_pgss_build_lookup_sql(sql, sizeof(sql), schema,
                                                 keys, count) == 0;
         if (sql_ok) {
-            counter_add(&r->daemon->counters.sampled_text_pgss_scans_total,
-                        1);
-            sql_ok = run_sql(r, database, sql, output, sizeof(output)) == 0;
+            int scans = r->test_unthrottled ? 5 : 1;
+            for (int i = 0; i < scans && sql_ok; i++) {
+                counter_add(
+                    &r->daemon->counters.sampled_text_pgss_scans_total, 1);
+                sql_ok = run_sql(r, database, sql, output,
+                                 sizeof(output)) == 0;
+            }
         }
         if (!sql_ok)
             counter_add(&r->daemon->counters.sampled_text_error_total, count);
@@ -567,8 +571,12 @@ static void *resolver_main(void *arg)
                     if (resolver_key_equal(&keys[i], &got_key)) {
                         found[i] = true;
                         if (parsed > 0) {
-                            pgwt_qt_store_pgss_deferred(r->query_text,
-                                                        &got_key, text);
+                            if (r->test_unthrottled)
+                                pgwt_qt_store_pgss(r->query_text,
+                                                   &got_key, text);
+                            else
+                                pgwt_qt_store_pgss_deferred(r->query_text,
+                                                            &got_key, text);
                             finish_entry(
                                 r, indices[i], &r->daemon->counters
                                                     .sampled_text_resolved_total);
@@ -581,7 +589,8 @@ static void *resolver_main(void *arg)
                     }
                 }
             }
-            pgwt_qt_flush(r->query_text);
+            if (!r->test_unthrottled)
+                pgwt_qt_flush(r->query_text);
         }
         int missing_indices[PGWT_PGSS_BATCH_MAX];
         size_t missing_count = 0;
@@ -610,7 +619,8 @@ int pgwt_pgss_resolver_start(struct pgwt_pgss_resolver **out,
     r->test_unthrottled = getenv("PGWT_TEST_PGSS_UNTHROTTLED") != NULL;
     if (r->test_unthrottled)
         fprintf(stderr, "WARN: PGWT_TEST_PGSS_UNTHROTTLED -- restoring "
-                "pre-throttle 32-key pgss scans (TEST ONLY)\n");
+                "pre-throttle 32-key pgss scan storm (5 scans/batch) and "
+                "synchronous persistence (TEST ONLY)\n");
     if (connection_info(r, postgres_binary) != 0 ||
         pthread_mutex_init(&r->mutex, NULL) != 0 ||
         pthread_cond_init(&r->cond, NULL) != 0) {

--- a/tests/sampled_overhead_gate.py
+++ b/tests/sampled_overhead_gate.py
@@ -2,15 +2,20 @@
 """Paired A/B regression gate for the always-on sampled capture tier.
 
 This is intentionally a coarse catastrophic-regression gate, not a claim that
-shared-runner timing can prove the sampled tier's sub-1% overhead target.  Each
+shared-runner timing can prove the sampled tier's sub-1% overhead target.  It
+bounds losses at or above the timing threshold and structurally guards the two
+known exact-uprobe and pg_stat_statements scan mechanisms; it does not bound a
+novel sub-threshold overhead source that routes through neither counter.  Each
 pair runs no-tracer and sampled measurements back-to-back, alternates AB/BA
 order, and gates on the median paired TPS loss.  Standard read-only and
 read-write pgbench are joined by a mandatory many-query-shape workload because
-ordinary pgbench cannot expose pg_stat_statements resolver scan storms.
+ordinary pgbench cannot expose pg_stat_statements resolver scan storms.  The
+timing comparison covers --mode sampled, not the tiered baseline.
 
 Run as root against a dedicated PostgreSQL port/postmaster.  The script creates
 and removes one dedicated database and never restarts or reconfigures PostgreSQL.
-Use --characterize to report data without applying the timing threshold.
+Use --characterize to suppress only timing threshold failures; structural
+invariants remain hard failures.
 """
 
 import argparse
@@ -283,9 +288,6 @@ def structural_errors(args, workload, metrics, shapes):
         errors.append(f"sampled exact probes fired/attached: "
                       f"query={qfires} activity={afires} mask={mask}")
     if workload == "high-cardinality":
-        if shapes < args.min_distinct_shapes:
-            errors.append(f"only {shapes} distinct query shapes; "
-                          f"need >= {args.min_distinct_shapes}")
         required = ("sampled_text_pgss_scans_total",
                     "sampled_text_resolved_total")
         missing = [name for name in required if name not in metrics]
@@ -296,9 +298,6 @@ def structural_errors(args, workload, metrics, shapes):
             resolved = int(metrics["sampled_text_resolved_total"])
             uptime = float(metrics.get("uptime_s", 0))
             allowed = math.ceil(uptime * args.max_pgss_scans_per_sec) + 1
-            if scans <= 0 or resolved <= 0:
-                errors.append(f"pgss resolver was not exercised: "
-                              f"scans={scans} resolved={resolved}")
             if scans > allowed:
                 errors.append(f"pgss scan rate unbounded: {scans} scans in "
                               f"{uptime:.2f}s (allowed {allowed})")
@@ -312,6 +311,40 @@ def structural_errors(args, workload, metrics, shapes):
         if name in enabled and marker not in stderr:
             errors.append(f"injected hook {name} did not report activation")
     return errors
+
+
+def aggregate_liveness_errors(args, workload, pairs):
+    """Require load-dependent resolver exercise somewhere in the workload."""
+    if workload != "high-cardinality":
+        return {}, []
+
+    shapes = [int(pair.get("distinct_shapes", 0)) for pair in pairs]
+    scans = []
+    resolved = []
+    for pair in pairs:
+        metrics = pair.get("metrics") or {}
+        scans.append(int(metrics.get("sampled_text_pgss_scans_total", 0)))
+        resolved.append(int(metrics.get("sampled_text_resolved_total", 0)))
+
+    summary = {
+        "pairs": len(pairs),
+        "max_distinct_shapes": max(shapes, default=0),
+        "total_pgss_scans": sum(scans),
+        "total_resolved": sum(resolved),
+    }
+    errors = []
+    if summary["max_distinct_shapes"] < args.min_distinct_shapes:
+        errors.append(
+            f"no pair observed enough distinct query shapes: max "
+            f"{summary['max_distinct_shapes']}, need >= "
+            f"{args.min_distinct_shapes}")
+    if summary["total_pgss_scans"] <= 0:
+        errors.append(f"pgss resolver performed zero scans across "
+                      f"{len(pairs)} pairs")
+    if summary["total_resolved"] <= 0:
+        errors.append(f"pgss resolver resolved zero keys across "
+                      f"{len(pairs)} pairs")
+    return summary, errors
 
 
 def run_pair(args, workload, scripts, rep):
@@ -405,7 +438,9 @@ def main():
     parser.add_argument("--max-pgss-scans-per-sec", type=float, default=1.0)
     parser.add_argument("--workloads", nargs="+", choices=DEFAULT_WORKLOADS,
                         default=list(DEFAULT_WORKLOADS))
-    parser.add_argument("--characterize", action="store_true")
+    parser.add_argument(
+        "--characterize", action="store_true",
+        help="suppress timing failures only; structural invariants still fail")
     parser.add_argument("--keep-database", action="store_true")
     parser.add_argument("--output-json")
     parser.add_argument("--tracer-env", action="append", default=[])
@@ -487,12 +522,19 @@ def main():
                               f"overhead={pair['overhead_pct']:+.2f}%")
                 stats = summarize(
                     [pair["overhead_pct"] for pair in pairs])
+                aggregate_liveness, liveness_errors = \
+                    aggregate_liveness_errors(args, workload, pairs)
+                report["structural_failures"] += [
+                    f"{workload} aggregate: {error}"
+                    for error in liveness_errors]
+                failed |= bool(liveness_errors)
                 report["workloads"][workload] = {
                     "pairs": pairs,
                     "primary_reps": args.reps,
                     "confirmation_reps_run": len(pairs) - args.reps,
                     "confirmation_triggered": confirmation_triggered,
                     "primary_stats": primary_stats,
+                    "aggregate_liveness": aggregate_liveness,
                     **stats,
                 }
                 verdict = "PASS"

--- a/tests/sampled_overhead_gate.py
+++ b/tests/sampled_overhead_gate.py
@@ -305,7 +305,7 @@ def structural_errors(args, workload, metrics, shapes):
     stderr = metrics.get("tracer_stderr_tail", "")
     hooks = {
         "PGWT_TEST_SAMPLED_UPROBES": "restoring always-on sampled attribution traps",
-        "PGWT_TEST_PGSS_UNTHROTTLED": "restoring pre-throttle 32-key pgss scans",
+        "PGWT_TEST_PGSS_UNTHROTTLED": "restoring pre-throttle 32-key pgss scan storm",
     }
     enabled = {item.partition("=")[0] for item in args.tracer_env}
     for name, marker in hooks.items():

--- a/tests/sampled_overhead_gate.py
+++ b/tests/sampled_overhead_gate.py
@@ -14,7 +14,6 @@ Use --characterize to report data without applying the timing threshold.
 """
 
 import argparse
-import contextlib
 import fcntl
 import json
 import math
@@ -161,7 +160,13 @@ def workload_argv(args, workload, scripts):
 
 
 def reset_pgss(args):
-    psql(args, "SELECT pg_stat_statements_reset()", database=args.database)
+    # Three-argument form is available on every supported PG13+ version and
+    # scopes the reset to this invocation's database.  A zero-argument reset
+    # would erase statistics for unrelated databases on a shared box.
+    psql(args, "SELECT pg_stat_statements_reset("
+          "0, (SELECT oid FROM pg_database "
+          "WHERE datname = current_database()), 0)",
+          database=args.database)
 
 
 def run_pgbench(args, workload, scripts, duration, *, warmup=False):
@@ -217,6 +222,8 @@ def measured_run(args, workload, scripts, sampled):
         return tps, metrics, shapes
     finally:
         stderr = stop_tracer(proc, trace_dir)
+        if metrics is not None:
+            metrics["tracer_stderr_tail"] = stderr[-4000:]
         if proc is not None and proc.returncode not in (0, -15):
             raise GateError(f"tracer failed ({proc.returncode}): {stderr[-2000:]}")
 
@@ -256,6 +263,19 @@ def structural_errors(args, workload, metrics, shapes):
     validation = metrics.get("pgbackend_layout_validation")
     if validation != "validated":
         errors.append(f"layout is {validation!r}, expected 'validated'")
+    if int(metrics.get("pg_pid", -1)) != args.pid:
+        errors.append(f"tracer reports postmaster {metrics.get('pg_pid')}, "
+                      f"expected {args.pid}")
+    if metrics.get("mode") != "sampled" or metrics.get("tier") != "sampled":
+        errors.append(f"tracer is not pure sampled mode/tier: "
+                      f"{metrics.get('mode')}/{metrics.get('tier')}")
+    if metrics.get("sampler_healthy") is not True:
+        errors.append("sampled provider reports unhealthy reads")
+    if metrics.get("sampled_attr_source") != "pgbackend_status":
+        errors.append(f"sampled attribution source is "
+                      f"{metrics.get('sampled_attr_source')!r}")
+    if int(metrics.get("samples_total", 0)) <= 0:
+        errors.append("sampled provider produced zero samples")
     qfires = int(metrics.get("exact_query_uprobe_fires_total", -1))
     afires = int(metrics.get("exact_activity_uprobe_fires_total", -1))
     mask = int(metrics.get("exact_probe_attached_mask", -1))
@@ -266,14 +286,58 @@ def structural_errors(args, workload, metrics, shapes):
         if shapes < args.min_distinct_shapes:
             errors.append(f"only {shapes} distinct query shapes; "
                           f"need >= {args.min_distinct_shapes}")
-        if "sampled_text_pgss_scans_total" in metrics:
+        required = ("sampled_text_pgss_scans_total",
+                    "sampled_text_resolved_total")
+        missing = [name for name in required if name not in metrics]
+        if missing:
+            errors.append(f"missing mandatory resolver metrics: {missing}")
+        else:
             scans = int(metrics["sampled_text_pgss_scans_total"])
+            resolved = int(metrics["sampled_text_resolved_total"])
             uptime = float(metrics.get("uptime_s", 0))
             allowed = math.ceil(uptime * args.max_pgss_scans_per_sec) + 1
+            if scans <= 0 or resolved <= 0:
+                errors.append(f"pgss resolver was not exercised: "
+                              f"scans={scans} resolved={resolved}")
             if scans > allowed:
                 errors.append(f"pgss scan rate unbounded: {scans} scans in "
                               f"{uptime:.2f}s (allowed {allowed})")
+    stderr = metrics.get("tracer_stderr_tail", "")
+    hooks = {
+        "PGWT_TEST_SAMPLED_UPROBES": "restoring always-on sampled attribution traps",
+        "PGWT_TEST_PGSS_UNTHROTTLED": "restoring pre-throttle 32-key pgss scans",
+    }
+    enabled = {item.partition("=")[0] for item in args.tracer_env}
+    for name, marker in hooks.items():
+        if name in enabled and marker not in stderr:
+            errors.append(f"injected hook {name} did not report activation")
     return errors
+
+
+def run_pair(args, workload, scripts, rep):
+    order = (False, True) if rep % 2 else (True, False)
+    values = {}
+    sampled_metrics = None
+    shapes = 0
+    for sampled in order:
+        tps, metrics, observed_shapes = measured_run(
+            args, workload, scripts, sampled)
+        values[sampled] = tps
+        if sampled:
+            sampled_metrics = metrics
+            shapes = observed_shapes
+    overhead = 100.0 * (1.0 - values[True] / values[False])
+    pair = {
+        "pair": rep,
+        "order": "AB" if order[0] is False else "BA",
+        "baseline_tps": values[False],
+        "sampled_tps": values[True],
+        "overhead_pct": overhead,
+        "distinct_shapes": shapes,
+        "metrics": sampled_metrics,
+    }
+    errors = structural_errors(args, workload, sampled_metrics, shapes)
+    return pair, errors
 
 
 def setup_database(args):
@@ -295,9 +359,10 @@ def setup_database(args):
     exists = psql(args, "SELECT 1 FROM pg_database WHERE datname = "
                   + "'" + args.database.replace("'", "''") + "'")
     if exists:
-        psql(args, f"DROP DATABASE {quote_ident(args.database)} WITH (FORCE)",
-             tuples=False)
+        raise GateError(f"refusing to replace pre-existing database "
+                        f"{args.database!r}")
     psql(args, f"CREATE DATABASE {quote_ident(args.database)}", tuples=False)
+    args.database_created = True
     psql(args, "CREATE EXTENSION pg_stat_statements", database=args.database,
          tuples=False)
     run([args.pgbench, "-i", "-q", "-s", str(args.scale), "-h", args.host,
@@ -307,9 +372,8 @@ def setup_database(args):
 
 
 def drop_database(args):
-    with contextlib.suppress(Exception):
-        psql(args, f"DROP DATABASE {quote_ident(args.database)} WITH (FORCE)",
-             tuples=False)
+    psql(args, f"DROP DATABASE {quote_ident(args.database)} WITH (FORCE)",
+         tuples=False)
 
 
 def main():
@@ -319,19 +383,25 @@ def main():
     parser.add_argument("--port", type=int, default=5432)
     parser.add_argument("--host", default="/var/run/postgresql")
     parser.add_argument("--user", default="postgres")
-    parser.add_argument("--database", default="pgwt_sampled_overhead_gate")
+    parser.add_argument("--database",
+                        help="new dedicated database name (default: run-unique)")
     parser.add_argument("--psql", default="psql")
     parser.add_argument("--pgbench", default="pgbench")
     parser.add_argument("--reps", type=int, default=7)
+    parser.add_argument("--confirm-reps", type=int, default=7,
+                        help="extra pairs after a candidate hard failure")
     parser.add_argument("--duration", type=int, default=10)
     parser.add_argument("--warmup", type=int, default=2)
     parser.add_argument("--clients", type=int, default=4)
     parser.add_argument("--jobs", type=int, default=4)
     parser.add_argument("--scale", type=int, default=10)
     parser.add_argument("--high-cardinality-shapes", type=int, default=256)
-    parser.add_argument("--min-distinct-shapes", type=int, default=128)
-    parser.add_argument("--max-overhead-pct", type=float, default=15.0)
-    parser.add_argument("--warn-overhead-pct", type=float, default=8.0)
+    parser.add_argument("--min-distinct-shapes", type=int, default=0,
+                        help="required observed shapes (default: 90%% of corpus)")
+    parser.add_argument("--max-overhead-pct", type=float, default=15.0,
+                        help="hard-fail paired-median TPS loss")
+    parser.add_argument("--warn-overhead-pct", type=float, default=10.0,
+                        help="nonblocking paired-median warning band")
     parser.add_argument("--max-pgss-scans-per-sec", type=float, default=1.0)
     parser.add_argument("--workloads", nargs="+", choices=DEFAULT_WORKLOADS,
                         default=list(DEFAULT_WORKLOADS))
@@ -341,12 +411,25 @@ def main():
     parser.add_argument("--tracer-env", action="append", default=[])
     args = parser.parse_args()
 
+    if args.database is None:
+        args.database = f"pgwt_sampled_overhead_{args.pid}_{os.getpid()}"
+    args.database_created = False
+    if args.min_distinct_shapes == 0:
+        args.min_distinct_shapes = math.ceil(
+            args.high_cardinality_shapes * 0.9)
+
     if os.geteuid() != 0:
         raise GateError("must run as root")
     if not TRACER.is_file() or not os.access(TRACER, os.X_OK):
         raise GateError(f"build first: {TRACER} is not executable")
-    if args.reps < 3 or args.duration < 1 or args.warmup < 0:
-        raise GateError("need >=3 reps, positive duration, nonnegative warmup")
+    if (args.reps < 3 or args.confirm_reps < 0 or args.duration < 1 or
+            args.warmup < 0):
+        raise GateError("need >=3 reps, nonnegative confirmation/warmup, "
+                        "and positive duration")
+    if (args.warn_overhead_pct >= args.max_overhead_pct or
+            args.max_pgss_scans_per_sec <= 0):
+        raise GateError("warning threshold must be below the hard threshold "
+                        "and the pgss scan-rate limit must be positive")
 
     lock_path = f"/tmp/pgwt_sampled_overhead_gate_{args.port}.lock"
     with open(lock_path, "w", encoding="utf-8") as lock:
@@ -358,63 +441,90 @@ def main():
         workdir = Path(tempfile.mkdtemp(prefix="pgwt_overhead_workload_"))
         scripts = high_cardinality_scripts(
             workdir, args.high_cardinality_shapes)
-        report = {"config": vars(args), "workloads": {},
-                  "structural_failures": []}
+        report = {"config": dict(vars(args)), "workloads": {},
+                  "structural_failures": [], "timing_failures": [],
+                  "timing_warnings": []}
         failed = False
         try:
             version = setup_database(args)
             report["postgres_major"] = version
             print(f"sampled-overhead: PG{version} port={args.port} "
-                  f"pairs={args.reps} duration={args.duration}s "
+                  f"pairs={args.reps}+{args.confirm_reps}-on-fail "
+                  f"duration={args.duration}s "
                   f"clients/jobs={args.clients}/{args.jobs}")
             for workload in args.workloads:
                 pairs = []
                 for rep in range(1, args.reps + 1):
-                    order = (False, True) if rep % 2 else (True, False)
-                    values = {}
-                    rep_metrics = None
-                    shapes = 0
-                    for sampled in order:
-                        tps, metrics, observed_shapes = measured_run(
-                            args, workload, scripts, sampled)
-                        values[sampled] = tps
-                        if sampled:
-                            rep_metrics = metrics
-                            shapes = observed_shapes
-                    overhead = 100.0 * (1.0 - values[True] / values[False])
-                    structural = structural_errors(
-                        args, workload, rep_metrics, shapes)
+                    pair, structural = run_pair(
+                        args, workload, scripts, rep)
                     report["structural_failures"] += [
                         f"{workload} pair {rep}: {error}" for error in structural]
                     failed |= bool(structural)
-                    pairs.append({
-                        "pair": rep,
-                        "order": "AB" if order[0] is False else "BA",
-                        "baseline_tps": values[False],
-                        "sampled_tps": values[True],
-                        "overhead_pct": overhead,
-                        "distinct_shapes": shapes,
-                        "metrics": rep_metrics,
-                    })
+                    pairs.append(pair)
                     print(f"  {workload:16s} pair={rep} "
-                          f"order={pairs[-1]['order']} overhead={overhead:+.2f}%")
-                stats = summarize([pair["overhead_pct"] for pair in pairs])
-                report["workloads"][workload] = {"pairs": pairs, **stats}
+                          f"order={pair['order']} "
+                          f"overhead={pair['overhead_pct']:+.2f}%")
+                primary_stats = summarize(
+                    [pair["overhead_pct"] for pair in pairs])
+                confirmation_triggered = (
+                    not args.characterize and args.confirm_reps > 0 and
+                    primary_stats["median_pct"] >= args.max_overhead_pct)
+                if confirmation_triggered:
+                    print(f"  {workload:16s} candidate hard failure "
+                          f"({primary_stats['median_pct']:+.2f}%); "
+                          f"running {args.confirm_reps} confirmation pairs")
+                    first = args.reps + 1
+                    for rep in range(first, first + args.confirm_reps):
+                        pair, structural = run_pair(
+                            args, workload, scripts, rep)
+                        report["structural_failures"] += [
+                            f"{workload} pair {rep}: {error}"
+                            for error in structural]
+                        failed |= bool(structural)
+                        pairs.append(pair)
+                        print(f"  {workload:16s} pair={rep} "
+                              f"order={pair['order']} "
+                              f"overhead={pair['overhead_pct']:+.2f}%")
+                stats = summarize(
+                    [pair["overhead_pct"] for pair in pairs])
+                report["workloads"][workload] = {
+                    "pairs": pairs,
+                    "primary_reps": args.reps,
+                    "confirmation_reps_run": len(pairs) - args.reps,
+                    "confirmation_triggered": confirmation_triggered,
+                    "primary_stats": primary_stats,
+                    **stats,
+                }
                 verdict = "PASS"
                 if stats["median_pct"] >= args.max_overhead_pct:
                     verdict = "FAIL"
+                    report["timing_failures"].append(
+                        f"{workload}: median {stats['median_pct']:.2f}% >= "
+                        f"{args.max_overhead_pct:.2f}%")
                     if not args.characterize:
                         failed = True
                 elif stats["median_pct"] >= args.warn_overhead_pct:
                     verdict = "WARN"
+                    report["timing_warnings"].append(
+                        f"{workload}: median {stats['median_pct']:.2f}% >= "
+                        f"{args.warn_overhead_pct:.2f}%")
                 print(f"  {workload:16s} median={stats['median_pct']:+.2f}% "
                       f"IQR={stats['iqr_pct']:.2f}pp "
                       f"range=[{stats['min_pct']:+.2f},{stats['max_pct']:+.2f}] "
                       f"{verdict if not args.characterize else 'CHARACTERIZE'}")
         finally:
-            if not args.keep_database:
-                drop_database(args)
-            shutil.rmtree(workdir, ignore_errors=True)
+            active_error = sys.exc_info()[0] is not None
+            try:
+                if args.database_created and not args.keep_database:
+                    drop_database(args)
+            except Exception as cleanup_error:
+                if active_error:
+                    print(f"sampled-overhead: cleanup also failed: "
+                          f"{cleanup_error}", file=sys.stderr)
+                else:
+                    raise
+            finally:
+                shutil.rmtree(workdir, ignore_errors=True)
 
         report["verdict"] = "fail" if failed else "pass"
         if args.output_json:
@@ -423,6 +533,10 @@ def main():
                 encoding="utf-8")
         for error in report["structural_failures"]:
             print(f"  STRUCTURAL FAIL: {error}")
+        for warning in report["timing_warnings"]:
+            print(f"  TIMING WARN: {warning}")
+            if os.environ.get("GITHUB_ACTIONS"):
+                print(f"::warning title=Sampled overhead::{warning}")
         if failed:
             print("sampled-overhead: FAIL")
             return 1

--- a/tests/sampled_overhead_gate.py
+++ b/tests/sampled_overhead_gate.py
@@ -1,0 +1,438 @@
+#!/usr/bin/env python3
+"""Paired A/B regression gate for the always-on sampled capture tier.
+
+This is intentionally a coarse catastrophic-regression gate, not a claim that
+shared-runner timing can prove the sampled tier's sub-1% overhead target.  Each
+pair runs no-tracer and sampled measurements back-to-back, alternates AB/BA
+order, and gates on the median paired TPS loss.  Standard read-only and
+read-write pgbench are joined by a mandatory many-query-shape workload because
+ordinary pgbench cannot expose pg_stat_statements resolver scan storms.
+
+Run as root against a dedicated PostgreSQL port/postmaster.  The script creates
+and removes one dedicated database and never restarts or reconfigures PostgreSQL.
+Use --characterize to report data without applying the timing threshold.
+"""
+
+import argparse
+import contextlib
+import fcntl
+import json
+import math
+import os
+import re
+import shutil
+import socket
+import statistics
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+
+PROJECT_DIR = Path(__file__).resolve().parent.parent
+TRACER = PROJECT_DIR / "pg_wait_tracer"
+DEFAULT_WORKLOADS = ("ro", "rw", "high-cardinality")
+TPS_RE = re.compile(r"^tps = ([0-9.]+) ", re.MULTILINE)
+
+
+class GateError(RuntimeError):
+    pass
+
+
+def run(argv, *, env=None, timeout=120, check=True, capture=True):
+    result = subprocess.run(
+        [str(v) for v in argv], env=env, timeout=timeout, check=False,
+        text=True, stdout=subprocess.PIPE if capture else None,
+        stderr=subprocess.PIPE if capture else None)
+    if check and result.returncode:
+        detail = ((result.stderr or "") + (result.stdout or ""))[-2000:]
+        shown = " ".join(map(str, argv[:24]))
+        if len(argv) > 24:
+            shown += f" ... ({len(argv) - 24} more arguments)"
+        raise GateError(f"command failed ({result.returncode}): "
+                        f"{shown}\n{detail}")
+    return result
+
+
+def psql(args, sql, *, database="postgres", tuples=True, timeout=30):
+    argv = [args.psql, "-X", "-v", "ON_ERROR_STOP=1", "-h", args.host,
+            "-p", str(args.port), "-U", args.user, "-d", database]
+    if tuples:
+        argv += ["-tA"]
+    argv += ["-c", sql]
+    return run(argv, timeout=timeout).stdout.strip()
+
+
+def quote_ident(value):
+    return '"' + value.replace('"', '""') + '"'
+
+
+def wait_for_socket(proc, trace_dir, timeout=12):
+    path = trace_dir / "pgwt.sock"
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if path.exists():
+            return
+        if proc.poll() is not None:
+            _, stderr = proc.communicate()
+            raise GateError("tracer exited before control socket: " +
+                            stderr.decode(errors="replace")[-2000:])
+        time.sleep(0.05)
+    raise GateError("tracer control socket did not appear")
+
+
+def control(trace_dir, command):
+    client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    client.settimeout(5)
+    try:
+        client.connect(str(trace_dir / "pgwt.sock"))
+        client.sendall((json.dumps({"cmd": command}) + "\n").encode())
+        data = b""
+        while b"\n" not in data:
+            chunk = client.recv(65536)
+            if not chunk:
+                break
+            data += chunk
+        if not data:
+            raise GateError("empty tracer control response")
+        response = json.loads(data.splitlines()[0])
+        if not response.get("ok"):
+            raise GateError(f"tracer control error: {response}")
+        return response
+    finally:
+        client.close()
+
+
+def stop_tracer(proc, trace_dir):
+    stderr = b""
+    if proc is not None:
+        if proc.poll() is None:
+            proc.terminate()
+        try:
+            _, stderr = proc.communicate(timeout=10)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            _, stderr = proc.communicate(timeout=5)
+    shutil.rmtree(trace_dir, ignore_errors=True)
+    return stderr.decode(errors="replace")
+
+
+def high_cardinality_scripts(root, count):
+    """Create cheap but structurally distinct point-query pgbench scripts."""
+    expressions = (
+        "aid + 0", "aid - 0", "aid * 1", "aid / 1",
+        "aid % 2147483647", "aid & 2147483647", "aid | 0", "aid # 0",
+        "abs(aid)", "greatest(aid, 0)",
+    )
+    if count > (1 << len(expressions)):
+        raise GateError(f"high-cardinality shapes must be <= {1 << len(expressions)}")
+    paths = []
+    shapes_per_script = 4
+    for first in range(0, count, shapes_per_script):
+        group = range(first, min(first + shapes_per_script, count))
+        lines = ["\\set aid random(1, 100000 * :scale)",
+                 f"\\set variant random(0, {len(group) - 1})"]
+        for variant, shape in enumerate(group):
+            lines.append(("\\if" if variant == 0 else "\\elif") +
+                         f" :variant = {variant}")
+            targets = ["abalance"]
+            targets += [expr for bit, expr in enumerate(expressions)
+                        if shape & (1 << bit)]
+            lines.append(f"SELECT {', '.join(targets)} "
+                         "FROM pgbench_accounts WHERE aid = :aid;")
+        lines.append("\\endif")
+        path = root / f"shapes-{first:04d}.sql"
+        path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+        paths.append(path)
+    return paths
+
+
+def workload_argv(args, workload, scripts):
+    argv = [args.pgbench, "-n", "-h", args.host, "-p", str(args.port),
+            "-U", args.user, "-d", args.database, "-c", str(args.clients),
+            "-j", str(args.jobs)]
+    if workload == "ro":
+        argv.append("-S")
+    elif workload == "high-cardinality":
+        for path in scripts:
+            argv += ["-f", path]
+    return argv
+
+
+def reset_pgss(args):
+    psql(args, "SELECT pg_stat_statements_reset()", database=args.database)
+
+
+def run_pgbench(args, workload, scripts, duration, *, warmup=False):
+    argv = workload_argv(args, workload, scripts) + ["-T", str(duration)]
+    result = run(argv, timeout=duration + 90)
+    values = TPS_RE.findall(result.stdout)
+    if not values:
+        raise GateError(f"pgbench produced no TPS for {workload}: "
+                        f"{(result.stderr + result.stdout)[-2000:]}")
+    return float(values[-1])
+
+
+def distinct_shapes(args):
+    sql = """
+        SELECT count(*)
+          FROM pg_stat_statements
+         WHERE dbid = (SELECT oid FROM pg_database
+                        WHERE datname = current_database())
+           AND query LIKE 'SELECT %pgbench_accounts%aid = $%'
+    """
+    value = psql(args, sql, database=args.database)
+    return int(value or 0)
+
+
+def measured_run(args, workload, scripts, sampled):
+    reset_pgss(args)
+    proc = None
+    trace_dir = Path(tempfile.mkdtemp(prefix="pgwt_sampled_overhead_"))
+    metrics = None
+    stderr = ""
+    try:
+        if sampled:
+            env = os.environ.copy()
+            for item in args.tracer_env:
+                name, sep, value = item.partition("=")
+                if not sep or not name.startswith("PGWT_TEST_"):
+                    raise GateError("--tracer-env requires PGWT_TEST_NAME=value")
+                env[name] = value
+            proc = subprocess.Popen(
+                [str(TRACER), "--mode", "sampled", "--pid", str(args.pid),
+                 "--trace-dir", str(trace_dir), "--duration",
+                 str(args.warmup + args.duration + 30), "--interval", "1",
+                 "--quiet"], stdout=subprocess.DEVNULL,
+                stderr=subprocess.PIPE, env=env)
+            wait_for_socket(proc, trace_dir)
+        if args.warmup:
+            run_pgbench(args, workload, scripts, args.warmup, warmup=True)
+        tps = run_pgbench(args, workload, scripts, args.duration)
+        shapes = distinct_shapes(args) if workload == "high-cardinality" else 0
+        if sampled:
+            metrics = control(trace_dir, "metrics")
+            metrics.update(control(trace_dir, "status"))
+        return tps, metrics, shapes
+    finally:
+        stderr = stop_tracer(proc, trace_dir)
+        if proc is not None and proc.returncode not in (0, -15):
+            raise GateError(f"tracer failed ({proc.returncode}): {stderr[-2000:]}")
+
+
+def percentile(values, fraction):
+    ordered = sorted(values)
+    if len(ordered) == 1:
+        return ordered[0]
+    point = fraction * (len(ordered) - 1)
+    lo = math.floor(point)
+    hi = math.ceil(point)
+    if lo == hi:
+        return ordered[lo]
+    return ordered[lo] + (ordered[hi] - ordered[lo]) * (point - lo)
+
+
+def summarize(values):
+    med = statistics.median(values)
+    q1 = percentile(values, 0.25)
+    q3 = percentile(values, 0.75)
+    return {
+        "median_pct": med,
+        "q1_pct": q1,
+        "q3_pct": q3,
+        "iqr_pct": q3 - q1,
+        "min_pct": min(values),
+        "max_pct": max(values),
+        "prefix_medians_pct": [statistics.median(values[:n])
+                                for n in range(3, len(values) + 1)],
+    }
+
+
+def structural_errors(args, workload, metrics, shapes):
+    errors = []
+    if not metrics:
+        return ["sampled run returned no metrics"]
+    validation = metrics.get("pgbackend_layout_validation")
+    if validation != "validated":
+        errors.append(f"layout is {validation!r}, expected 'validated'")
+    qfires = int(metrics.get("exact_query_uprobe_fires_total", -1))
+    afires = int(metrics.get("exact_activity_uprobe_fires_total", -1))
+    mask = int(metrics.get("exact_probe_attached_mask", -1))
+    if (qfires, afires, mask) != (0, 0, 0):
+        errors.append(f"sampled exact probes fired/attached: "
+                      f"query={qfires} activity={afires} mask={mask}")
+    if workload == "high-cardinality":
+        if shapes < args.min_distinct_shapes:
+            errors.append(f"only {shapes} distinct query shapes; "
+                          f"need >= {args.min_distinct_shapes}")
+        if "sampled_text_pgss_scans_total" in metrics:
+            scans = int(metrics["sampled_text_pgss_scans_total"])
+            uptime = float(metrics.get("uptime_s", 0))
+            allowed = math.ceil(uptime * args.max_pgss_scans_per_sec) + 1
+            if scans > allowed:
+                errors.append(f"pgss scan rate unbounded: {scans} scans in "
+                              f"{uptime:.2f}s (allowed {allowed})")
+    return errors
+
+
+def setup_database(args):
+    version = int(psql(args, "SHOW server_version_num")) // 10000
+    port = int(psql(args, "SHOW port"))
+    if port != args.port:
+        raise GateError(f"connected server reports port {port}, expected {args.port}")
+    if args.pg_version and version != args.pg_version:
+        raise GateError(f"connected PG{version}, expected PG{args.pg_version}")
+    data_dir = Path(psql(args, "SHOW data_directory"))
+    try:
+        server_pid = int((data_dir / "postmaster.pid").read_text(
+            encoding="utf-8").splitlines()[0])
+    except (OSError, ValueError, IndexError) as exc:
+        raise GateError(f"cannot validate postmaster.pid in {data_dir}") from exc
+    if server_pid != args.pid:
+        raise GateError(f"port {port} belongs to postmaster {server_pid}, "
+                        f"not requested PID {args.pid}")
+    exists = psql(args, "SELECT 1 FROM pg_database WHERE datname = "
+                  + "'" + args.database.replace("'", "''") + "'")
+    if exists:
+        psql(args, f"DROP DATABASE {quote_ident(args.database)} WITH (FORCE)",
+             tuples=False)
+    psql(args, f"CREATE DATABASE {quote_ident(args.database)}", tuples=False)
+    psql(args, "CREATE EXTENSION pg_stat_statements", database=args.database,
+         tuples=False)
+    run([args.pgbench, "-i", "-q", "-s", str(args.scale), "-h", args.host,
+         "-p", str(args.port), "-U", args.user, "-d", args.database],
+        timeout=300)
+    return version
+
+
+def drop_database(args):
+    with contextlib.suppress(Exception):
+        psql(args, f"DROP DATABASE {quote_ident(args.database)} WITH (FORCE)",
+             tuples=False)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--pid", type=int, required=True)
+    parser.add_argument("--pg-version", type=int, default=0)
+    parser.add_argument("--port", type=int, default=5432)
+    parser.add_argument("--host", default="/var/run/postgresql")
+    parser.add_argument("--user", default="postgres")
+    parser.add_argument("--database", default="pgwt_sampled_overhead_gate")
+    parser.add_argument("--psql", default="psql")
+    parser.add_argument("--pgbench", default="pgbench")
+    parser.add_argument("--reps", type=int, default=7)
+    parser.add_argument("--duration", type=int, default=10)
+    parser.add_argument("--warmup", type=int, default=2)
+    parser.add_argument("--clients", type=int, default=4)
+    parser.add_argument("--jobs", type=int, default=4)
+    parser.add_argument("--scale", type=int, default=10)
+    parser.add_argument("--high-cardinality-shapes", type=int, default=256)
+    parser.add_argument("--min-distinct-shapes", type=int, default=128)
+    parser.add_argument("--max-overhead-pct", type=float, default=15.0)
+    parser.add_argument("--warn-overhead-pct", type=float, default=8.0)
+    parser.add_argument("--max-pgss-scans-per-sec", type=float, default=1.0)
+    parser.add_argument("--workloads", nargs="+", choices=DEFAULT_WORKLOADS,
+                        default=list(DEFAULT_WORKLOADS))
+    parser.add_argument("--characterize", action="store_true")
+    parser.add_argument("--keep-database", action="store_true")
+    parser.add_argument("--output-json")
+    parser.add_argument("--tracer-env", action="append", default=[])
+    args = parser.parse_args()
+
+    if os.geteuid() != 0:
+        raise GateError("must run as root")
+    if not TRACER.is_file() or not os.access(TRACER, os.X_OK):
+        raise GateError(f"build first: {TRACER} is not executable")
+    if args.reps < 3 or args.duration < 1 or args.warmup < 0:
+        raise GateError("need >=3 reps, positive duration, nonnegative warmup")
+
+    lock_path = f"/tmp/pgwt_sampled_overhead_gate_{args.port}.lock"
+    with open(lock_path, "w", encoding="utf-8") as lock:
+        try:
+            fcntl.flock(lock, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError as exc:
+            raise GateError(f"another gate owns PostgreSQL port {args.port}") from exc
+
+        workdir = Path(tempfile.mkdtemp(prefix="pgwt_overhead_workload_"))
+        scripts = high_cardinality_scripts(
+            workdir, args.high_cardinality_shapes)
+        report = {"config": vars(args), "workloads": {},
+                  "structural_failures": []}
+        failed = False
+        try:
+            version = setup_database(args)
+            report["postgres_major"] = version
+            print(f"sampled-overhead: PG{version} port={args.port} "
+                  f"pairs={args.reps} duration={args.duration}s "
+                  f"clients/jobs={args.clients}/{args.jobs}")
+            for workload in args.workloads:
+                pairs = []
+                for rep in range(1, args.reps + 1):
+                    order = (False, True) if rep % 2 else (True, False)
+                    values = {}
+                    rep_metrics = None
+                    shapes = 0
+                    for sampled in order:
+                        tps, metrics, observed_shapes = measured_run(
+                            args, workload, scripts, sampled)
+                        values[sampled] = tps
+                        if sampled:
+                            rep_metrics = metrics
+                            shapes = observed_shapes
+                    overhead = 100.0 * (1.0 - values[True] / values[False])
+                    structural = structural_errors(
+                        args, workload, rep_metrics, shapes)
+                    report["structural_failures"] += [
+                        f"{workload} pair {rep}: {error}" for error in structural]
+                    failed |= bool(structural)
+                    pairs.append({
+                        "pair": rep,
+                        "order": "AB" if order[0] is False else "BA",
+                        "baseline_tps": values[False],
+                        "sampled_tps": values[True],
+                        "overhead_pct": overhead,
+                        "distinct_shapes": shapes,
+                        "metrics": rep_metrics,
+                    })
+                    print(f"  {workload:16s} pair={rep} "
+                          f"order={pairs[-1]['order']} overhead={overhead:+.2f}%")
+                stats = summarize([pair["overhead_pct"] for pair in pairs])
+                report["workloads"][workload] = {"pairs": pairs, **stats}
+                verdict = "PASS"
+                if stats["median_pct"] >= args.max_overhead_pct:
+                    verdict = "FAIL"
+                    if not args.characterize:
+                        failed = True
+                elif stats["median_pct"] >= args.warn_overhead_pct:
+                    verdict = "WARN"
+                print(f"  {workload:16s} median={stats['median_pct']:+.2f}% "
+                      f"IQR={stats['iqr_pct']:.2f}pp "
+                      f"range=[{stats['min_pct']:+.2f},{stats['max_pct']:+.2f}] "
+                      f"{verdict if not args.characterize else 'CHARACTERIZE'}")
+        finally:
+            if not args.keep_database:
+                drop_database(args)
+            shutil.rmtree(workdir, ignore_errors=True)
+
+        report["verdict"] = "fail" if failed else "pass"
+        if args.output_json:
+            Path(args.output_json).write_text(
+                json.dumps(report, indent=2, sort_keys=True) + "\n",
+                encoding="utf-8")
+        for error in report["structural_failures"]:
+            print(f"  STRUCTURAL FAIL: {error}")
+        if failed:
+            print("sampled-overhead: FAIL")
+            return 1
+        print("sampled-overhead: PASS")
+        return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except (GateError, OSError, ValueError) as exc:
+        print(f"sampled-overhead: ERROR: {exc}", file=sys.stderr)
+        sys.exit(2)

--- a/tests/test_exact_probe.c
+++ b/tests/test_exact_probe.c
@@ -80,12 +80,17 @@ static void test_policy(void)
     degraded13.validation = PGWT_PGBS_VALIDATION_DEGRADED;
     struct PgBackendStatusLayout missing_anchor13 = valid13;
     missing_anchor13.status_anchor = 0;
-    CHECK(pgwt_exact_probe_startup_mask(PGWT_MODE_SAMPLED, 17, &valid,
-                                       false, false) == 0,
-          "validated PG17 sampled has zero exact links");
-    CHECK(pgwt_exact_probe_startup_mask(PGWT_MODE_TIERED, 17, &valid,
-                                       false, false) == 0,
-          "validated PG17 tiered baseline has zero exact links");
+    for (int major = 14; major <= 18; major++) {
+        struct PgBackendStatusLayout version_valid = validated_layout(major);
+        CHECK(pgwt_exact_probe_startup_mask(
+                  PGWT_MODE_SAMPLED, major, &version_valid,
+                  false, false) == 0,
+              "validated PG14-18 sampled has zero exact links");
+        CHECK(pgwt_exact_probe_startup_mask(
+                  PGWT_MODE_TIERED, major, &version_valid,
+                  false, false) == 0,
+              "validated PG14-18 tiered baseline has zero exact links");
+    }
     CHECK(pgwt_exact_probe_startup_mask(PGWT_MODE_SAMPLED, 17, &degraded,
                                        false, false) ==
               PGWT_EXACT_PROBE_ATTR_MASK,
@@ -93,6 +98,9 @@ static void test_policy(void)
     CHECK(pgwt_exact_probe_startup_mask(PGWT_MODE_TIERED, 13, &valid13,
                                        false, false) == 0,
           "validated PG13 activity-text path has zero sampled exact links");
+    CHECK(pgwt_exact_probe_startup_mask(PGWT_MODE_SAMPLED, 13, &valid13,
+                                       false, false) == 0,
+          "validated PG13 sampled path has zero exact links");
     CHECK(pgwt_exact_probe_startup_mask(PGWT_MODE_TIERED, 13, &degraded13,
                                        false, false) ==
               PGWT_EXACT_PROBE_ATTR_MASK,

--- a/tests/test_sampled_overhead_gate.py
+++ b/tests/test_sampled_overhead_gate.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Synthetic policy tests for the sampled-overhead gate."""
+
+import unittest
+from types import SimpleNamespace
+
+from sampled_overhead_gate import aggregate_liveness_errors, structural_errors
+
+
+def valid_metrics(*, scans=1, resolved=1, query_fires=0, mask=0):
+    return {
+        "pgbackend_layout_validation": "validated",
+        "pg_pid": 1234,
+        "mode": "sampled",
+        "tier": "sampled",
+        "sampler_healthy": True,
+        "sampled_attr_source": "pgbackend_status",
+        "samples_total": 1,
+        "exact_query_uprobe_fires_total": query_fires,
+        "exact_activity_uprobe_fires_total": 0,
+        "exact_probe_attached_mask": mask,
+        "sampled_text_pgss_scans_total": scans,
+        "sampled_text_resolved_total": resolved,
+        "uptime_s": 12.0,
+    }
+
+
+class SampledOverheadPolicyTest(unittest.TestCase):
+    def setUp(self):
+        self.args = SimpleNamespace(
+            pid=1234,
+            min_distinct_shapes=231,
+            max_pgss_scans_per_sec=1.0,
+            tracer_env=[],
+        )
+
+    @staticmethod
+    def pair(metrics, shapes):
+        return {"metrics": metrics, "distinct_shapes": shapes}
+
+    def test_one_starved_pair_does_not_fail_aggregate_liveness(self):
+        starved = valid_metrics(scans=0, resolved=0)
+        exercised = valid_metrics(scans=1, resolved=200)
+
+        self.assertEqual(
+            structural_errors(self.args, "high-cardinality", starved, 0), [])
+        summary, errors = aggregate_liveness_errors(
+            self.args, "high-cardinality",
+            [self.pair(starved, 0), self.pair(exercised, 256)])
+
+        self.assertEqual(errors, [])
+        self.assertEqual(summary["max_distinct_shapes"], 256)
+        self.assertEqual(summary["total_pgss_scans"], 1)
+        self.assertEqual(summary["total_resolved"], 200)
+
+    def test_all_starved_pairs_fail_aggregate_liveness(self):
+        starved = valid_metrics(scans=0, resolved=0)
+        _, errors = aggregate_liveness_errors(
+            self.args, "high-cardinality",
+            [self.pair(starved, 0), self.pair(starved, 100)])
+
+        self.assertEqual(len(errors), 3)
+
+    def test_scan_rate_and_exact_probe_teeth_remain_per_pair(self):
+        storm = valid_metrics(scans=20, resolved=200)
+        probe = valid_metrics(query_fires=1, mask=1)
+
+        self.assertTrue(any(
+            "scan rate unbounded" in error for error in
+            structural_errors(self.args, "high-cardinality", storm, 256)))
+        self.assertTrue(any(
+            "exact probes fired/attached" in error for error in
+            structural_errors(self.args, "high-cardinality", probe, 256)))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit_tests.list
+++ b/tests/unit_tests.list
@@ -30,4 +30,5 @@ test_pg13_resolve
 test_discovery_pie
 test_discovery_nopie
 test_replay_fidelity
+test_sampled_overhead_gate.py
 test_data_query_text_context.py


### PR DESCRIPTION
## Summary

Adds a permanent two-layer sampled-overhead regression gate:

- paired A/B timing for pgbench RO, RW, and 256 distinct high-cardinality shapes
- deterministic structural guards for zero sampled query/activity uprobes, bounded actual pg_stat_statements scans, validated sampler/layout/PID, and PG13 async persistence
- blocking PostgreSQL 17 GitHub job with JSON evidence artifacts
- loud test-only fault hooks that prove both historical regression classes make the gate red

## Root cause

The previous overhead test exercised full mode with unpaired ordinary pgbench blocks. It could not detect always-on sampled per-query uprobe traps, and ordinary pgbench hid the unthrottled high-cardinality pg_stat_statements resolver scan storm.

## Noise characterization

Dedicated Rocky 8.10 four-core box, 9 alternating 10-second pairs:

- RO: +0.63% median, 1.44 pp IQR, -2.04% to +3.97%
- RW: +0.24% median, 1.49 pp IQR, -2.31% to +2.96%
- high-cardinality: -0.36% median, 2.03 pp IQR, -2.30% to +7.14%
- largest 7-pair to 9-pair median movement: 1.33 pp

GitHub ubuntu-latest four-vCPU characterization, 7 pairs:

- RO: +1.99% median, 11.02 pp IQR, -12.75% to +19.38%
- RW: +3.47% median, 9.84 pp IQR, -7.77% to +7.11%
- high-cardinality: +3.25% median, 5.78 pp IQR, -3.74% to +11.56%
- largest prefix-median movement: 3.74 pp

The allocated hosted runner had four vCPUs; no 2-vCPU measurement is claimed. Hosted noise is too large for a credible blocking 1% assertion.

## Gate design

The blocking CI gate uses the paired median of 7 alternating AB/BA pairs, warns at 10%, and hard-fails at 15%. A candidate hard failure automatically runs 7 confirmation pairs and fails only on the exactly balanced combined 14-pair median. The 15% boundary is 11.53 pp above the worst hosted null median; the historical 20% and 28% classes predict roughly 21.6-22.8% and 29.4-30.5% against the observed null medians.

A documented 9-pair, 30-second dedicated-box characterization profile tracks the sub-1% target without pretending it is a reliable shared-runner hard boundary.

## Validation

Current code, dedicated box, three complete gate runs:

- run 1: RO +1.23%, RW -0.41%, high-cardinality +1.12%
- run 2: RO -0.84%, RW +1.35%, high-cardinality +1.39%
- run 3: RO +0.12%, RW +0.86%, high-cardinality +0.92%
- all passed with no confirmation phase and no structural failure

Injected sampled uprobes:

- RW primary median +17.96%; balanced 14-pair median +17.61%
- attached mask 3 and up to 1,013,262 query plus activity fires per pair
- timing and all 14 structural checks failed

Injected resolver scan storm:

- high-cardinality primary median +20.44%; balanced 14-pair median +21.66%
- 163-295 actual pg_stat_statements scans per about 12 seconds versus 14 allowed
- timing and all 14 structural checks failed

The exact one-scan-per-unthrottled-batch variant independently failed the structural bound at 63-72 scans versus 14 allowed but measured +12.11%, below the timing hard threshold. The final disclosed fault hook uses five real SRF scans per admitted batch to reproduce historical scan-storm intensity; it is not described as a byte-for-byte revert.

Final SHA validation:

- clean remote build
- make -C tests check green
- structural suites: 43/43, 32/32, 52/52
- full ci_smoke.sh green on fresh PG13, PG17, and PG18 CI hosts
- sampled-overhead blocking job green; additional unchanged reruns recorded in Actions

No tests were relaxed. Draft only; do not merge.