### PR TITLE
Harden capture smoke against runner stalls

### DIFF
--- a/docs/DAEMON_ARCHITECTURE.md
+++ b/docs/DAEMON_ARCHITECTURE.md
@@ -89,7 +89,7 @@ struct pgwt_trace_event {
 // Event output ringbuf
 struct {
     __uint(type, BPF_MAP_TYPE_RINGBUF);
-    __uint(max_entries, 64 * 1024 * 1024);  // 64MB buffer
+    __uint(max_entries, 64 * 1024 * 1024);  // 64 MiB buffer
 } event_ringbuf SEC(".maps");
 
 SEC("perf_event")
@@ -124,6 +124,16 @@ int on_watchpoint(struct pt_regs *ctx) {
     return 0;
 }
 ```
+
+**Full-tier NMI limitation:** hardware-watchpoint perf-event programs can run
+in NMI context. The kernel's shared BPF ring uses a spinlock for reservation,
+so a reservation can fail in NMI context even when the ring has free space;
+increasing `max_entries` does not remove that contention failure. Every such
+loss is exposed as `ringbuf_drops_total`. Consumers that require a provably
+lossless event-ring interval must check that the counter did not advance;
+other capture health counters cover failures outside this ring. High-rate
+multi-CPU capture can report a non-zero counter even with ample ring capacity.
+See the kernel's [BPF ring-buffer design](https://docs.kernel.org/bpf/ringbuf.html#design-and-implementation).
 
 **Removed from BPF:** All `wait_stats` and `query_wait_stats` map updates (count++,
 total_ns+=, min/max, histogram). This simplifies the BPF program and reduces

--- a/src/anomaly.c
+++ b/src/anomaly.c
@@ -161,10 +161,10 @@ pgwt_anomaly_eval_observation(struct pgwt_anomaly *a,
      * exactly one observation rather than several seconds of evidence. */
     bool in_cooldown = a->last_fire_ns != 0
                     && now_ns - a->last_fire_ns < a->cooldown_ns;
-    bool in_setup_retry_backoff = a->cpu_setup_retry_after_ns != 0
-                              && now_ns < a->cpu_setup_retry_after_ns;
-    if (a->cpu_setup_retry_after_ns != 0 && !in_setup_retry_backoff)
-        a->cpu_setup_retry_after_ns = 0;
+    bool in_setup_retry_backoff = a->setup_retry_after_ns != 0
+                              && now_ns < a->setup_retry_after_ns;
+    if (a->setup_retry_after_ns != 0 && !in_setup_retry_backoff)
+        a->setup_retry_after_ns = 0;
 
     /* ── CPU-demand saturation CUSUM ───────────────────────────────────── */
     bool cpu_rule_enabled = a->cpu_cusum_enabled
@@ -195,11 +195,9 @@ pgwt_anomaly_eval_observation(struct pgwt_anomaly *a,
     bool trusted_below_reference = capacity_known && obs->cpu_coverage_ok
                                 && u < a->cpu_cusum_k;
     if (trusted_below_reference) {
-        /* A real recovery ends the setup-retry episode even when a transient
-         * failure had already re-armed CPU during its backoff. */
+        /* A real recovery re-arms the CPU rule. Generic setup-retry state is
+         * cleared below only after every rule in that episode has recovered. */
         a->cpu_armed = true;
-        a->cpu_setup_retries = 0;
-        a->cpu_setup_retry_after_ns = 0;
     }
     bool blind_observation = !capacity_known
                           || (!obs->cpu_coverage_ok
@@ -279,6 +277,21 @@ pgwt_anomaly_eval_observation(struct pgwt_anomaly *a,
     bool lock_over = (a->lock_fraction > 0.0)
                   && (lock_fraction > a->lock_fraction)
                   && (lock_aas >= a->lock_min_aas);
+    if (a->setup_retry_rules != 0) {
+        bool recovered = true;
+        if ((a->setup_retry_rules & PGWT_RULE_AAS) && aas_over)
+            recovered = false;
+        if ((a->setup_retry_rules & PGWT_RULE_LOCK) && lock_over)
+            recovered = false;
+        if ((a->setup_retry_rules & PGWT_RULE_CPU_SATURATION) &&
+            !trusted_below_reference)
+            recovered = false;
+        if (recovered) {
+            a->setup_retries = 0;
+            a->setup_retry_after_ns = 0;
+            a->setup_retry_rules = 0;
+        }
+    }
     if (in_setup_retry_backoff)
         a->lock_over_streak = 0;
     else if (lock_over)
@@ -375,22 +388,27 @@ pgwt_anomaly_eval(struct pgwt_anomaly *a, double aas, double lock_fraction,
     return pgwt_anomaly_eval_observation(a, &obs, now_ns);
 }
 
-bool pgwt_anomaly_retry_after_setup_failure(struct pgwt_anomaly *a,
-                                             unsigned fired_mask,
-                                             uint64_t now_ns)
+enum pgwt_anomaly_setup_retry_result
+pgwt_anomaly_retry_after_setup_failure(struct pgwt_anomaly *a,
+                                       unsigned fired_mask,
+                                       uint64_t now_ns)
 {
-    if (!(fired_mask & PGWT_RULE_CPU_SATURATION) ||
-        a->cpu_setup_retries >= PGWT_ANOMALY_CPU_SETUP_MAX_RETRIES)
-        return false;
+    unsigned retryable = fired_mask &
+        (PGWT_RULE_AAS | PGWT_RULE_LOCK | PGWT_RULE_CPU_SATURATION);
+    if (!retryable)
+        return PGWT_ANOMALY_SETUP_RETRY_NOT_APPLICABLE;
+    if (a->setup_retries >= PGWT_ANOMALY_SETUP_MAX_RETRIES)
+        return PGWT_ANOMALY_SETUP_RETRY_LIMIT_REACHED;
 
     /* The engine never opened a window, so charging cooldown or permanently
-     * consuming the CPU episode would lose a real incident.  Restart each
+     * consuming the firing episode would lose a real incident. Restart each
      * firing rule's evidence after a bounded backoff instead of retrying on
-     * the very next tick.  The retry cap prevents a permanent attach failure
-     * from hammering exact setup for the lifetime of a saturated episode. */
-    a->cpu_setup_retries++;
-    a->cpu_setup_retry_after_ns = now_ns +
-        (uint64_t)PGWT_ANOMALY_CPU_SETUP_RETRY_S * 1000000000ULL;
+     * the very next tick. The retry cap prevents a permanent attach failure
+     * from hammering exact setup for the lifetime of an episode. */
+    a->setup_retries++;
+    a->setup_retry_after_ns = now_ns +
+        (uint64_t)PGWT_ANOMALY_SETUP_RETRY_S * 1000000000ULL;
+    a->setup_retry_rules = retryable;
     a->last_fire_ns = 0;
     if (fired_mask & PGWT_RULE_AAS)
         a->aas_over_streak = 0;
@@ -400,13 +418,14 @@ bool pgwt_anomaly_retry_after_setup_failure(struct pgwt_anomaly *a,
         a->cpu_armed = true;
         a->cpu_cusum = 0.0;
     }
-    return true;
+    return PGWT_ANOMALY_SETUP_RETRY_SCHEDULED;
 }
 
 void pgwt_anomaly_escalation_succeeded(struct pgwt_anomaly *a)
 {
-    a->cpu_setup_retries = 0;
-    a->cpu_setup_retry_after_ns = 0;
+    a->setup_retries = 0;
+    a->setup_retry_after_ns = 0;
+    a->setup_retry_rules = 0;
 }
 
 /* ── Daemon-side wrapper ──────────────────────────────────────────────── */
@@ -582,21 +601,29 @@ void pgwt_anomaly_tick(struct pgwt_daemon *d,
                     why ? why : "budget exhausted");
         } else if (failure == PGWT_ESC_FAIL_EXACT_ATTACH ||
                    failure == PGWT_ESC_FAIL_EXACT_PRESEED) {
-            bool retry = pgwt_anomaly_retry_after_setup_failure(
+            enum pgwt_anomaly_setup_retry_result retry =
+                pgwt_anomaly_retry_after_setup_failure(
                 a, dec.fired_mask, now);
-            if (retry) {
+            if (retry == PGWT_ANOMALY_SETUP_RETRY_SCHEDULED) {
                 fprintf(stderr,
                         "WARN: anomaly escalation setup failed; retry %u/%u "
                         "after backoff and fresh evidence: rule=%saas=%.1f "
                         "lock_frac=%.2f (%s)\n",
-                        a->cpu_setup_retries,
-                        PGWT_ANOMALY_CPU_SETUP_MAX_RETRIES,
+                        a->setup_retries,
+                        PGWT_ANOMALY_SETUP_MAX_RETRIES,
+                        rb, dec.aas, dec.lock_fraction,
+                        why ? why : "escalation denied");
+            } else if (retry == PGWT_ANOMALY_SETUP_RETRY_LIMIT_REACHED) {
+                fprintf(stderr,
+                        "WARN: anomaly escalation setup failed; retry limit "
+                        "reached for this episode: rule=%saas=%.1f "
+                        "lock_frac=%.2f (%s)\n",
                         rb, dec.aas, dec.lock_fraction,
                         why ? why : "escalation denied");
             } else {
                 fprintf(stderr,
-                        "WARN: anomaly escalation setup failed; retry limit "
-                        "reached for this episode: rule=%saas=%.1f "
+                        "WARN: anomaly escalation setup failed; no firing "
+                        "rule was eligible for retry: rule=%saas=%.1f "
                         "lock_frac=%.2f (%s)\n",
                         rb, dec.aas, dec.lock_fraction,
                         why ? why : "escalation denied");

--- a/src/anomaly.c
+++ b/src/anomaly.c
@@ -161,6 +161,10 @@ pgwt_anomaly_eval_observation(struct pgwt_anomaly *a,
      * exactly one observation rather than several seconds of evidence. */
     bool in_cooldown = a->last_fire_ns != 0
                     && now_ns - a->last_fire_ns < a->cooldown_ns;
+    bool in_setup_retry_backoff = a->cpu_setup_retry_after_ns != 0
+                              && now_ns < a->cpu_setup_retry_after_ns;
+    if (a->cpu_setup_retry_after_ns != 0 && !in_setup_retry_backoff)
+        a->cpu_setup_retry_after_ns = 0;
 
     /* ── CPU-demand saturation CUSUM ───────────────────────────────────── */
     bool cpu_rule_enabled = a->cpu_cusum_enabled
@@ -188,6 +192,15 @@ pgwt_anomaly_eval_observation(struct pgwt_anomaly *a,
      * reference cannot prove low demand, so it holds S and advances the #80
      * blind-gap reset. UNKNOWN capacity is independently blind. */
     bool saturation_lower_bound = capacity_known && u >= reference;
+    bool trusted_below_reference = capacity_known && obs->cpu_coverage_ok
+                                && u < a->cpu_cusum_k;
+    if (trusted_below_reference) {
+        /* A real recovery ends the setup-retry episode even when a transient
+         * failure had already re-armed CPU during its backoff. */
+        a->cpu_armed = true;
+        a->cpu_setup_retries = 0;
+        a->cpu_setup_retry_after_ns = 0;
+    }
     bool blind_observation = !capacity_known
                           || (!obs->cpu_coverage_ok
                               && !saturation_lower_bound);
@@ -206,7 +219,8 @@ pgwt_anomaly_eval_observation(struct pgwt_anomaly *a,
      * old units. An open escalation window or cooldown also clears evidence:
      * this prevents a manual/other-rule window from banking an almost-fire
      * that would immediately consume another budget grant when it closes. */
-    if (obs->cpu_capacity_changed || obs->cpu_guard_blocked || in_cooldown) {
+    if (obs->cpu_capacity_changed || obs->cpu_guard_blocked || in_cooldown ||
+        in_setup_retry_backoff) {
         a->cpu_cusum = 0.0;
     } else if (!cpu_rule_enabled) {
         a->cpu_cusum = 0.0;
@@ -217,8 +231,9 @@ pgwt_anomaly_eval_observation(struct pgwt_anomaly *a,
          * continuous saturation therefore consumes at most one grant. */
         if (!a->cpu_armed) {
             a->cpu_cusum = 0.0;
-            if (obs->cpu_coverage_ok && u < a->cpu_cusum_k)
+            if (obs->cpu_coverage_ok && u < a->cpu_cusum_k) {
                 a->cpu_armed = true;
+            }
         } else {
             double before = a->cpu_cusum;
             a->cpu_cusum += a->sample_period_s * (u - reference);
@@ -246,7 +261,9 @@ pgwt_anomaly_eval_observation(struct pgwt_anomaly *a,
          * sessions before the multiplicative rule can fire. */
         aas_over = (aas >= 2.0) && (aas > threshold);
     }
-    if (aas_over)
+    if (in_setup_retry_backoff)
+        a->aas_over_streak = 0;
+    else if (aas_over)
         a->aas_over_streak++;
     else
         a->aas_over_streak = 0;
@@ -262,7 +279,9 @@ pgwt_anomaly_eval_observation(struct pgwt_anomaly *a,
     bool lock_over = (a->lock_fraction > 0.0)
                   && (lock_fraction > a->lock_fraction)
                   && (lock_aas >= a->lock_min_aas);
-    if (lock_over)
+    if (in_setup_retry_backoff)
+        a->lock_over_streak = 0;
+    else if (lock_over)
         a->lock_over_streak++;
     else
         a->lock_over_streak = 0;
@@ -354,6 +373,40 @@ pgwt_anomaly_eval(struct pgwt_anomaly *a, double aas, double lock_fraction,
         .cpu_coverage_ok = false,
     };
     return pgwt_anomaly_eval_observation(a, &obs, now_ns);
+}
+
+bool pgwt_anomaly_retry_after_setup_failure(struct pgwt_anomaly *a,
+                                             unsigned fired_mask,
+                                             uint64_t now_ns)
+{
+    if (!(fired_mask & PGWT_RULE_CPU_SATURATION) ||
+        a->cpu_setup_retries >= PGWT_ANOMALY_CPU_SETUP_MAX_RETRIES)
+        return false;
+
+    /* The engine never opened a window, so charging cooldown or permanently
+     * consuming the CPU episode would lose a real incident.  Restart each
+     * firing rule's evidence after a bounded backoff instead of retrying on
+     * the very next tick.  The retry cap prevents a permanent attach failure
+     * from hammering exact setup for the lifetime of a saturated episode. */
+    a->cpu_setup_retries++;
+    a->cpu_setup_retry_after_ns = now_ns +
+        (uint64_t)PGWT_ANOMALY_CPU_SETUP_RETRY_S * 1000000000ULL;
+    a->last_fire_ns = 0;
+    if (fired_mask & PGWT_RULE_AAS)
+        a->aas_over_streak = 0;
+    if (fired_mask & PGWT_RULE_LOCK)
+        a->lock_over_streak = 0;
+    if (fired_mask & PGWT_RULE_CPU_SATURATION) {
+        a->cpu_armed = true;
+        a->cpu_cusum = 0.0;
+    }
+    return true;
+}
+
+void pgwt_anomaly_escalation_succeeded(struct pgwt_anomaly *a)
+{
+    a->cpu_setup_retries = 0;
+    a->cpu_setup_retry_after_ns = 0;
 }
 
 /* ── Daemon-side wrapper ──────────────────────────────────────────────── */
@@ -502,28 +555,59 @@ void pgwt_anomaly_tick(struct pgwt_daemon *d,
     case PGWT_ANOMALY_FIRE: {
         int granted = 0;
         const char *why = NULL;
+        enum pgwt_escalate_failure failure = PGWT_ESC_FAIL_NONE;
         rule_names(dec.fired_mask, rb, sizeof(rb));
         int reason = (dec.fired_mask & PGWT_RULE_CPU_SATURATION)
                    ? PGWT_ESC_REASON_CPU_SATURATION
                    : PGWT_ESC_REASON_ANOMALY;
         int rc = pgwt_escalate(d, a->escalation_s, reason,
-                               &granted, &why);
+                               &granted, &why, &failure);
         if (rc == 0) {
+            pgwt_anomaly_escalation_succeeded(a);
             fprintf(stderr,
                     "INFO: anomaly AUTO-escalation: rule=%saas=%.1f "
                     "baseline=%.2f lock_frac=%.2f cpu_aas=%.1f "
                     "capacity=%.3f -> full fidelity %ds\n",
                     rb, dec.aas, dec.baseline, dec.lock_fraction,
                     dec.cpu_aas, dec.cpu_capacity, granted);
-        } else {
+        } else if (failure == PGWT_ESC_FAIL_BUDGET) {
             /* Over budget: dropped SILENTLY (log only, no error to anyone) —
              * unlike a manual escalate which returns a denial to its caller. */
             a->dropped_budget++;
+            pgwt_anomaly_escalation_succeeded(a);
             fprintf(stderr,
                     "INFO: anomaly trigger DROPPED (budget): rule=%saas=%.1f "
                     "lock_frac=%.2f (%s)\n",
                     rb, dec.aas, dec.lock_fraction,
                     why ? why : "budget exhausted");
+        } else if (failure == PGWT_ESC_FAIL_EXACT_ATTACH ||
+                   failure == PGWT_ESC_FAIL_EXACT_PRESEED) {
+            bool retry = pgwt_anomaly_retry_after_setup_failure(
+                a, dec.fired_mask, now);
+            if (retry) {
+                fprintf(stderr,
+                        "WARN: anomaly escalation setup failed; retry %u/%u "
+                        "after backoff and fresh evidence: rule=%saas=%.1f "
+                        "lock_frac=%.2f (%s)\n",
+                        a->cpu_setup_retries,
+                        PGWT_ANOMALY_CPU_SETUP_MAX_RETRIES,
+                        rb, dec.aas, dec.lock_fraction,
+                        why ? why : "escalation denied");
+            } else {
+                fprintf(stderr,
+                        "WARN: anomaly escalation setup failed; retry limit "
+                        "reached for this episode: rule=%saas=%.1f "
+                        "lock_frac=%.2f (%s)\n",
+                        rb, dec.aas, dec.lock_fraction,
+                        why ? why : "escalation denied");
+            }
+        } else {
+            pgwt_anomaly_escalation_succeeded(a);
+            fprintf(stderr,
+                    "WARN: anomaly escalation rejected: rule=%saas=%.1f "
+                    "lock_frac=%.2f (%s)\n",
+                    rb, dec.aas, dec.lock_fraction,
+                    why ? why : "invalid escalation request");
         }
         break;
     }

--- a/src/anomaly.h
+++ b/src/anomaly.h
@@ -131,7 +131,9 @@ struct pgwt_anomaly {
     double cpu_cusum_cap;     /* cap applied to cpu_aas / capacity */
     double sample_period_s;   /* NOMINAL 1/sample_rate_hz, never wall gap */
     double cpu_cusum;         /* O(1) accumulated saturation evidence */
-    bool   cpu_armed;         /* one fire until trusted below-k recovery */
+    bool   cpu_armed;         /* one successful fire/retry cap until recovery */
+    unsigned cpu_setup_retries; /* transient exact-setup retries this episode */
+    uint64_t cpu_setup_retry_after_ns; /* backoff gate before fresh evidence */
     double cpu_coverage_gap_reset_s; /* configured blind-gap duration */
     int    cpu_coverage_gap_reset_ticks; /* duration rounded up to ticks */
     int    cpu_coverage_gap_ticks; /* consecutive blind LOW/UNKNOWN ticks */
@@ -187,6 +189,8 @@ struct pgwt_anomaly {
 #define PGWT_ANOMALY_DEF_CPU_CUSUM_K   0.80
 #define PGWT_ANOMALY_DEF_CPU_CUSUM_H   1.50
 #define PGWT_ANOMALY_DEF_CPU_CUSUM_CAP 1.25
+#define PGWT_ANOMALY_CPU_SETUP_MAX_RETRIES 3
+#define PGWT_ANOMALY_CPU_SETUP_RETRY_S 3
 /* Brief blind under-reference or UNKNOWN-capacity flaps hold CPU evidence.
  * Two seconds is comfortably beyond sub-second coverage flapping, but still
  * discards evidence across a genuinely blind interval. Incomplete ticks with
@@ -238,6 +242,17 @@ pgwt_anomaly_eval_observation(struct pgwt_anomaly *a,
 struct pgwt_anomaly_decision
 pgwt_anomaly_eval(struct pgwt_anomaly *a, double aas, double lock_fraction,
                   uint64_t now_ns);
+
+/* Roll back the episode/cooldown latch after the escalation engine rejects a
+ * CPU FIRE for a transient exact-mode setup failure.  Rule streaks and CPU
+ * CUSUM restart after a bounded backoff, so each capped retry requires a full
+ * fresh evidence horizon. Returns true when a retry was armed. */
+bool pgwt_anomaly_retry_after_setup_failure(struct pgwt_anomaly *a,
+                                             unsigned fired_mask,
+                                             uint64_t now_ns);
+
+/* Clear retry bookkeeping after the escalation engine opens a window. */
+void pgwt_anomaly_escalation_succeeded(struct pgwt_anomaly *a);
 
 /* Derive (aas, lock_fraction, cpu_aas) from a tick's encoded sample batch.
  * `samples` is the build_batch output (idle/on-CPU handling already applied

--- a/src/anomaly.h
+++ b/src/anomaly.h
@@ -132,8 +132,9 @@ struct pgwt_anomaly {
     double sample_period_s;   /* NOMINAL 1/sample_rate_hz, never wall gap */
     double cpu_cusum;         /* O(1) accumulated saturation evidence */
     bool   cpu_armed;         /* one successful fire/retry cap until recovery */
-    unsigned cpu_setup_retries; /* transient exact-setup retries this episode */
-    uint64_t cpu_setup_retry_after_ns; /* backoff gate before fresh evidence */
+    unsigned setup_retries; /* transient exact-setup retries this episode */
+    uint64_t setup_retry_after_ns; /* backoff gate before fresh evidence */
+    unsigned setup_retry_rules; /* firing rules that define this episode */
     double cpu_coverage_gap_reset_s; /* configured blind-gap duration */
     int    cpu_coverage_gap_reset_ticks; /* duration rounded up to ticks */
     int    cpu_coverage_gap_ticks; /* consecutive blind LOW/UNKNOWN ticks */
@@ -189,8 +190,8 @@ struct pgwt_anomaly {
 #define PGWT_ANOMALY_DEF_CPU_CUSUM_K   0.80
 #define PGWT_ANOMALY_DEF_CPU_CUSUM_H   1.50
 #define PGWT_ANOMALY_DEF_CPU_CUSUM_CAP 1.25
-#define PGWT_ANOMALY_CPU_SETUP_MAX_RETRIES 3
-#define PGWT_ANOMALY_CPU_SETUP_RETRY_S 3
+#define PGWT_ANOMALY_SETUP_MAX_RETRIES 3
+#define PGWT_ANOMALY_SETUP_RETRY_S 3
 /* Brief blind under-reference or UNKNOWN-capacity flaps hold CPU evidence.
  * Two seconds is comfortably beyond sub-second coverage flapping, but still
  * discards evidence across a genuinely blind interval. Incomplete ticks with
@@ -243,13 +244,21 @@ struct pgwt_anomaly_decision
 pgwt_anomaly_eval(struct pgwt_anomaly *a, double aas, double lock_fraction,
                   uint64_t now_ns);
 
+enum pgwt_anomaly_setup_retry_result {
+    PGWT_ANOMALY_SETUP_RETRY_NOT_APPLICABLE = 0,
+    PGWT_ANOMALY_SETUP_RETRY_SCHEDULED,
+    PGWT_ANOMALY_SETUP_RETRY_LIMIT_REACHED,
+};
+
 /* Roll back the episode/cooldown latch after the escalation engine rejects a
- * CPU FIRE for a transient exact-mode setup failure.  Rule streaks and CPU
- * CUSUM restart after a bounded backoff, so each capped retry requires a full
- * fresh evidence horizon. Returns true when a retry was armed. */
-bool pgwt_anomaly_retry_after_setup_failure(struct pgwt_anomaly *a,
-                                             unsigned fired_mask,
-                                             uint64_t now_ns);
+ * FIRE for a transient exact-mode setup failure. Every firing rule restarts
+ * its evidence after a bounded backoff, so each capped retry requires a full
+ * fresh evidence horizon. The result distinguishes a real exhausted episode
+ * from a call that did not contain any retryable firing rule. */
+enum pgwt_anomaly_setup_retry_result
+pgwt_anomaly_retry_after_setup_failure(struct pgwt_anomaly *a,
+                                       unsigned fired_mask,
+                                       uint64_t now_ns);
 
 /* Clear retry bookkeeping after the escalation engine opens a window. */
 void pgwt_anomaly_escalation_succeeded(struct pgwt_anomaly *a);

--- a/src/backend_status_layout.c
+++ b/src/backend_status_layout.c
@@ -25,15 +25,22 @@
 #include <unistd.h>
 
 /* The hosted-runner reproducer measured process scheduling gaps of about 20s.
- * Runtime validation crosses four controlled state boundaries, so give the
- * whole sequence one 90s deadline (four observed gaps plus bounded headroom),
- * not a fresh timeout per step. Active SQL outlives that deadline and is
- * cancelled immediately once its exact state and coherent snapshot are seen;
- * 120s is a safety cap, never an unconditional startup delay. Cleanup gets a
- * separate three-gap deadline so a failed validator cannot leak a backend. */
-#define PGWT_PGBS_VALIDATION_TIMEOUT_MS 90000
-#define PGWT_PGBS_CLEANUP_TIMEOUT_MS    60000
-#define PGWT_PGBS_ACTIVE_WINDOW_S         120
+ * Give every controlled observation its own 90s budget: one slow, progressing
+ * step must not consume the opportunity to validate the later state changes.
+ * A hung step still fails after 90s. Active SQL outlives one step and is
+ * cancelled once its exact state and coherent snapshot are seen; 120s is a
+ * safety cap, never an unconditional startup delay. The twelve-minute outer
+ * bound leaves every
+ * handshake/observation/drain step a full window, while failure cleanup has a
+ * separate short cap. */
+#define PGWT_PGBS_VALIDATION_STEP_TIMEOUT_MS     90000
+#define PGWT_PGBS_VALIDATION_OVERALL_TIMEOUT_MS 720000
+#define PGWT_PGBS_CLEANUP_TIMEOUT_MS              60000
+#define PGWT_PGBS_ACTIVE_WINDOW_S                    120
+/* Four observer phases x 48 plus the controlled backend stay below the
+ * 256-entry exclusion cap even if every attempt records a unique PID. */
+#define PGWT_PGBS_MAX_OBSERVER_ATTEMPTS               48
+#define PGWT_PGBS_OBSERVER_RETRY_MS                  2000
 
 /* ── Names and native key ─────────────────────────────────── */
 
@@ -1598,6 +1605,30 @@ static int deadline_remaining_ms(uint64_t deadline_ms)
     return remaining > INT_MAX ? INT_MAX : (int)remaining;
 }
 
+static uint64_t deadline_from_now(uint64_t timeout_ms, uint64_t cap_ms)
+{
+    uint64_t now_ms = monotonic_ms();
+    uint64_t deadline_ms = UINT64_MAX - now_ms < timeout_ms
+                         ? UINT64_MAX : now_ms + timeout_ms;
+    return deadline_ms < cap_ms ? deadline_ms : cap_ms;
+}
+
+static uint64_t validation_step_deadline(uint64_t overall_deadline_ms)
+{
+    return deadline_from_now(PGWT_PGBS_VALIDATION_STEP_TIMEOUT_MS,
+                             overall_deadline_ms);
+}
+
+static uint64_t validation_cleanup_deadline(uint64_t overall_deadline_ms)
+{
+    uint64_t cleanup_cap = UINT64_MAX - overall_deadline_ms <
+                           PGWT_PGBS_CLEANUP_TIMEOUT_MS
+                         ? UINT64_MAX
+                         : overall_deadline_ms +
+                           PGWT_PGBS_CLEANUP_TIMEOUT_MS;
+    return deadline_from_now(PGWT_PGBS_CLEANUP_TIMEOUT_MS, cleanup_cap);
+}
+
 int pgwt_pgbs_pid_start_time(pid_t pid, uint64_t *start_time)
 {
     if (pid <= 0 || !start_time)
@@ -1655,12 +1686,11 @@ bool pgwt_pgbs_pid_is_original(pid_t pid, uint64_t start_time)
            current == start_time;
 }
 
-int pgwt_pgbs_exclusion_add(struct pgwt_pgbs_exclusion_set *set, pid_t pid)
+static int exclusion_add_identity(struct pgwt_pgbs_exclusion_set *set,
+                                  pid_t pid, uint64_t start_time)
 {
     if (!set || pid <= 0)
         return -1;
-    uint64_t start_time = 0;
-    (void)pgwt_pgbs_pid_start_time(pid, &start_time);
     for (unsigned i = 0; i < set->count; i++) {
         if (set->entries[i].pid == pid &&
             set->entries[i].start_time == start_time)
@@ -1673,6 +1703,13 @@ int pgwt_pgbs_exclusion_add(struct pgwt_pgbs_exclusion_set *set, pid_t pid)
         .start_time = start_time,
     };
     return 0;
+}
+
+int pgwt_pgbs_exclusion_add(struct pgwt_pgbs_exclusion_set *set, pid_t pid)
+{
+    uint64_t start_time = 0;
+    (void)pgwt_pgbs_pid_start_time(pid, &start_time);
+    return exclusion_add_identity(set, pid, start_time);
 }
 
 bool pgwt_pgbs_exclusion_contains(const struct pgwt_pgbs_exclusion_set *set,
@@ -1694,6 +1731,45 @@ bool pgwt_pgbs_exclusion_contains(const struct pgwt_pgbs_exclusion_set *set,
             return true;
     }
     return false;
+}
+
+static void exclusion_remove_unknown_identity(
+    struct pgwt_pgbs_exclusion_set *set, pid_t pid)
+{
+    if (!set || pid <= 0)
+        return;
+    for (unsigned i = 0; i < set->count; i++) {
+        if (set->entries[i].pid != pid || set->entries[i].start_time != 0)
+            continue;
+        if (i + 1 < set->count)
+            memmove(&set->entries[i], &set->entries[i + 1],
+                    (set->count - i - 1) * sizeof(set->entries[0]));
+        set->count--;
+        return;
+    }
+}
+
+int pgwt_pgbs_exclusion_add_live(struct pgwt_pgbs_exclusion_set *set,
+                                 pid_t pid, uint64_t *start_time,
+                                 bool *already_retired)
+{
+    if (!set || pid <= 0 || !start_time || !already_retired)
+        return -1;
+    *start_time = 0;
+    *already_retired = false;
+    if (pgwt_pgbs_pid_start_time(pid, start_time) == 0)
+        return exclusion_add_identity(set, pid, *start_time);
+    if (kill(pid, 0) != 0 && errno == ESRCH) {
+        *already_retired = true;
+        return 0;
+    }
+
+    int rc = exclusion_add_identity(set, pid, 0);
+    if (rc == 0 && kill(pid, 0) != 0 && errno == ESRCH) {
+        exclusion_remove_unknown_identity(set, pid);
+        *already_retired = true;
+    }
+    return rc;
 }
 
 static int wait_for_pid_retirement(pid_t pid, uint64_t start_time,
@@ -1763,7 +1839,10 @@ static int observe_controlled_backend(const char *psql, const char *user,
                  "FROM rows ORDER BY ord",
                  appname, want_active ? "active" : "idle");
 
-    while (monotonic_ms() < deadline_ms) {
+    for (unsigned attempt = 0;
+         attempt < PGWT_PGBS_MAX_OBSERVER_ATTEMPTS &&
+         monotonic_ms() < deadline_ms;
+         attempt++) {
         /* Never create a backend whose identity cannot be retained.  A full
          * set is a degradable validation condition, not permission to let an
          * observer become capture-eligible. */
@@ -1779,21 +1858,21 @@ static int observe_controlled_backend(const char *psql, const char *user,
         int active = -1;
         int observer_excluded = -1;
         uint64_t observer_start_time = 0;
+        bool observer_identity_unknown = false;
         char observer_line[128], output[1024];
         int remaining_ms = deadline_remaining_ms(deadline_ms);
         ssize_t observer_line_len = read_proc_output_bounded(
             &observer, observer_line, sizeof(observer_line), remaining_ms,
             true);
+        bool observer_retired_untracked = false;
         if (observer_line_len >= 0 &&
             sscanf(observer_line, "observer|%d", &observer_pid) == 1 &&
             observer_pid > 0) {
-            (void)pgwt_pgbs_pid_start_time(observer_pid,
-                                            &observer_start_time);
-            /* Even when /proc identity capture fails, retain a conservative
-             * numeric-PID exclusion.  exclusion_contains() deliberately
-             * keeps such entries excluded for the tracer lifetime. */
-            observer_excluded = pgwt_pgbs_exclusion_add(exclusions,
-                                                        observer_pid);
+            observer_excluded = pgwt_pgbs_exclusion_add_live(
+                exclusions, observer_pid, &observer_start_time,
+                &observer_retired_untracked);
+            observer_identity_unknown = observer_excluded == 0 &&
+                observer_start_time == 0 && !observer_retired_untracked;
         }
         remaining_ms = deadline_remaining_ms(deadline_ms);
         ssize_t output_len = observer_line_len >= 0 && remaining_ms > 0
@@ -1818,15 +1897,22 @@ static int observe_controlled_backend(const char *psql, const char *user,
         int close_timeout_ms = deadline_remaining_ms(
             exclusion_failed ? cleanup_deadline_ms : deadline_ms);
         int status = pgwt_proc_close_bounded(&observer, close_timeout_ms);
+        if (observer_identity_unknown &&
+            kill(observer_pid, 0) != 0 && errno == ESRCH) {
+            exclusion_remove_unknown_identity(exclusions, observer_pid);
+            observer_retired_untracked = true;
+        }
         if (exclusion_failed) {
             if (observer_pid > 0 && observer_start_time > 0)
                 (void)terminate_backend_and_wait(
                     observer_pid, observer_start_time, cleanup_deadline_ms);
             return -1;
         }
-        if (observer_pid <= 0 || observer_start_time == 0 ||
-            wait_for_pid_retirement(observer_pid, observer_start_time,
-                                    deadline_ms) != 0) {
+        if (observer_pid <= 0 ||
+            (!observer_retired_untracked &&
+             (observer_start_time == 0 ||
+              wait_for_pid_retirement(observer_pid, observer_start_time,
+                                      deadline_ms) != 0))) {
             if (observer_pid > 0 && observer_start_time > 0)
                 (void)terminate_backend_and_wait(
                     observer_pid, observer_start_time, cleanup_deadline_ms);
@@ -1847,7 +1933,12 @@ static int observe_controlled_backend(const char *psql, const char *user,
             expected->query_id_available = pg_major >= 14 && query_id != 0;
             return 0;
         }
-        usleep(50000);
+        remaining_ms = deadline_remaining_ms(deadline_ms);
+        if (remaining_ms > 0) {
+            int retry_ms = remaining_ms < PGWT_PGBS_OBSERVER_RETRY_MS
+                         ? remaining_ms : PGWT_PGBS_OBSERVER_RETRY_MS;
+            usleep((useconds_t)retry_ms * 1000);
+        }
     }
     return -1;
 }
@@ -1951,10 +2042,11 @@ void pgwt_pgbs_validate_runtime(struct PgBackendStatusLayout *layout,
         degrade_unvalidated(layout, "could not start controlled backend");
         return;
     }
-    uint64_t validation_deadline_ms =
-        monotonic_ms() + PGWT_PGBS_VALIDATION_TIMEOUT_MS;
-    uint64_t cleanup_deadline_ms = validation_deadline_ms +
-                                   PGWT_PGBS_CLEANUP_TIMEOUT_MS;
+    uint64_t validation_deadline_ms = deadline_from_now(
+        PGWT_PGBS_VALIDATION_OVERALL_TIMEOUT_MS, UINT64_MAX);
+    uint64_t step_deadline_ms =
+        validation_step_deadline(validation_deadline_ms);
+    uint64_t cleanup_deadline_ms = 0;
     bool controlled_command_pending = false;
 
     char command[256];
@@ -1966,7 +2058,7 @@ void pgwt_pgbs_validate_runtime(struct PgBackendStatusLayout *layout,
     uint64_t controlled_start_time = 0;
     unsigned long long activity_buffer_size = 0;
     char controlled_line[128];
-    int remaining_ms = deadline_remaining_ms(validation_deadline_ms);
+    int remaining_ms = deadline_remaining_ms(step_deadline_ms);
     if (observed == 0 &&
         read_proc_output_bounded(&controlled, controlled_line,
                                  sizeof(controlled_line),
@@ -2001,7 +2093,8 @@ void pgwt_pgbs_validate_runtime(struct PgBackendStatusLayout *layout,
      * idle state whose retained activity text contains idle_marker. */
     if (observed == 0) {
         validation_step = "idle marker completion";
-        remaining_ms = deadline_remaining_ms(validation_deadline_ms);
+        step_deadline_ms = validation_step_deadline(validation_deadline_ms);
+        remaining_ms = deadline_remaining_ms(step_deadline_ms);
         char idle_ready_line[64];
         if (remaining_ms <= 0 ||
             read_proc_output_bounded(&controlled, idle_ready_line,
@@ -2026,9 +2119,12 @@ void pgwt_pgbs_validate_runtime(struct PgBackendStatusLayout *layout,
 
     if (observed == 0) {
         validation_step = "idle observation";
+        step_deadline_ms = validation_step_deadline(validation_deadline_ms);
+        cleanup_deadline_ms =
+            validation_cleanup_deadline(validation_deadline_ms);
         observed = observe_controlled_backend(
             psql, user, socket_dir, port, appname, layout->major, false,
-            &idle_expected, exclusions, validation_deadline_ms,
+            &idle_expected, exclusions, step_deadline_ms,
             cleanup_deadline_ms);
     }
     if (observed == 0) {
@@ -2051,9 +2147,12 @@ void pgwt_pgbs_validate_runtime(struct PgBackendStatusLayout *layout,
     }
     if (observed == 0) {
         validation_step = "first active observation";
+        step_deadline_ms = validation_step_deadline(validation_deadline_ms);
+        cleanup_deadline_ms =
+            validation_cleanup_deadline(validation_deadline_ms);
         observed = observe_controlled_backend(
             psql, user, socket_dir, port, appname, layout->major, true,
-            &first_expected, exclusions, validation_deadline_ms,
+            &first_expected, exclusions, step_deadline_ms,
             cleanup_deadline_ms);
     }
     if (observed == 0) {
@@ -2087,9 +2186,12 @@ void pgwt_pgbs_validate_runtime(struct PgBackendStatusLayout *layout,
     memset(&between_expected, 0, sizeof(between_expected));
     if (observed == 0) {
         validation_step = "between-command idle observation";
+        step_deadline_ms = validation_step_deadline(validation_deadline_ms);
+        cleanup_deadline_ms =
+            validation_cleanup_deadline(validation_deadline_ms);
         observed = observe_controlled_backend(
             psql, user, socket_dir, port, appname, layout->major, false,
-            &between_expected, exclusions, validation_deadline_ms,
+            &between_expected, exclusions, step_deadline_ms,
             cleanup_deadline_ms);
     }
 
@@ -2103,9 +2205,12 @@ void pgwt_pgbs_validate_runtime(struct PgBackendStatusLayout *layout,
     }
     if (observed == 0) {
         validation_step = "second active observation";
+        step_deadline_ms = validation_step_deadline(validation_deadline_ms);
+        cleanup_deadline_ms =
+            validation_cleanup_deadline(validation_deadline_ms);
         observed = observe_controlled_backend(
             psql, user, socket_dir, port, appname, layout->major, true,
-            &second_expected, exclusions, validation_deadline_ms,
+            &second_expected, exclusions, step_deadline_ms,
             cleanup_deadline_ms);
     }
     if (observed == 0) {
@@ -2141,9 +2246,13 @@ void pgwt_pgbs_validate_runtime(struct PgBackendStatusLayout *layout,
         fclose(controlled.in);
         controlled.in = NULL;
     }
+    if (observed == 0)
+        validation_step = "controlled session drain";
+    step_deadline_ms = validation_step_deadline(validation_deadline_ms);
+    cleanup_deadline_ms = validation_cleanup_deadline(validation_deadline_ms);
     char discard[512];
     remaining_ms = deadline_remaining_ms(
-        observed == 0 ? validation_deadline_ms : cleanup_deadline_ms);
+        observed == 0 ? step_deadline_ms : cleanup_deadline_ms);
     if (remaining_ms <= 0) {
         observed = -1;
         remaining_ms = deadline_remaining_ms(cleanup_deadline_ms);

--- a/src/backend_status_layout.c
+++ b/src/backend_status_layout.c
@@ -12,6 +12,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <inttypes.h>
+#include <limits.h>
 #include <poll.h>
 #include <pwd.h>
 #include <signal.h>
@@ -20,7 +21,19 @@
 #include <string.h>
 #include <sys/stat.h>
 #include <sys/utsname.h>
+#include <time.h>
 #include <unistd.h>
+
+/* The hosted-runner reproducer measured process scheduling gaps of about 20s.
+ * Runtime validation crosses four controlled state boundaries, so give the
+ * whole sequence one 90s deadline (four observed gaps plus bounded headroom),
+ * not a fresh timeout per step. Active SQL outlives that deadline and is
+ * cancelled immediately once its exact state and coherent snapshot are seen;
+ * 120s is a safety cap, never an unconditional startup delay. Cleanup gets a
+ * separate three-gap deadline so a failed validator cannot leak a backend. */
+#define PGWT_PGBS_VALIDATION_TIMEOUT_MS 90000
+#define PGWT_PGBS_CLEANUP_TIMEOUT_MS    60000
+#define PGWT_PGBS_ACTIVE_WINDOW_S         120
 
 /* ── Names and native key ─────────────────────────────────── */
 
@@ -1569,6 +1582,22 @@ static ssize_t read_proc_output_bounded(struct pgwt_proc *proc,
     return -1;
 }
 
+static uint64_t monotonic_ms(void)
+{
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return (uint64_t)ts.tv_sec * 1000 + (uint64_t)ts.tv_nsec / 1000000;
+}
+
+static int deadline_remaining_ms(uint64_t deadline_ms)
+{
+    uint64_t now_ms = monotonic_ms();
+    if (now_ms >= deadline_ms)
+        return 0;
+    uint64_t remaining = deadline_ms - now_ms;
+    return remaining > INT_MAX ? INT_MAX : (int)remaining;
+}
+
 int pgwt_pgbs_pid_start_time(pid_t pid, uint64_t *start_time)
 {
     if (pid <= 0 || !start_time)
@@ -1667,7 +1696,8 @@ bool pgwt_pgbs_exclusion_contains(const struct pgwt_pgbs_exclusion_set *set,
     return false;
 }
 
-static int wait_for_pid_retirement(pid_t pid, uint64_t start_time)
+static int wait_for_pid_retirement(pid_t pid, uint64_t start_time,
+                                   uint64_t deadline_ms)
 {
     if (pid <= 0)
         return -1;
@@ -1675,7 +1705,7 @@ static int wait_for_pid_retirement(pid_t pid, uint64_t start_time)
         uint64_t current = 0;
         return pgwt_pgbs_pid_start_time(pid, &current) != 0 ? 0 : -1;
     }
-    for (int attempt = 0; attempt < 100; attempt++) {
+    while (monotonic_ms() < deadline_ms) {
         if (!pgwt_pgbs_pid_is_original(pid, start_time))
             return 0;
         usleep(50000);
@@ -1683,12 +1713,26 @@ static int wait_for_pid_retirement(pid_t pid, uint64_t start_time)
     return -1;
 }
 
+/* Identity-safe failure cleanup for a validation/observer backend. A PID that
+ * has already retired or been reused is success and is never signalled. */
+static int terminate_backend_and_wait(pid_t pid, uint64_t start_time,
+                                      uint64_t cleanup_deadline_ms)
+{
+    if (!pgwt_pgbs_pid_is_original(pid, start_time))
+        return 0;
+    if (kill(pid, SIGTERM) != 0 && errno != ESRCH)
+        return -1;
+    return wait_for_pid_retirement(pid, start_time, cleanup_deadline_ms);
+}
+
 static int observe_controlled_backend(const char *psql, const char *user,
                                       const char *socket_dir, int port,
                                       const char *appname, int pg_major,
                                       bool want_active,
                                       struct pgwt_pgbs_expected *expected,
-                                      struct pgwt_pgbs_exclusion_set *exclusions)
+                                      struct pgwt_pgbs_exclusion_set *exclusions,
+                                      uint64_t deadline_ms,
+                                      uint64_t cleanup_deadline_ms)
 {
     char sql[1024];
     if (pg_major >= 14)
@@ -1719,7 +1763,7 @@ static int observe_controlled_backend(const char *psql, const char *user,
                  "FROM rows ORDER BY ord",
                  appname, want_active ? "active" : "idle");
 
-    for (int attempt = 0; attempt < 20; attempt++) {
+    while (monotonic_ms() < deadline_ms) {
         /* Never create a backend whose identity cannot be retained.  A full
          * set is a degradable validation condition, not permission to let an
          * observer become capture-eligible. */
@@ -1736,8 +1780,10 @@ static int observe_controlled_backend(const char *psql, const char *user,
         int observer_excluded = -1;
         uint64_t observer_start_time = 0;
         char observer_line[128], output[1024];
+        int remaining_ms = deadline_remaining_ms(deadline_ms);
         ssize_t observer_line_len = read_proc_output_bounded(
-            &observer, observer_line, sizeof(observer_line), 3000, true);
+            &observer, observer_line, sizeof(observer_line), remaining_ms,
+            true);
         if (observer_line_len >= 0 &&
             sscanf(observer_line, "observer|%d", &observer_pid) == 1 &&
             observer_pid > 0) {
@@ -1749,9 +1795,10 @@ static int observe_controlled_backend(const char *psql, const char *user,
             observer_excluded = pgwt_pgbs_exclusion_add(exclusions,
                                                         observer_pid);
         }
-        ssize_t output_len = observer_line_len >= 0
+        remaining_ms = deadline_remaining_ms(deadline_ms);
+        ssize_t output_len = observer_line_len >= 0 && remaining_ms > 0
             ? read_proc_output_bounded(&observer, output, sizeof(output),
-                                       3000, false)
+                                       remaining_ms, false)
             : -1;
         char *save = NULL;
         for (char *line = output_len >= 0
@@ -1762,21 +1809,29 @@ static int observe_controlled_backend(const char *psql, const char *user,
                        &query_id, &active) == 5)
                 continue;
         }
-        if (observer_pid > 0 && observer_excluded != 0) {
+        bool exclusion_failed = observer_pid > 0 && observer_excluded != 0;
+        if (!exclusion_failed && target_pid > 0 &&
+            pgwt_pgbs_exclusion_add(exclusions, target_pid) != 0)
+            exclusion_failed = true;
+        if (exclusion_failed)
             (void)kill(observer.pid, SIGTERM);
-            (void)pgwt_proc_close(&observer);
+        int close_timeout_ms = deadline_remaining_ms(
+            exclusion_failed ? cleanup_deadline_ms : deadline_ms);
+        int status = pgwt_proc_close_bounded(&observer, close_timeout_ms);
+        if (exclusion_failed) {
+            if (observer_pid > 0 && observer_start_time > 0)
+                (void)terminate_backend_and_wait(
+                    observer_pid, observer_start_time, cleanup_deadline_ms);
             return -1;
         }
-        if (target_pid > 0 &&
-            pgwt_pgbs_exclusion_add(exclusions, target_pid) != 0) {
-            (void)kill(observer.pid, SIGTERM);
-            (void)pgwt_proc_close(&observer);
-            return -1;
-        }
-        int status = pgwt_proc_close(&observer);
         if (observer_pid <= 0 || observer_start_time == 0 ||
-            wait_for_pid_retirement(observer_pid, observer_start_time) != 0)
+            wait_for_pid_retirement(observer_pid, observer_start_time,
+                                    deadline_ms) != 0) {
+            if (observer_pid > 0 && observer_start_time > 0)
+                (void)terminate_backend_and_wait(
+                    observer_pid, observer_start_time, cleanup_deadline_ms);
             return -1;
+        }
         bool qid_ok = pg_major < 14 || !want_active || query_id != 0;
         if (output_len >= 0 && status == 0 && target_pid > 0 &&
             databaseid > 0 && userid > 0 &&
@@ -1896,6 +1951,11 @@ void pgwt_pgbs_validate_runtime(struct PgBackendStatusLayout *layout,
         degrade_unvalidated(layout, "could not start controlled backend");
         return;
     }
+    uint64_t validation_deadline_ms =
+        monotonic_ms() + PGWT_PGBS_VALIDATION_TIMEOUT_MS;
+    uint64_t cleanup_deadline_ms = validation_deadline_ms +
+                                   PGWT_PGBS_CLEANUP_TIMEOUT_MS;
+    bool controlled_command_pending = false;
 
     char command[256];
     const char *validation_step = "controlled PID handshake";
@@ -1906,9 +1966,11 @@ void pgwt_pgbs_validate_runtime(struct PgBackendStatusLayout *layout,
     uint64_t controlled_start_time = 0;
     unsigned long long activity_buffer_size = 0;
     char controlled_line[128];
+    int remaining_ms = deadline_remaining_ms(validation_deadline_ms);
     if (observed == 0 &&
         read_proc_output_bounded(&controlled, controlled_line,
-                                 sizeof(controlled_line), 3000, true) >= 0 &&
+                                 sizeof(controlled_line),
+                                 remaining_ms, true) >= 0 &&
         sscanf(controlled_line, "controlled|%d|%llu", &controlled_pid,
                &activity_buffer_size) == 2 &&
         controlled_pid > 0 && activity_buffer_size >= 2 &&
@@ -1927,9 +1989,30 @@ void pgwt_pgbs_validate_runtime(struct PgBackendStatusLayout *layout,
             observed = send_psql(&controlled, "SET compute_query_id=on;");
     if (observed == 0)
         validation_step = "idle marker command";
-    snprintf(command, sizeof(command), "SELECT 1 /* %s */;", idle_marker);
-    if (observed == 0)
+    snprintf(command, sizeof(command),
+             "SELECT 'idle-ready' /* %s */;", idle_marker);
+    if (observed == 0) {
         observed = send_psql(&controlled, command);
+        controlled_command_pending = observed == 0;
+    }
+    /* Completion barrier: an idle observer before this output could be the
+     * backend's pre-command state. Consuming the unique result proves the
+     * marker ran; the following bounded observer must see the post-command
+     * idle state whose retained activity text contains idle_marker. */
+    if (observed == 0) {
+        validation_step = "idle marker completion";
+        remaining_ms = deadline_remaining_ms(validation_deadline_ms);
+        char idle_ready_line[64];
+        if (remaining_ms <= 0 ||
+            read_proc_output_bounded(&controlled, idle_ready_line,
+                                     sizeof(idle_ready_line), remaining_ms,
+                                     true) < 0 ||
+            strncmp(idle_ready_line, "idle-ready", 10) != 0) {
+            observed = -1;
+        } else {
+            controlled_command_pending = false;
+        }
+    }
 
     struct pgwt_pgbs_expected idle_expected, first_expected, second_expected;
     memset(&idle_expected, 0, sizeof(idle_expected));
@@ -1945,7 +2028,8 @@ void pgwt_pgbs_validate_runtime(struct PgBackendStatusLayout *layout,
         validation_step = "idle observation";
         observed = observe_controlled_backend(
             psql, user, socket_dir, port, appname, layout->major, false,
-            &idle_expected, exclusions);
+            &idle_expected, exclusions, validation_deadline_ms,
+            cleanup_deadline_ms);
     }
     if (observed == 0) {
         validation_step = "idle activity-marker snapshot";
@@ -1958,16 +2042,19 @@ void pgwt_pgbs_validate_runtime(struct PgBackendStatusLayout *layout,
     }
 
     snprintf(command, sizeof(command),
-             "SELECT pg_sleep(2) /* %s */;", first_marker);
+             "SELECT pg_sleep(%d) /* %s */;",
+             PGWT_PGBS_ACTIVE_WINDOW_S, first_marker);
     if (observed == 0) {
         validation_step = "first active command";
         observed = send_psql(&controlled, command);
+        controlled_command_pending = observed == 0;
     }
     if (observed == 0) {
         validation_step = "first active observation";
         observed = observe_controlled_backend(
             psql, user, socket_dir, port, appname, layout->major, true,
-            &first_expected, exclusions);
+            &first_expected, exclusions, validation_deadline_ms,
+            cleanup_deadline_ms);
     }
     if (observed == 0) {
         validation_step = "first active activity-marker snapshot";
@@ -1989,6 +2076,8 @@ void pgwt_pgbs_validate_runtime(struct PgBackendStatusLayout *layout,
                                        controlled_start_time) ||
             kill(controlled_pid, SIGINT) != 0)
             observed = -1;
+        else
+            controlled_command_pending = false;
     }
 
     /* Wait for the same backend to become idle before issuing the second,
@@ -2000,20 +2089,24 @@ void pgwt_pgbs_validate_runtime(struct PgBackendStatusLayout *layout,
         validation_step = "between-command idle observation";
         observed = observe_controlled_backend(
             psql, user, socket_dir, port, appname, layout->major, false,
-            &between_expected, exclusions);
+            &between_expected, exclusions, validation_deadline_ms,
+            cleanup_deadline_ms);
     }
 
     snprintf(command, sizeof(command),
-             "SELECT 1 FROM pg_sleep(2) /* %s */;", second_marker);
+             "SELECT 1 FROM pg_sleep(%d) /* %s */;",
+             PGWT_PGBS_ACTIVE_WINDOW_S, second_marker);
     if (observed == 0) {
         validation_step = "second active command";
         observed = send_psql(&controlled, command);
+        controlled_command_pending = observed == 0;
     }
     if (observed == 0) {
         validation_step = "second active observation";
         observed = observe_controlled_backend(
             psql, user, socket_dir, port, appname, layout->major, true,
-            &second_expected, exclusions);
+            &second_expected, exclusions, validation_deadline_ms,
+            cleanup_deadline_ms);
     }
     if (observed == 0) {
         validation_step = "second active activity-marker snapshot";
@@ -2030,23 +2123,44 @@ void pgwt_pgbs_validate_runtime(struct PgBackendStatusLayout *layout,
                                        controlled_start_time) ||
             kill(controlled_pid, SIGINT) != 0)
             observed = -1;
+        else
+            controlled_command_pending = false;
     }
 
     /* Finish the final statement, then deliver EOF and drain psql's small
      * result stream before reaping it.  Closing stdout first would give psql
      * SIGPIPE after the validation had already succeeded. */
+    if (controlled_command_pending) {
+        if (!pgwt_pgbs_pid_is_original(controlled_pid,
+                                       controlled_start_time) ||
+            kill(controlled_pid, SIGINT) != 0)
+            observed = -1;
+        controlled_command_pending = false;
+    }
     if (controlled.in) {
         fclose(controlled.in);
         controlled.in = NULL;
     }
     char discard[512];
-    if (read_proc_output_bounded(&controlled, discard, sizeof(discard),
-                                 3000, false) < 0)
+    remaining_ms = deadline_remaining_ms(
+        observed == 0 ? validation_deadline_ms : cleanup_deadline_ms);
+    if (remaining_ms <= 0) {
         observed = -1;
-    int controlled_status = pgwt_proc_close(&controlled);
+        remaining_ms = deadline_remaining_ms(cleanup_deadline_ms);
+    }
+    if (read_proc_output_bounded(&controlled, discard, sizeof(discard),
+                                 remaining_ms, false) < 0)
+        observed = -1;
+    int controlled_status = pgwt_proc_close_bounded(
+        &controlled, deadline_remaining_ms(cleanup_deadline_ms));
     bool retired = controlled_pid > 0 &&
                    wait_for_pid_retirement(controlled_pid,
-                                           controlled_start_time) == 0;
+                       controlled_start_time,
+                       cleanup_deadline_ms) == 0;
+    if (!retired && controlled_pid > 0 && controlled_start_time > 0)
+        retired = terminate_backend_and_wait(controlled_pid,
+                                             controlled_start_time,
+                                             cleanup_deadline_ms) == 0;
     if (!retired) {
         char reason[192];
         snprintf(reason, sizeof(reason),

--- a/src/backend_status_layout.h
+++ b/src/backend_status_layout.h
@@ -236,6 +236,11 @@ void pgwt_pgbs_validate_runtime(struct PgBackendStatusLayout *layout,
 int pgwt_pgbs_pid_start_time(pid_t pid, uint64_t *start_time);
 bool pgwt_pgbs_pid_is_original(pid_t pid, uint64_t start_time);
 int pgwt_pgbs_exclusion_add(struct pgwt_pgbs_exclusion_set *set, pid_t pid);
+/* Add a short-lived helper only while it is still live. If /proc identity
+ * capture loses the exit race, already_retired is true and no entry is kept. */
+int pgwt_pgbs_exclusion_add_live(struct pgwt_pgbs_exclusion_set *set,
+                                 pid_t pid, uint64_t *start_time,
+                                 bool *already_retired);
 bool pgwt_pgbs_exclusion_contains(const struct pgwt_pgbs_exclusion_set *set,
                                   pid_t pid);
 /* Auth-free fallback used only when the controlled backend could not be

--- a/src/bpf/pg_wait_tracer.bpf.c
+++ b/src/bpf/pg_wait_tracer.bpf.c
@@ -180,8 +180,9 @@ struct {
 } accum_map SEC(".maps");
 
 /* event_ringbuf drop counter (A2). Single per-CPU u64 bumped when a
- * bpf_ringbuf_output() into event_ringbuf fails (ring full). PERCPU so the
- * hot path stays atomic-free; the daemon sums across CPUs and surfaces it as
+ * bpf_ringbuf_output() into event_ringbuf fails (capacity or reservation
+ * contention, including NMI context). PERCPU so the hot path stays
+ * atomic-free; the daemon sums across CPUs and surfaces it as
  * ringbuf_drops_total on the control socket. */
 struct {
     __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
@@ -211,7 +212,9 @@ static __always_inline void count_map_fail(u32 slot)
 }
 
 /* Emit a trace event to event_ringbuf, counting drops on failure.
- * bpf_ringbuf_output() returns 0 on success, negative when the ring is full. */
+ * bpf_ringbuf_output() returns 0 on success, negative when reservation/output
+ * fails; an NMI-context reservation can lose spinlock contention even while
+ * the ring has free capacity. */
 static __always_inline void emit_event(const struct pgwt_trace_event *evt)
 {
     long rc = bpf_ringbuf_output(&event_ringbuf, (void *)evt, sizeof(*evt),

--- a/src/compute.c
+++ b/src/compute.c
@@ -947,7 +947,11 @@ void pgwt_compute_top_events(const struct pgwt_trace_event *events, int count,
             ht[h].event_id = ev->old_event;
             num_entries++;
         }
-        ht[h].count++;
+        /* Exact-window subtraction can split one delayed sampled observation
+         * into multiple timeline fragments. Preserve its duration pieces but
+         * count the physical observation once. */
+        if (!(ev->flags & PGWT_EVENT_FLAG_SAMPLE_CONT) || ht[h].count == 0)
+            ht[h].count++;
         ht[h].total_ns += ev->duration_ns;
         /* Latency stats from exact records only (FID-3). */
         if (!(ev->flags & PGWT_EVENT_FLAG_SAMPLE)) {
@@ -1158,7 +1162,9 @@ void pgwt_compute_top_queries(const struct pgwt_trace_event *events, int count,
             ht[h].query_id = ev->query_id;
             num_entries++;
         }
-        ht[h].count++;
+        /* Split sample continuations conserve time, not observation count. */
+        if (!(ev->flags & PGWT_EVENT_FLAG_SAMPLE_CONT) || ht[h].count == 0)
+            ht[h].count++;
         ht[h].total_ns += ev->duration_ns;
         ht[h].class_ns[pgwt_wait_class_index(ev->old_event)] += ev->duration_ns;
 
@@ -2224,6 +2230,11 @@ void pgwt_compute_transitions(const struct pgwt_trace_event *events, int count,
 
     for (int i = 0; i < count; i++) {
         const struct pgwt_trace_event *ev = &events[i];
+        /* Exact-required view: normalized sample points are not state
+         * transitions. In a mixed window they remain available to sampled
+         * views only. */
+        if (ev->flags & PGWT_EVENT_FLAG_SAMPLE)
+            continue;
         if (!pgwt_filter_matches(f, ev))
             continue;
         /* Visibility filter: Client:ClientRead transitions stay in the graph. */
@@ -2318,6 +2329,10 @@ void pgwt_compute_fingerprints(const struct pgwt_trace_event *events, int count,
 
     for (int i = 0; i < count; i++) {
         const struct pgwt_trace_event *ev = &events[i];
+        /* Fingerprints describe exact transition structure; sampled records
+         * (including clipped continuations) must not fabricate self-edges. */
+        if (ev->flags & PGWT_EVENT_FLAG_SAMPLE)
+            continue;
         if (!pgwt_filter_matches(f, ev))
             continue;
         if (pgwt_is_idle_event(ev->old_event))

--- a/src/control.c
+++ b/src/control.c
@@ -414,7 +414,7 @@ static cJSON *build_escalate(struct pgwt_daemon *d, cJSON *req)
     int granted = 0;
     const char *why = NULL;
     if (pgwt_escalate(d, duration_s, PGWT_ESC_REASON_MANUAL,
-                      &granted, &why) != 0) {
+                      &granted, &why, NULL) != 0) {
         cJSON_AddBoolToObject(root, "ok", 0);
         cJSON_AddStringToObject(root, "error",
                                 why ? why : "escalation denied");

--- a/src/escalation.c
+++ b/src/escalation.c
@@ -407,15 +407,21 @@ static void arm_deadline(struct pgwt_escalation *e, uint64_t deadline_ns)
 }
 
 int pgwt_escalate(struct pgwt_daemon *d, int duration_s, int reason,
-                  int *granted_s, const char **why)
+                  int *granted_s, const char **why,
+                  enum pgwt_escalate_failure *failure)
 {
     struct pgwt_escalation *e = &d->escalation;
 
+    if (failure)
+        *failure = PGWT_ESC_FAIL_NONE;
+
     if (!e->enabled) {
+        if (failure) *failure = PGWT_ESC_FAIL_INVALID;
         if (why) *why = "escalation requires --mode tiered";
         return -1;
     }
     if (duration_s <= 0) {
+        if (failure) *failure = PGWT_ESC_FAIL_INVALID;
         if (why) *why = "duration_s must be positive";
         return -1;
     }
@@ -430,6 +436,7 @@ int pgwt_escalate(struct pgwt_daemon *d, int duration_s, int reason,
      * matter how many times it is extended (the extend-every-second attack). */
     uint64_t grant_ns = want_ns;
     if (pgwt_esc_budget_decide(e, now, want_ns, &grant_ns, why) != 0) {
+        if (failure) *failure = PGWT_ESC_FAIL_BUDGET;
         e->denied_total++;
         return -1;
     }
@@ -459,6 +466,7 @@ int pgwt_escalate(struct pgwt_daemon *d, int duration_s, int reason,
         e->generation = 0;
         e->attach_boundary_ns = 0;
         e->denied_total++;
+        if (failure) *failure = PGWT_ESC_FAIL_EXACT_ATTACH;
         if (why)
             *why = "exact probe bundle attach failed; escalation rolled back";
         return -1;
@@ -474,6 +482,7 @@ int pgwt_escalate(struct pgwt_daemon *d, int duration_s, int reason,
         e->generation = 0;
         e->attach_boundary_ns = 0;
         e->denied_total++;
+        if (failure) *failure = PGWT_ESC_FAIL_EXACT_PRESEED;
         if (why)
             *why = "coherent exact preseed failed; escalation rolled back";
         return -1;

--- a/src/escalation.h
+++ b/src/escalation.h
@@ -34,6 +34,17 @@
 
 struct pgwt_daemon;
 
+/* Why an escalation request failed.  Automatic callers use this to
+ * distinguish a durable budget denial from a transient exact-mode setup
+ * failure that should be retried after collecting fresh anomaly evidence. */
+enum pgwt_escalate_failure {
+    PGWT_ESC_FAIL_NONE = 0,
+    PGWT_ESC_FAIL_INVALID,
+    PGWT_ESC_FAIL_BUDGET,
+    PGWT_ESC_FAIL_EXACT_ATTACH,
+    PGWT_ESC_FAIL_EXACT_PRESEED,
+};
+
 /* Rolling-hour budget ledger. Each closed window appends one segment; the
  * accounting drops segments older than the window when computing consumed
  * seconds, giving a true rolling-hour figure without a per-second ring. */
@@ -88,9 +99,11 @@ void pgwt_escalation_cleanup(struct pgwt_daemon *d);
  * is escalated; returns 0. On denial returns -1 and *why (if non-NULL) points
  * to a static reason string. If already escalated the deadline is EXTENDED to
  * max(current, now+duration) when budget allows. Budget is enforced for every
- * caller (manual and anomaly). */
+ * caller (manual and anomaly).  When failure is non-NULL it is set to a
+ * machine-readable reason; why remains the operator-facing detail. */
 int pgwt_escalate(struct pgwt_daemon *d, int duration_s, int reason,
-                  int *granted_s, const char **why);
+                  int *granted_s, const char **why,
+                  enum pgwt_escalate_failure *failure);
 
 /* Detach now (idempotent). reason is recorded in the END marker. */
 void pgwt_deescalate(struct pgwt_daemon *d, int reason);

--- a/src/exact_probe.c
+++ b/src/exact_probe.c
@@ -210,10 +210,22 @@ static void *attach_link(void *ctx, enum pgwt_exact_probe_index index)
     const char *bin = d->pg_binary_saved;
     struct bpf_link *link = NULL;
     const char *fail = getenv("PGWT_TEST_EXACT_PROBE_FAIL_AT");
-    if (fail && atoi(fail) == (int)index) {
+    const char *escalation_fail =
+        getenv("PGWT_TEST_EXACT_PROBE_ESCALATION_FAIL_AT");
+    bool force_startup_or_exact = fail && atoi(fail) == (int)index;
+    /* The escalation-only variant exercises atomic acquisition rollback
+     * without corrupting startup capability discovery.  Keep the original
+     * unscoped hook for the independent startup-degradation regression test. */
+    bool force_escalation = escalation_fail &&
+        atoi(escalation_fail) == (int)index &&
+        d->escalation.generation != 0;
+    if (force_startup_or_exact || force_escalation) {
         errno = EIO;
-        fprintf(stderr, "WARN: PGWT_TEST_EXACT_PROBE_FAIL_AT=%d -- forcing "
-                "exact-link attach failure (TEST ONLY)\n", index);
+        fprintf(stderr, "WARN: %s=%d -- forcing exact-link attach failure "
+                "(TEST ONLY)\n",
+                force_startup_or_exact ? "PGWT_TEST_EXACT_PROBE_FAIL_AT" :
+                "PGWT_TEST_EXACT_PROBE_ESCALATION_FAIL_AT",
+                index);
         return NULL;
     }
     if (!bin) {
@@ -604,6 +616,18 @@ int pgwt_exact_seed_backend(struct pgwt_daemon *d, pid_t pid,
 
 int pgwt_exact_seed_all(struct pgwt_daemon *d, uint64_t generation)
 {
+    /* Deterministic integration hook for anomaly retry coverage: fail exactly
+     * one coherent preseed in this process, after link acquisition but before
+     * publishing any generation seed. */
+    static bool test_preseed_failed_once;
+    if (!test_preseed_failed_once &&
+        getenv("PGWT_TEST_EXACT_PRESEED_FAIL_ONCE")) {
+        test_preseed_failed_once = true;
+        fprintf(stderr, "WARN: PGWT_TEST_EXACT_PRESEED_FAIL_ONCE -- forcing "
+                "one coherent preseed rollback (TEST ONLY)\n");
+        return -1;
+    }
+
     for (int i = 0; i < d->backends.count; i++) {
         struct pgwt_backend *be = &d->backends.entries[i];
         if (!be->is_alive || be->pid <= 0)

--- a/src/pg_wait_tracer.c
+++ b/src/pg_wait_tracer.c
@@ -690,17 +690,24 @@ int main(int argc, char **argv)
     }
     /* pg_binary_saved is set by pgwt_discover via strdup (heap-allocated) */
 
+    /* Block shutdown signals before pgwt_daemon_init() can create worker
+     * threads. Every thread must inherit the blocked mask so SIGINT/SIGTERM
+     * are consumed by the main loop's signalfd and run normal finalization.
+     * Daemon mode used to do this here while single-shot mode waited until
+     * late init, after the asynchronous pgss resolver had already started. */
+    sigset_t shutdown_mask;
+    sigemptyset(&shutdown_mask);
+    sigaddset(&shutdown_mask, SIGINT);
+    sigaddset(&shutdown_mask, SIGTERM);
+    if (sigprocmask(SIG_BLOCK, &shutdown_mask, NULL) != 0) {
+        perror("sigprocmask");
+        free(d);
+        return 1;
+    }
+
     /* ── Daemon mode: supervision loop ─────────────────────── */
     if (daemon_mode) {
         int rc = 0;
-
-        /* Block signals for sigtimedwait in wait phase.
-         * pgwt_daemon_init() will also call sigprocmask (idempotent). */
-        sigset_t mask;
-        sigemptyset(&mask);
-        sigaddset(&mask, SIGINT);
-        sigaddset(&mask, SIGTERM);
-        sigprocmask(SIG_BLOCK, &mask, NULL);
 
         for (;;) {
             if (pgwt_daemon_init(d) != 0) {
@@ -719,7 +726,7 @@ int main(int argc, char **argv)
             bool found = false;
             while (!found) {
                 struct timespec ts = { .tv_sec = 5 };
-                int sig = sigtimedwait(&mask, NULL, &ts);
+                int sig = sigtimedwait(&shutdown_mask, NULL, &ts);
                 if (sig > 0) {
                     fprintf(stderr, "\npg_wait_tracer: shutting down\n");
                     goto done;

--- a/src/pg_wait_tracer.c
+++ b/src/pg_wait_tracer.c
@@ -681,20 +681,12 @@ int main(int argc, char **argv)
         }
     }
 
-    /* First discovery */
-    if (pgwt_discover(d) != 0) {
-        if (!pgdata && pm_pid == 0)
-            fprintf(stderr, "\nUse --pid <PID> or --pgdata <DIR>\n");
-        free(d);
-        return 1;
-    }
-    /* pg_binary_saved is set by pgwt_discover via strdup (heap-allocated) */
-
-    /* Block shutdown signals before pgwt_daemon_init() can create worker
-     * threads. Every thread must inherit the blocked mask so SIGINT/SIGTERM
-     * are consumed by the main loop's signalfd and run normal finalization.
-     * Daemon mode used to do this here while single-shot mode waited until
-     * late init, after the asynchronous pgss resolver had already started. */
+    /* Block shutdown signals before first discovery. Runtime layout
+     * validation can run controlled PostgreSQL backends for an extended
+     * bounded interval; leaving SIGTERM asynchronous here could kill the
+     * tracer before their identity-safe cleanup. The helper spawn path
+     * restores child masks, and every later worker thread inherits this mask,
+     * preserving the resolver/signalfd ordering invariant. */
     sigset_t shutdown_mask;
     sigemptyset(&shutdown_mask);
     sigaddset(&shutdown_mask, SIGINT);
@@ -704,6 +696,15 @@ int main(int argc, char **argv)
         free(d);
         return 1;
     }
+
+    /* First discovery */
+    if (pgwt_discover(d) != 0) {
+        if (!pgdata && pm_pid == 0)
+            fprintf(stderr, "\nUse --pid <PID> or --pgdata <DIR>\n");
+        free(d);
+        return 1;
+    }
+    /* pg_binary_saved is set by pgwt_discover via strdup (heap-allocated) */
 
     /* ── Daemon mode: supervision loop ─────────────────────── */
     if (daemon_mode) {

--- a/src/pg_wait_tracer.h
+++ b/src/pg_wait_tracer.h
@@ -233,6 +233,7 @@ struct pgwt_trace_event {
 #define PGWT_EVENT_FLAG_PLAN       0x20U  /* inside a PLAN marker window */
 #define PGWT_EVENT_FLAG_EXEC       0x40U  /* inside an EXEC marker window */
 #define PGWT_EVENT_FLAG_QUERY_SYNTH 0x80U /* PG13 escalation straddler seed */
+#define PGWT_EVENT_FLAG_SAMPLE_CONT 0x100U /* reader-only split continuation */
 
 #define PGWT_EVENT_EXIT  0xFFFFFFFFU  /* sentinel new_event for process exit */
 

--- a/src/server.c
+++ b/src/server.c
@@ -18,6 +18,7 @@
 #include <ctype.h>
 #include <time.h>
 #include <errno.h>
+#include <limits.h>
 #include <sys/stat.h>
 #include <sys/socket.h>
 #include <sys/un.h>
@@ -229,6 +230,8 @@ struct pgwt_load_info {
     uint64_t sample_period_ns;  /* nominal sample interval (0 if no samples) */
     int      overloaded;        /* DUR-9: hard load bound hit — result is
                                    partial; handlers MUST error, not render */
+    int      allocation_failed; /* working/merge allocation failed — never
+                                   misreport this as a range-size refusal */
 };
 
 struct pgwt_server {
@@ -1050,13 +1053,15 @@ static int load_max_events(void)
  * ASH math.
  * DUR-9: `pid` != 0 pushes the pid filter into the load (events for other
  * pids never enter the working array); *overloaded is set and the load
- * stops when *total reaches load_max_events(). */
+ * stops when *total reaches load_max_events(). Allocation failure is reported
+ * independently through *allocation_failed. */
 static void load_file_range_mono(const char *path,
                                  uint64_t from_mono, uint64_t to_mono,
                                  uint64_t sample_to_mono,
                                  uint32_t pid, int markers_only,
                                  struct pgwt_trace_event **events,
-                                 int *total, int *cap, int *overloaded)
+                                 int *total, int *cap, int *overloaded,
+                                 int *allocation_failed)
 {
     struct pgwt_event_reader reader;
     if (pgwt_reader_open(&reader, path) != 0)
@@ -1092,10 +1097,21 @@ static void load_file_range_mono(const char *path,
                 return;
             }
             if (*total >= *cap) {
-                *cap *= 2;
-                struct pgwt_trace_event *tmp = realloc(*events, *cap * sizeof(**events));
-                if (!tmp) { pgwt_reader_close(&reader); return; }
+                int next = *cap < max_events / 2 ? *cap * 2 : max_events;
+                if (next <= *cap) {
+                    *overloaded = 1;
+                    pgwt_reader_close(&reader);
+                    return;
+                }
+                struct pgwt_trace_event *tmp =
+                    realloc(*events, (size_t)next * sizeof(**events));
+                if (!tmp) {
+                    *allocation_failed = 1;
+                    pgwt_reader_close(&reader);
+                    return;
+                }
                 *events = tmp;
+                *cap = next;
             }
 
             (*events)[*total] = block_buf[i];
@@ -1582,22 +1598,37 @@ static int spans_first_ending_after(const struct pgwt_span *s, int n,
 /* Append one event to the fidelity-merged result. Sample clipping can turn
  * one delayed, measured-elapsed sample into two uncovered fragments, so the
  * merge cannot safely compact the input array in place. */
-static int merge_append_event(struct pgwt_trace_event **events, int *count,
-                              int *capacity, int max_events,
-                              const struct pgwt_trace_event *event,
-                              int64_t wall_offset)
+enum pgwt_merge_append_result {
+    PGWT_MERGE_APPEND_OK = 0,
+    PGWT_MERGE_APPEND_CAPACITY,
+    PGWT_MERGE_APPEND_NOMEM,
+};
+
+static bool test_load_alloc_failure(const char *point)
+{
+    const char *fail = getenv("PGWT_TEST_LOAD_ALLOC_FAIL");
+    return fail && strcmp(fail, point) == 0;
+}
+
+static enum pgwt_merge_append_result
+merge_append_event(struct pgwt_trace_event **events, int *count,
+                   int *capacity, int max_events,
+                   const struct pgwt_trace_event *event,
+                   int64_t wall_offset)
 {
     if (*count >= max_events)
-        return -1;
+        return PGWT_MERGE_APPEND_CAPACITY;
     if (*count >= *capacity) {
         int next = *capacity < max_events / 2
                  ? *capacity * 2 : max_events;
         if (next <= *capacity)
-            return -1;
+            return PGWT_MERGE_APPEND_CAPACITY;
+        if (test_load_alloc_failure("merge_grow"))
+            return PGWT_MERGE_APPEND_NOMEM;
         struct pgwt_trace_event *grown =
             realloc(*events, (size_t)next * sizeof(**events));
         if (!grown)
-            return -1;
+            return PGWT_MERGE_APPEND_NOMEM;
         *events = grown;
         *capacity = next;
     }
@@ -1605,10 +1636,10 @@ static int merge_append_event(struct pgwt_trace_event **events, int *count,
     (*events)[*count].timestamp_ns = (uint64_t)
         ((int64_t)event->timestamp_ns + wall_offset);
     (*count)++;
-    return 0;
+    return PGWT_MERGE_APPEND_OK;
 }
 
-static int merge_append_sample_part(
+static enum pgwt_merge_append_result merge_append_sample_part(
     struct pgwt_trace_event **events, int *count, int *capacity,
     int max_events, const struct pgwt_trace_event *sample,
     uint64_t part_start, uint64_t part_end,
@@ -1619,7 +1650,7 @@ static int merge_append_sample_part(
                            ? part_start : range_start;
     uint64_t clipped_end = part_end < range_end ? part_end : range_end;
     if (clipped_end <= clipped_start)
-        return 0;
+        return PGWT_MERGE_APPEND_OK;
 
     struct pgwt_trace_event part = *sample;
     part.timestamp_ns = clipped_end;
@@ -1628,11 +1659,13 @@ static int merge_append_sample_part(
         part.flags |= PGWT_EVENT_FLAG_SAMPLE_CONT;
     else
         part.flags &= ~PGWT_EVENT_FLAG_SAMPLE_CONT;
-    if (merge_append_event(events, count, capacity, max_events, &part,
-                           wall_offset) != 0)
-        return -1;
+    enum pgwt_merge_append_result appended =
+        merge_append_event(events, count, capacity, max_events, &part,
+                           wall_offset);
+    if (appended != PGWT_MERGE_APPEND_OK)
+        return appended;
     *contributed = true;
-    return 0;
+    return PGWT_MERGE_APPEND_OK;
 }
 
 /* Clipping can move a delayed sample fragment before records that preceded
@@ -1642,6 +1675,8 @@ static int stable_sort_events(struct pgwt_trace_event *events, int count)
 {
     if (count < 2)
         return 0;
+    if (test_load_alloc_failure("sort"))
+        return -1;
     struct pgwt_trace_event *tmp =
         malloc((size_t)count * sizeof(*tmp));
     if (!tmp)
@@ -1798,6 +1833,7 @@ server_load_events_fi_mode(struct pgwt_server *srv,
     *out_count = 0;
     if (info) memset(info, 0, sizeof(*info));
     int overloaded = 0;
+    int allocation_failed = 0;
     int max_events = load_max_events();
 
     /* Rescan directory + refresh coverage/clock-domain state. */
@@ -1808,9 +1844,15 @@ server_load_events_fi_mode(struct pgwt_server *srv,
     if (to_wall_ns == 0)
         to_wall_ns = srv->latest_wall_ns;
 
-    int cap = 65536;
+    int cap = max_events < 65536 ? max_events : 65536;
+    if (cap < 1)
+        cap = 1;
     struct pgwt_trace_event *events = malloc(cap * sizeof(*events));
-    if (!events) return NULL;
+    if (!events) {
+        if (info)
+            info->allocation_failed = 1;
+        return NULL;
+    }
     int total = 0;
 
     /* Per-segment bookkeeping: each file contributes one contiguous run of
@@ -1824,7 +1866,9 @@ server_load_events_fi_mode(struct pgwt_server *srv,
     int n_segs = 0;
     uint64_t sample_period_ns = 0;
 
-    for (int ci = 0; ci < srv->cov_count && n_segs < 256 && !overloaded;
+    for (int ci = 0;
+         ci < srv->cov_count && n_segs < 256 &&
+         !overloaded && !allocation_failed;
          ci++) {
         struct pgwt_file_cov *fc = &srv->cov[ci];
         if (!fc->valid)
@@ -1857,14 +1901,16 @@ server_load_events_fi_mode(struct pgwt_server *srv,
              * available for clipping. Non-samples are rejected below. */
             load_file_range_mono(fc->path, from_m, to_m, sample_to_m,
                                  pid, markers_only,
-                                 &events, &total, &cap, &overloaded);
+                                 &events, &total, &cap, &overloaded,
+                                 &allocation_failed);
         } else {
             struct file_cache_entry *ce = get_cached_immutable(srv, fc->path);
             if (!ce || !ce->events) {
                 /* Cache miss (file too large or alloc failed) */
                 load_file_range_mono(fc->path, from_m, to_m, sample_to_m,
                                      pid, markers_only,
-                                     &events, &total, &cap, &overloaded);
+                                     &events, &total, &cap, &overloaded,
+                                     &allocation_failed);
             } else {
                 for (int i = 0; i < ce->count; i++) {
                     uint64_t ts = ce->events[i].timestamp_ns;
@@ -1883,11 +1929,20 @@ server_load_events_fi_mode(struct pgwt_server *srv,
                         break;
                     }
                     if (total >= cap) {
-                        cap *= 2;
+                        int next = cap < max_events / 2
+                                 ? cap * 2 : max_events;
+                        if (next <= cap) {
+                            overloaded = 1;
+                            break;
+                        }
                         struct pgwt_trace_event *tmp =
-                            realloc(events, cap * sizeof(*tmp));
-                        if (!tmp) { *out_count = total; return events; }
+                            realloc(events, (size_t)next * sizeof(*tmp));
+                        if (!tmp) {
+                            allocation_failed = 1;
+                            break;
+                        }
                         events = tmp;
+                        cap = next;
                     }
                     events[total++] = ce->events[i];
                 }
@@ -1905,26 +1960,71 @@ server_load_events_fi_mode(struct pgwt_server *srv,
         }
     }
 
+    if (allocation_failed) {
+        if (info)
+            info->allocation_failed = 1;
+        *out_count = total;
+        return events;
+    }
+
     /* Exact-wins merge (mono, per generation) + wall re-anchoring, then
      * derive what actually contributed for the fidelity indicator. Use a
      * separate output because subtracting exact spans can split one delayed
-     * sample into multiple uncovered fragments. */
+     * sample into multiple uncovered fragments. The raw-load limit is not an
+     * output limit: reserve a proven upper bound of one result per input plus
+     * one extra fragment per intersecting exact span. */
     int has_transitions = 0, has_samples = 0;
+    size_t merge_limit_sz = (size_t)total;
+    for (int s = 0; s < n_segs && !allocation_failed; s++) {
+        const struct pgwt_gen_cov *gc = gen_cov_get(srv, segs[s].gen);
+        if (!gc || gc->n_exact <= 0)
+            continue;
+        for (int i = segs[s].start; i < segs[s].start + segs[s].count; i++) {
+            if (!(events[i].flags & PGWT_EVENT_FLAG_SAMPLE))
+                continue;
+            uint64_t end = events[i].timestamp_ns;
+            uint64_t start = end >= events[i].duration_ns
+                           ? end - events[i].duration_ns : 0;
+            int first = spans_first_ending_after(gc->exact, gc->n_exact,
+                                                 start);
+            for (int j = first;
+                 j < gc->n_exact && gc->exact[j].start_ns < end; j++) {
+                if (merge_limit_sz >= INT_MAX) {
+                    allocation_failed = 1;
+                    break;
+                }
+                merge_limit_sz++;
+            }
+            if (allocation_failed)
+                break;
+        }
+    }
+    if (allocation_failed) {
+        if (info)
+            info->allocation_failed = 1;
+        *out_count = total;
+        return events;
+    }
+    int merge_max_events = (int)merge_limit_sz;
     int merged_cap = total > 0 ? total : 16;
-    if (merged_cap > max_events)
-        merged_cap = max_events;
     struct pgwt_trace_event *merged =
-        malloc((size_t)merged_cap * sizeof(*merged));
+        test_load_alloc_failure("merge_initial") ? NULL
+        : malloc((size_t)merged_cap * sizeof(*merged));
     if (!merged) {
         free(events);
         *out_count = 0;
+        if (info)
+            info->allocation_failed = 1;
         return NULL;
     }
     int kept = 0;
-    for (int s = 0; s < n_segs && !overloaded; s++) {
+    for (int s = 0;
+         s < n_segs && !overloaded && !allocation_failed; s++) {
         const struct pgwt_gen_cov *gc = gen_cov_get(srv, segs[s].gen);
         for (int i = segs[s].start;
-             i < segs[s].start + segs[s].count && !overloaded; i++) {
+             i < segs[s].start + segs[s].count &&
+             !overloaded && !allocation_failed;
+             i++) {
             if (events[i].flags & PGWT_EVENT_FLAG_SAMPLE) {
                 uint64_t end = events[i].timestamp_ns;
                 uint64_t start = end >= events[i].duration_ns
@@ -1948,12 +2048,14 @@ server_load_events_fi_mode(struct pgwt_server *srv,
                         if (exact_start > cursor) {
                             uint64_t part_end = exact_start < end
                                               ? exact_start : end;
-                            if (merge_append_sample_part(
-                                    &merged, &kept, &merged_cap, max_events,
-                                    &events[i], cursor, part_end,
-                                    segs[s].from_m, segs[s].to_m,
-                                    segs[s].off, &contributed) != 0) {
-                                overloaded = 1;
+                            enum pgwt_merge_append_result appended =
+                                merge_append_sample_part(
+                                    &merged, &kept, &merged_cap,
+                                    merge_max_events, &events[i], cursor,
+                                    part_end, segs[s].from_m,
+                                    segs[s].to_m, segs[s].off, &contributed);
+                            if (appended != PGWT_MERGE_APPEND_OK) {
+                                allocation_failed = 1;
                                 break;
                             }
                         }
@@ -1961,14 +2063,14 @@ server_load_events_fi_mode(struct pgwt_server *srv,
                             cursor = exact_end < end ? exact_end : end;
                     }
                 }
-                if (!overloaded && cursor < end) {
-                    if (merge_append_sample_part(
-                            &merged, &kept, &merged_cap, max_events,
-                            &events[i], cursor, end,
-                            segs[s].from_m, segs[s].to_m,
-                            segs[s].off, &contributed) != 0) {
-                        overloaded = 1;
-                    }
+                if (!overloaded && !allocation_failed && cursor < end) {
+                    enum pgwt_merge_append_result appended =
+                        merge_append_sample_part(
+                            &merged, &kept, &merged_cap, merge_max_events,
+                            &events[i], cursor, end, segs[s].from_m,
+                            segs[s].to_m, segs[s].off, &contributed);
+                    if (appended != PGWT_MERGE_APPEND_OK)
+                        allocation_failed = 1;
                 }
                 if (contributed)
                     has_samples = 1;
@@ -1997,10 +2099,12 @@ server_load_events_fi_mode(struct pgwt_server *srv,
                         continue;   /* phantom exit interval */
                 }
                 has_transitions = 1;
-                if (merge_append_event(&merged, &kept, &merged_cap,
-                                       max_events, &events[i],
-                                       segs[s].off) != 0)
-                    overloaded = 1;
+                enum pgwt_merge_append_result appended =
+                    merge_append_event(&merged, &kept, &merged_cap,
+                                       merge_max_events, &events[i],
+                                       segs[s].off);
+                if (appended != PGWT_MERGE_APPEND_OK)
+                    allocation_failed = 1;
             }
         }
     }
@@ -2015,8 +2119,9 @@ server_load_events_fi_mode(struct pgwt_server *srv,
             break;
         }
     }
-    if (!overloaded && !ordered && stable_sort_events(events, total) != 0)
-        overloaded = 1;
+    if (!overloaded && !allocation_failed && !ordered &&
+        stable_sort_events(events, total) != 0)
+        allocation_failed = 1;
 
     /* T2: annotate the merged window with categories (pid types from
      * backends.jsonl) and the PLAN/EXEC/CMD marker windows; classify exact
@@ -2030,12 +2135,16 @@ server_load_events_fi_mode(struct pgwt_server *srv,
         info->has_samples = has_samples;
         info->sample_period_ns = has_samples ? sample_period_ns : 0;
         info->overloaded = overloaded;
+        info->allocation_failed = allocation_failed;
     }
     if (overloaded)
         fprintf(stderr, "ERROR: window too large: the requested range holds "
                 "more than %d events%s — narrow the time range%s\n",
                 max_events, pid ? " for this pid" : "",
                 pid ? "" : " or add a pid/query filter");
+    if (allocation_failed)
+        fprintf(stderr, "ERROR: memory allocation failed while loading or "
+                "merging the requested event window\n");
 
     *out_count = total;
     return events;
@@ -2198,28 +2307,34 @@ static void emit_unavailable(uint64_t req_id, enum pgwt_fidelity fid)
     emit_json(root);
 }
 
-/* DUR-9: the raw-load hard bound fired — the loaded array is PARTIAL.
- * Rendering it would silently under-report; emit a structured error the
- * client can present ("window too large") instead. Frees the partial array
- * and returns 1 when the handler must stop. */
+/* A raw-load bound or allocation failure leaves a partial/unavailable array.
+ * Rendering it would silently under-report. Emit distinct structured errors
+ * so OOM is never mislabeled as a request that exceeded max_events. */
 static int reject_overload(struct pgwt_server *srv,
                            const struct pgwt_request *req,
                            struct pgwt_trace_event *events,
                            const struct pgwt_load_info *info)
 {
-    if (!info->overloaded)
+    if (!info->overloaded && !info->allocation_failed)
         return 0;
     free(events);
-    /* Keep the refusal's fidelity label in the same freshly-refreshed
+    /* Keep the failure's fidelity label in the same freshly-refreshed
      * coverage generation as the load which detected the bound. */
     coverage_refresh(srv);
     cJSON *root = cJSON_CreateObject();
     cJSON_AddNumberToObject(root, "id", (double)req->id);
-    cJSON_AddStringToObject(root, "error", "window too large");
-    cJSON_AddStringToObject(root, "code", "window_too_large");
-    cJSON_AddNumberToObject(root, "max_events", load_max_events());
-    cJSON_AddStringToObject(root, "hint",
-        "narrow the time range or add a pid/query filter");
+    if (info->allocation_failed) {
+        cJSON_AddStringToObject(root, "error", "memory allocation failed");
+        cJSON_AddStringToObject(root, "code", "allocation_failed");
+        cJSON_AddStringToObject(root, "hint",
+            "retry the request or reduce the time range");
+    } else {
+        cJSON_AddStringToObject(root, "error", "window too large");
+        cJSON_AddStringToObject(root, "code", "window_too_large");
+        cJSON_AddNumberToObject(root, "max_events", load_max_events());
+        cJSON_AddStringToObject(root, "hint",
+            "narrow the time range or add a pid/query filter");
+    }
     uint64_t from = req->from_ns ? req->from_ns : srv->earliest_wall_ns;
     uint64_t to = req->to_ns ? req->to_ns : srv->latest_wall_ns;
     if (strcmp(req->cmd, "execution_detail") == 0 &&
@@ -4265,6 +4380,11 @@ static void dump_summary(struct pgwt_server *srv)
     struct pgwt_load_info linfo = {0};
     struct pgwt_trace_event *events =
         server_load_events_fi(srv, from, to, 0, &count, &linfo);
+    if (linfo.allocation_failed) {
+        printf("ERROR: memory allocation failed while loading the trace\n");
+        free(events);
+        return;
+    }
     if (linfo.overloaded) {
         printf("ERROR: window too large — more than %d events in range; "
                "use the JSON interface with a narrower range\n",

--- a/src/server.c
+++ b/src/server.c
@@ -154,9 +154,10 @@ struct bm_entry {
  *      coverage.
  *
  * Boundary rule (FID-6): a sample represents the interval
- * (ts − period, ts]. It is dropped iff its MIDPOINT (ts − period/2) falls
- * inside a covered span (inclusive); worst-case error per window edge is
- * period/2, zero-mean.
+ * (ts − period, ts]. Exact spans are subtracted from that interval. Fully
+ * covered samples disappear; boundary-straddling samples retain only their
+ * uncovered pieces. This matters when SMP-3 weights a delayed tick by several
+ * seconds of measured elapsed time rather than one nominal sample period.
  *
  * Clock domain (FID-7): all coverage comparison happens in the MONOTONIC
  * domain. Files written by one daemon run share the monotonic clock; their
@@ -188,6 +189,7 @@ struct pgwt_file_cov {
     uint64_t mono_first, mono_last;
     int      has_samples, has_transitions;
     uint64_t sample_period_ns;
+    uint64_t max_sample_period_ns; /* SMP-3 lookahead, not reported cadence */
     int      blocks_scanned;       /* header-scan watermark (incremental) */
     struct pgwt_span *s_spans; int n_s, cap_s;   /* SAMPLES block spans */
     struct pgwt_span *t_spans; int n_t, cap_t;   /* TRANSITIONS block spans */
@@ -1039,7 +1041,9 @@ static int load_max_events(void)
 
 /* Read events from a trace file for a MONO time range — on demand, no
  * caching. Opens file, seeks to the right blocks via block index, decodes
- * only the blocks that overlap [from_mono, to_mono]. Appends events at
+ * only the blocks that overlap [from_mono, sample_to_mono]. Non-samples use
+ * the nominal `to_mono`; the wider endpoint admits only delayed samples whose
+ * intervals may overlap the requested right edge. Appends events at
  * *total (growing as needed) with timestamps left MONOTONIC. SAMPLES
  * records are normalized to interval shape (old_event = sampled event,
  * duration_ns = sample_period_ns) so the duration-based estimators apply
@@ -1049,6 +1053,7 @@ static int load_max_events(void)
  * stops when *total reaches load_max_events(). */
 static void load_file_range_mono(const char *path,
                                  uint64_t from_mono, uint64_t to_mono,
+                                 uint64_t sample_to_mono,
                                  uint32_t pid, int markers_only,
                                  struct pgwt_trace_event **events,
                                  int *total, int *cap, int *overloaded)
@@ -1062,18 +1067,20 @@ static void load_file_range_mono(const char *path,
     int max_events = load_max_events();
 
     for (int b = first_block; b < reader.num_blocks; b++) {
-        if (reader.block_index[b].timestamp_ns > to_mono)
+        if (reader.block_index[b].timestamp_ns > sample_to_mono)
             break;
 
         struct pgwt_block_info bi;
         int n = pgwt_reader_decode_block_info(&reader, b, block_buf,
                                               PGWT_BLOCK_EVENTS, &bi);
         if (n < 0) continue;
+        bool sample_block = bi.block_type == PGWT_BLOCK_SAMPLES;
+        uint64_t block_to = sample_block ? sample_to_mono : to_mono;
 
         for (int i = 0; i < n; i++) {
             uint64_t ts_mono = block_buf[i].timestamp_ns;
             if (ts_mono < from_mono) continue;
-            if (ts_mono > to_mono) break;
+            if (ts_mono > block_to) break;
             if (pid != 0 && block_buf[i].pid != pid)
                 continue;
             if (markers_only && !PGWT_IS_MARKER(block_buf[i].old_event))
@@ -1235,12 +1242,17 @@ static void cov_scan_file(struct pgwt_server *srv, struct pgwt_file_cov *fc)
             fc->mono_last = bi.last_timestamp_ns;
         if (bi.block_type == PGWT_BLOCK_SAMPLES) {
             fc->has_samples = 1;
+            /* SMP-3 delayed ticks carry their measured inter-tick elapsed
+             * time. Retain the maximum for request lookahead even when later
+             * nominal-period blocks follow the stalled block. */
             if (bi.sample_period_ns)
                 fc->sample_period_ns = bi.sample_period_ns;
+            if (bi.sample_period_ns > fc->max_sample_period_ns)
+                fc->max_sample_period_ns = bi.sample_period_ns;
             /* Merge adjacent sample spans (gap up to 2 periods) */
             span_list_add(&fc->s_spans, &fc->n_s, &fc->cap_s,
                           bi.first_timestamp_ns, bi.last_timestamp_ns,
-                          fc->sample_period_ns * 2);
+                          bi.sample_period_ns * 2);
         } else {
             fc->has_transitions = 1;
             span_list_add(&fc->t_spans, &fc->n_t, &fc->cap_t,
@@ -1552,6 +1564,122 @@ static int spans_contain(const struct pgwt_span *s, int n, uint64_t mono_ns)
     return lo < n && mono_ns >= s[lo].start_ns && mono_ns <= s[lo].end_ns;
 }
 
+/* First normalized span whose end is strictly after `mono_ns`. */
+static int spans_first_ending_after(const struct pgwt_span *s, int n,
+                                    uint64_t mono_ns)
+{
+    int lo = 0, hi = n;
+    while (lo < hi) {
+        int mid = (lo + hi) / 2;
+        if (s[mid].end_ns <= mono_ns)
+            lo = mid + 1;
+        else
+            hi = mid;
+    }
+    return lo;
+}
+
+/* Append one event to the fidelity-merged result. Sample clipping can turn
+ * one delayed, measured-elapsed sample into two uncovered fragments, so the
+ * merge cannot safely compact the input array in place. */
+static int merge_append_event(struct pgwt_trace_event **events, int *count,
+                              int *capacity, int max_events,
+                              const struct pgwt_trace_event *event,
+                              int64_t wall_offset)
+{
+    if (*count >= max_events)
+        return -1;
+    if (*count >= *capacity) {
+        int next = *capacity < max_events / 2
+                 ? *capacity * 2 : max_events;
+        if (next <= *capacity)
+            return -1;
+        struct pgwt_trace_event *grown =
+            realloc(*events, (size_t)next * sizeof(**events));
+        if (!grown)
+            return -1;
+        *events = grown;
+        *capacity = next;
+    }
+    (*events)[*count] = *event;
+    (*events)[*count].timestamp_ns = (uint64_t)
+        ((int64_t)event->timestamp_ns + wall_offset);
+    (*count)++;
+    return 0;
+}
+
+static int merge_append_sample_part(
+    struct pgwt_trace_event **events, int *count, int *capacity,
+    int max_events, const struct pgwt_trace_event *sample,
+    uint64_t part_start, uint64_t part_end,
+    uint64_t range_start, uint64_t range_end,
+    int64_t wall_offset, bool *contributed)
+{
+    uint64_t clipped_start = part_start > range_start
+                           ? part_start : range_start;
+    uint64_t clipped_end = part_end < range_end ? part_end : range_end;
+    if (clipped_end <= clipped_start)
+        return 0;
+
+    struct pgwt_trace_event part = *sample;
+    part.timestamp_ns = clipped_end;
+    part.duration_ns = clipped_end - clipped_start;
+    if (*contributed)
+        part.flags |= PGWT_EVENT_FLAG_SAMPLE_CONT;
+    else
+        part.flags &= ~PGWT_EVENT_FLAG_SAMPLE_CONT;
+    if (merge_append_event(events, count, capacity, max_events, &part,
+                           wall_offset) != 0)
+        return -1;
+    *contributed = true;
+    return 0;
+}
+
+/* Clipping can move a delayed sample fragment before records that preceded
+ * its physical block. Restore timestamp order without disturbing marker tie
+ * order: lifecycle and timeline consumers rely on both properties. */
+static int stable_sort_events(struct pgwt_trace_event *events, int count)
+{
+    if (count < 2)
+        return 0;
+    struct pgwt_trace_event *tmp =
+        malloc((size_t)count * sizeof(*tmp));
+    if (!tmp)
+        return -1;
+
+    struct pgwt_trace_event *src = events;
+    struct pgwt_trace_event *dst = tmp;
+    for (size_t width = 1; width < (size_t)count; width *= 2) {
+        for (size_t base = 0; base < (size_t)count; base += 2 * width) {
+            size_t left = base;
+            size_t mid = base + width < (size_t)count
+                       ? base + width : (size_t)count;
+            size_t right = mid;
+            size_t end = base + 2 * width < (size_t)count
+                       ? base + 2 * width : (size_t)count;
+            size_t out = base;
+            while (left < mid && right < end) {
+                /* Left wins ties: stable marker/event ordering. */
+                if (src[left].timestamp_ns <= src[right].timestamp_ns)
+                    dst[out++] = src[left++];
+                else
+                    dst[out++] = src[right++];
+            }
+            while (left < mid) dst[out++] = src[left++];
+            while (right < end) dst[out++] = src[right++];
+        }
+        struct pgwt_trace_event *swap = src;
+        src = dst;
+        dst = swap;
+        if (width > (size_t)count / 2)
+            break;
+    }
+    if (src != events)
+        memcpy(events, src, (size_t)count * sizeof(*events));
+    free(tmp);
+    return 0;
+}
+
 static const struct pgwt_gen_cov *gen_cov_get(const struct pgwt_server *srv,
                                               int gen)
 {
@@ -1641,13 +1769,14 @@ static struct pgwt_wfid window_fidelity(struct pgwt_server *srv,
  * Returns malloc'd array. Caller must free(). Sets *out_count.
  *
  * Fidelity (trace format v2, D3 + T1): SAMPLES records are normalized so
- * the duration-based estimators apply ASH math. The exact-wins merge drops
- * any sample whose interval midpoint falls inside the exact coverage
- * (escalation-marker windows — see the coverage block comment above), so a
- * sampler running through a full-fidelity window does not double-count —
- * including across long waits whose single transition lands only at
- * wait-end (FID-1), and across files whose wall offsets disagree (FID-7:
- * the merge runs in the monotonic domain per clock generation).
+ * the duration-based estimators apply ASH math. The exact-wins merge subtracts
+ * exact coverage (escalation-marker windows) from each sample interval, so a
+ * sampler running through a full-fidelity window does not double-count. A
+ * delayed tick can carry seconds of measured elapsed weight (SMP-3): clipping
+ * preserves the portions outside the exact window instead of dropping or
+ * retaining the whole interval based on its midpoint. The merge remains in
+ * the monotonic domain per clock generation, so per-file wall offsets cannot
+ * shift coverage against samples (FID-7).
  * When `info` is non-NULL it is filled with what actually contributed
  * (has_transitions / has_samples / sample_period_ns).
  *
@@ -1686,7 +1815,11 @@ server_load_events_fi_mode(struct pgwt_server *srv,
 
     /* Per-segment bookkeeping: each file contributes one contiguous run of
      * events; merge + wall conversion need its generation and offset. */
-    struct load_seg { int start, count, gen; int64_t off; };
+    struct load_seg {
+        int start, count, gen;
+        int64_t off;
+        uint64_t from_m, to_m;
+    };
     struct load_seg segs[256];
     int n_segs = 0;
     uint64_t sample_period_ns = 0;
@@ -1704,8 +1837,13 @@ server_load_events_fi_mode(struct pgwt_server *srv,
                         ? (uint64_t)((int64_t)from_wall_ns - fc->canon_offset)
                         : 0;
         uint64_t to_m = (uint64_t)((int64_t)to_wall_ns - fc->canon_offset);
+        uint64_t sample_to_m = to_m;
+        if (!markers_only && fc->max_sample_period_ns) {
+            sample_to_m = UINT64_MAX - to_m < fc->max_sample_period_ns
+                        ? UINT64_MAX : to_m + fc->max_sample_period_ns;
+        }
 
-        if (fc->mono_first > to_m || fc->mono_last < from_m)
+        if (fc->mono_first > sample_to_m || fc->mono_last < from_m)
             continue;
 
         if (fc->sample_period_ns)
@@ -1714,20 +1852,27 @@ server_load_events_fi_mode(struct pgwt_server *srv,
         int seg_start = total;
 
         if (fc->is_current) {
-            /* On-demand: read only blocks in [from, to] */
-            load_file_range_mono(fc->path, from_m, to_m, pid, markers_only,
+            /* Read through one maximum measured sample period beyond `to` so
+             * a delayed observation whose interval overlaps the right edge is
+             * available for clipping. Non-samples are rejected below. */
+            load_file_range_mono(fc->path, from_m, to_m, sample_to_m,
+                                 pid, markers_only,
                                  &events, &total, &cap, &overloaded);
         } else {
             struct file_cache_entry *ce = get_cached_immutable(srv, fc->path);
             if (!ce || !ce->events) {
                 /* Cache miss (file too large or alloc failed) */
-                load_file_range_mono(fc->path, from_m, to_m, pid, markers_only,
+                load_file_range_mono(fc->path, from_m, to_m, sample_to_m,
+                                     pid, markers_only,
                                      &events, &total, &cap, &overloaded);
             } else {
                 for (int i = 0; i < ce->count; i++) {
                     uint64_t ts = ce->events[i].timestamp_ns;
                     if (ts < from_m) continue;
-                    if (ts > to_m) break;
+                    if (ts > sample_to_m) break;
+                    if (!(ce->events[i].flags & PGWT_EVENT_FLAG_SAMPLE) &&
+                        ts > to_m)
+                        continue;
                     if (pid != 0 && ce->events[i].pid != pid)
                         continue;
                     if (markers_only && !PGWT_IS_MARKER(ce->events[i].old_event))
@@ -1754,27 +1899,86 @@ server_load_events_fi_mode(struct pgwt_server *srv,
             segs[n_segs].count = total - seg_start;
             segs[n_segs].gen = fc->gen;
             segs[n_segs].off = fc->canon_offset;
+            segs[n_segs].from_m = from_m;
+            segs[n_segs].to_m = to_m;
             n_segs++;
         }
     }
 
     /* Exact-wins merge (mono, per generation) + wall re-anchoring, then
-     * derive what actually contributed for the fidelity indicator. */
+     * derive what actually contributed for the fidelity indicator. Use a
+     * separate output because subtracting exact spans can split one delayed
+     * sample into multiple uncovered fragments. */
     int has_transitions = 0, has_samples = 0;
+    int merged_cap = total > 0 ? total : 16;
+    if (merged_cap > max_events)
+        merged_cap = max_events;
+    struct pgwt_trace_event *merged =
+        malloc((size_t)merged_cap * sizeof(*merged));
+    if (!merged) {
+        free(events);
+        *out_count = 0;
+        return NULL;
+    }
     int kept = 0;
-    for (int s = 0; s < n_segs; s++) {
+    for (int s = 0; s < n_segs && !overloaded; s++) {
         const struct pgwt_gen_cov *gc = gen_cov_get(srv, segs[s].gen);
-        for (int i = segs[s].start; i < segs[s].start + segs[s].count; i++) {
+        for (int i = segs[s].start;
+             i < segs[s].start + segs[s].count && !overloaded; i++) {
             if (events[i].flags & PGWT_EVENT_FLAG_SAMPLE) {
-                /* Boundary rule (FID-6): drop iff the sample's interval
-                 * midpoint lies inside exact coverage. */
-                uint64_t mid = events[i].timestamp_ns
-                             - events[i].duration_ns / 2;
-                if (gc && gc->n_exact > 0 &&
-                    spans_contain(gc->exact, gc->n_exact, mid))
-                    continue;   /* exact data is authoritative here */
-                has_samples = 1;
+                uint64_t end = events[i].timestamp_ns;
+                uint64_t start = end >= events[i].duration_ns
+                               ? end - events[i].duration_ns : 0;
+                uint64_t cursor = start;
+                bool contributed = false;
+
+                /* Emit every positive-length portion outside normalized exact
+                 * coverage. Keeping the observation on each piece preserves
+                 * SMP-3's measured elapsed weight without double-counting any
+                 * overlap against exact transitions. */
+                if (gc && gc->n_exact > 0) {
+                    int first = spans_first_ending_after(
+                        gc->exact, gc->n_exact, cursor);
+                    for (int j = first;
+                         j < gc->n_exact && cursor < end; j++) {
+                        uint64_t exact_start = gc->exact[j].start_ns;
+                        uint64_t exact_end = gc->exact[j].end_ns;
+                        if (exact_start >= end)
+                            break;
+                        if (exact_start > cursor) {
+                            uint64_t part_end = exact_start < end
+                                              ? exact_start : end;
+                            if (merge_append_sample_part(
+                                    &merged, &kept, &merged_cap, max_events,
+                                    &events[i], cursor, part_end,
+                                    segs[s].from_m, segs[s].to_m,
+                                    segs[s].off, &contributed) != 0) {
+                                overloaded = 1;
+                                break;
+                            }
+                        }
+                        if (exact_end > cursor)
+                            cursor = exact_end < end ? exact_end : end;
+                    }
+                }
+                if (!overloaded && cursor < end) {
+                    if (merge_append_sample_part(
+                            &merged, &kept, &merged_cap, max_events,
+                            &events[i], cursor, end,
+                            segs[s].from_m, segs[s].to_m,
+                            segs[s].off, &contributed) != 0) {
+                        overloaded = 1;
+                    }
+                }
+                if (contributed)
+                    has_samples = 1;
             } else {
+                /* The loader's right lookahead is only for overlapping sample
+                 * intervals; preserve the prior endpoint selection for exact
+                 * records and structural markers. */
+                if (events[i].timestamp_ns < segs[s].from_m ||
+                    events[i].timestamp_ns > segs[s].to_m)
+                    continue;
                 /* T2 backstop (study defect 2): an EXIT record whose closing
                  * interval lies OUTSIDE exact coverage in a generation that
                  * has sampled coverage is a phantom — pre-fix daemons
@@ -1793,14 +1997,26 @@ server_load_events_fi_mode(struct pgwt_server *srv,
                         continue;   /* phantom exit interval */
                 }
                 has_transitions = 1;
+                if (merge_append_event(&merged, &kept, &merged_cap,
+                                       max_events, &events[i],
+                                       segs[s].off) != 0)
+                    overloaded = 1;
             }
-            events[kept] = events[i];
-            events[kept].timestamp_ns = (uint64_t)
-                ((int64_t)events[kept].timestamp_ns + segs[s].off);
-            kept++;
         }
     }
+    free(events);
+    events = merged;
     total = kept;
+
+    bool ordered = true;
+    for (int i = 1; i < total; i++) {
+        if (events[i - 1].timestamp_ns > events[i].timestamp_ns) {
+            ordered = false;
+            break;
+        }
+    }
+    if (!overloaded && !ordered && stable_sort_events(events, total) != 0)
+        overloaded = 1;
 
     /* T2: annotate the merged window with categories (pid types from
      * backends.jsonl) and the PLAN/EXEC/CMD marker windows; classify exact
@@ -4059,16 +4275,22 @@ static void dump_summary(struct pgwt_server *srv)
 
     /* Count sample vs transition records so a sampled-mode trace is visible
      * at a glance (A2 evidence: SAMPLES blocks landed). */
-    int n_samples = 0;
-    for (int i = 0; i < count; i++)
-        if (events[i].flags & PGWT_EVENT_FLAG_SAMPLE)
-            n_samples++;
+    int n_samples = 0, n_transitions = 0;
+    for (int i = 0; i < count; i++) {
+        if (events[i].flags & PGWT_EVENT_FLAG_SAMPLE) {
+            if (!(events[i].flags & PGWT_EVENT_FLAG_SAMPLE_CONT))
+                n_samples++;
+        } else {
+            n_transitions++;
+        }
+    }
 
     enum pgwt_fidelity fid = load_fidelity(&linfo);
 
     printf("════════════════════════════════════════════════════════════════════════════════\n");
     printf("pgwt-server — Summary    Events: %d (%d transitions, %d samples)    Duration: %.1fs\n",
-           count, count - n_samples, n_samples, wall_ms / 1000.0);
+           n_transitions + n_samples, n_transitions, n_samples,
+           wall_ms / 1000.0);
     printf("Fidelity: %s", pgwt_fidelity_str(fid));
     if (linfo.has_samples && linfo.sample_period_ns)
         printf("    Sample period: %.1f ms (%.0f Hz)",

--- a/src/spawn.c
+++ b/src/spawn.c
@@ -12,6 +12,8 @@
 #include <time.h>
 #include <sys/wait.h>
 
+#define PGWT_PROC_KILL_REAP_TIMEOUT_MS 500
+
 static int proc_open(struct pgwt_proc *p, char *const argv[], bool writable)
 {
     p->out = NULL;
@@ -169,14 +171,26 @@ int pgwt_proc_close_bounded(struct pgwt_proc *p, int timeout_ms)
         usleep(10000);
     }
 
-    /* This is the exact fork child, not a caller-supplied/system PID. Reap it
-     * after SIGKILL so an overloaded helper cannot make daemon startup wait
-     * forever or leave a zombie. */
+    /* This is the exact fork child, not a caller-supplied/system PID. Give a
+     * normal SIGKILL reap a short opportunity, but do not turn bounded close
+     * back into an unbounded wait when the helper is stuck in uninterruptible
+     * sleep. The process remains owned by init/subreaper after daemon exit. */
     (void)kill(p->pid, SIGKILL);
-    pid_t r;
-    do {
-        r = waitpid(p->pid, &status, 0);
-    } while (r < 0 && errno == EINTR);
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    deadline_ms = (uint64_t)ts.tv_sec * 1000 +
+                  (uint64_t)ts.tv_nsec / 1000000 +
+                  PGWT_PROC_KILL_REAP_TIMEOUT_MS;
+    for (;;) {
+        pid_t r = waitpid(p->pid, &status, WNOHANG);
+        if (r == p->pid || (r < 0 && errno != EINTR))
+            break;
+        clock_gettime(CLOCK_MONOTONIC, &ts);
+        uint64_t now_ms = (uint64_t)ts.tv_sec * 1000 +
+                          (uint64_t)ts.tv_nsec / 1000000;
+        if (now_ms >= deadline_ms)
+            break;
+        usleep(10000);
+    }
     p->pid = -1;
     return -1;
 }

--- a/src/spawn.c
+++ b/src/spawn.c
@@ -3,10 +3,13 @@
 #include "spawn.h"
 
 #include <stdbool.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <unistd.h>
 #include <fcntl.h>
 #include <errno.h>
+#include <signal.h>
+#include <time.h>
 #include <sys/wait.h>
 
 static int proc_open(struct pgwt_proc *p, char *const argv[], bool writable)
@@ -37,6 +40,21 @@ static int proc_open(struct pgwt_proc *p, char *const argv[], bool writable)
     }
 
     if (pid == 0) {
+        /* The daemon blocks shutdown signals before creating threads so its
+         * signalfd owns graceful shutdown.  A fork/exec helper must not carry
+         * that process-internal policy into runuser/psql/readelf children:
+         * exec preserves the signal mask (and ignored dispositions). */
+        sigset_t shutdown_signals;
+        struct sigaction default_action = { .sa_handler = SIG_DFL };
+        sigemptyset(&shutdown_signals);
+        sigaddset(&shutdown_signals, SIGINT);
+        sigaddset(&shutdown_signals, SIGTERM);
+        sigemptyset(&default_action.sa_mask);
+        if (sigaction(SIGINT, &default_action, NULL) != 0 ||
+            sigaction(SIGTERM, &default_action, NULL) != 0 ||
+            sigprocmask(SIG_UNBLOCK, &shutdown_signals, NULL) != 0)
+            _exit(127);
+
         /* Child: stdout -> pipe and stderr -> /dev/null.  The read-only
          * variant also maps stdin to /dev/null; the bidirectional variant
          * maps it to the parent's input pipe.  dup2 clears O_CLOEXEC on the
@@ -95,7 +113,7 @@ int pgwt_proc_open_rw(struct pgwt_proc *p, char *const argv[])
     return proc_open(p, argv, true);
 }
 
-int pgwt_proc_close(struct pgwt_proc *p)
+static int close_pipes(struct pgwt_proc *p)
 {
     if (!p->out)
         return -1;
@@ -105,6 +123,13 @@ int pgwt_proc_close(struct pgwt_proc *p)
     }
     fclose(p->out);
     p->out = NULL;
+    return 0;
+}
+
+int pgwt_proc_close(struct pgwt_proc *p)
+{
+    if (close_pipes(p) != 0)
+        return -1;
 
     int status = 0;
     pid_t r;
@@ -113,4 +138,45 @@ int pgwt_proc_close(struct pgwt_proc *p)
     } while (r < 0 && errno == EINTR);
     p->pid = -1;
     return (r < 0) ? -1 : status;
+}
+
+int pgwt_proc_close_bounded(struct pgwt_proc *p, int timeout_ms)
+{
+    if (close_pipes(p) != 0)
+        return -1;
+
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    uint64_t deadline_ms = (uint64_t)ts.tv_sec * 1000 +
+                           (uint64_t)ts.tv_nsec / 1000000 +
+                           (timeout_ms > 0 ? (uint64_t)timeout_ms : 0);
+    int status = 0;
+    for (;;) {
+        pid_t r = waitpid(p->pid, &status, WNOHANG);
+        if (r == p->pid) {
+            p->pid = -1;
+            return status;
+        }
+        if (r < 0 && errno != EINTR) {
+            p->pid = -1;
+            return -1;
+        }
+        clock_gettime(CLOCK_MONOTONIC, &ts);
+        uint64_t now_ms = (uint64_t)ts.tv_sec * 1000 +
+                          (uint64_t)ts.tv_nsec / 1000000;
+        if (now_ms >= deadline_ms)
+            break;
+        usleep(10000);
+    }
+
+    /* This is the exact fork child, not a caller-supplied/system PID. Reap it
+     * after SIGKILL so an overloaded helper cannot make daemon startup wait
+     * forever or leave a zombie. */
+    (void)kill(p->pid, SIGKILL);
+    pid_t r;
+    do {
+        r = waitpid(p->pid, &status, 0);
+    } while (r < 0 && errno == EINTR);
+    p->pid = -1;
+    return -1;
 }

--- a/src/spawn.h
+++ b/src/spawn.h
@@ -42,4 +42,9 @@ int pgwt_proc_open_rw(struct pgwt_proc *p, char *const argv[]);
  * callers that close early must ignore the status, as with pclose). */
 int pgwt_proc_close(struct pgwt_proc *p);
 
+/* Deadline-bounded close for startup validation helpers. Closes the pipes,
+ * polls waitpid for timeout_ms, then SIGKILLs and reaps an overrun child.
+ * Returns the raw wait status on a natural exit, or -1 after forced cleanup. */
+int pgwt_proc_close_bounded(struct pgwt_proc *p, int timeout_ms);
+
 #endif /* PGWT_SPAWN_H */

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -10,7 +10,7 @@ BUILD     = ../build
 # Rocky 8 / RHEL 8 where the bundled static libbpf is used instead.
 LIBBPF_LIB ?= -lbpf
 
-TESTS     = test_wait_event test_cmdline test_event_writer test_event_reader \
+TESTS     = test_wait_event test_cmdline test_spawn test_event_writer test_event_reader \
             test_trace_v2 test_sampler test_anomaly test_escalation_budget \
             test_exact_probe \
             test_effective_cores \
@@ -47,6 +47,9 @@ test_wait_event: test_wait_event.c $(BUILD)/wait_event.o $(BUILD)/spawn.o $(BUIL
 	$(CC) $(CFLAGS) -o $@ $^
 
 test_cmdline: test_cmdline.c $(BUILD)/cmdline.o
+	$(CC) $(CFLAGS) -o $@ $^
+
+test_spawn: test_spawn.c ../src/spawn.c
 	$(CC) $(CFLAGS) -o $@ $^
 
 test_event_writer: test_event_writer.c $(BUILD)/event_writer.o

--- a/tests/test_anomaly.c
+++ b/tests/test_anomaly.c
@@ -839,6 +839,108 @@ static void test_cpu_cusum_episode_latch(void)
            grants, (unsigned long long)chronic.fires_total);
 }
 
+/* A FIRE is only an attempt until the escalation engine opens the exact
+ * window.  A transient attach/preseed rollback must not consume the entire
+ * saturation episode, but the retry must still earn a fresh CUSUM horizon. */
+static void test_cpu_setup_failure_retry(void)
+{
+    printf("--- CPU CUSUM: transient setup failure retries safely ---\n");
+
+    struct pgwt_anomaly a;
+    pgwt_anomaly_init(&a, true, 10);
+    isolate_cpu_rule(&a);
+    uint64_t clk = TICK_NS;
+    struct pgwt_anomaly_decision d = {0};
+
+    for (int t = 0; t < 100 && d.action != PGWT_ANOMALY_FIRE; t++)
+        d = cpu_tick(&a, 4.0, 4.0, 4.0,
+                     true, false, false, &clk);
+    CHECK(d.action == PGWT_ANOMALY_FIRE && !a.cpu_armed,
+          "initial saturation did not fire and latch");
+
+    bool retry = pgwt_anomaly_retry_after_setup_failure(
+        &a, d.fired_mask, clk);
+    CHECK(retry && a.cpu_armed && a.cpu_cusum == 0.0 &&
+          a.last_fire_ns == 0 && a.cpu_setup_retries == 1,
+          "setup rollback did not reset CPU evidence/cooldown");
+
+    d = cpu_tick(&a, 4.0, 4.0, 4.0,
+                 true, false, false, &clk);
+    CHECK(d.action != PGWT_ANOMALY_FIRE,
+          "setup rollback retried without a fresh evidence horizon");
+
+    int retry_tick = 0;
+    for (int t = 1; t < 200; t++) {
+        d = cpu_tick(&a, 4.0, 4.0, 4.0,
+                     true, false, false, &clk);
+        if (d.action == PGWT_ANOMALY_FIRE) {
+            retry_tick = t + 1;
+            break;
+        }
+    }
+    CHECK(retry_tick > 1 && a.fires_total == 2 && !a.cpu_armed,
+          "fresh saturation did not produce one bounded retry "
+          "(tick=%d fires=%llu armed=%d)", retry_tick,
+          (unsigned long long)a.fires_total, a.cpu_armed);
+
+    pgwt_anomaly_escalation_succeeded(&a);
+    CHECK(a.cpu_setup_retries == 0 && a.cpu_setup_retry_after_ns == 0,
+          "successful escalation did not clear retry bookkeeping");
+
+    int extra_fires = 0;
+    for (int t = 0; t < 100; t++) {
+        d = cpu_tick(&a, 4.0, 4.0, 4.0,
+                     true, false, false, &clk);
+        extra_fires += d.action == PGWT_ANOMALY_FIRE;
+    }
+    CHECK(extra_fires == 0,
+          "successful retry did not latch the saturation episode");
+}
+
+static void test_cpu_setup_failure_retry_cap(void)
+{
+    printf("--- CPU CUSUM: setup retry is capped per episode ---\n");
+
+    struct pgwt_anomaly a;
+    pgwt_anomaly_init(&a, true, 10);
+    isolate_cpu_rule(&a);
+    a.cooldown_ns = 0;
+    uint64_t clk = TICK_NS;
+    struct pgwt_anomaly_decision d = {0};
+
+    for (unsigned attempt = 0;
+         attempt <= PGWT_ANOMALY_CPU_SETUP_MAX_RETRIES; attempt++) {
+        d.action = PGWT_ANOMALY_NONE;
+        for (int t = 0; t < 200 && d.action != PGWT_ANOMALY_FIRE; t++)
+            d = cpu_tick(&a, 4.0, 4.0, 4.0,
+                         true, false, false, &clk);
+        CHECK(d.action == PGWT_ANOMALY_FIRE,
+              "setup attempt %u never earned fresh evidence", attempt + 1);
+        bool will_retry = pgwt_anomaly_retry_after_setup_failure(
+            &a, d.fired_mask, clk);
+        CHECK(will_retry ==
+              (attempt < PGWT_ANOMALY_CPU_SETUP_MAX_RETRIES),
+              "setup attempt %u retry decision=%d", attempt + 1,
+              will_retry);
+    }
+
+    int extra_fires = 0;
+    for (int t = 0; t < 200; t++) {
+        d = cpu_tick(&a, 4.0, 4.0, 4.0,
+                     true, false, false, &clk);
+        extra_fires += d.action == PGWT_ANOMALY_FIRE;
+    }
+    CHECK(extra_fires == 0 && !a.cpu_armed &&
+          a.cpu_setup_retries == PGWT_ANOMALY_CPU_SETUP_MAX_RETRIES,
+          "retry cap did not latch failed episode (extra=%d retries=%u)",
+          extra_fires, a.cpu_setup_retries);
+
+    cpu_tick(&a, 0.0, 0.0, 4.0,
+             true, false, false, &clk);
+    CHECK(a.cpu_armed && a.cpu_setup_retries == 0,
+          "trusted recovery did not reset the capped retry episode");
+}
+
 /* ── AAS-1 Stage 3 fix: activity floor + affinity-only margin ────────── */
 static void test_cpu_cusum_floor_and_margin(void)
 {
@@ -1430,6 +1532,8 @@ int main(void)
     test_cpu_cusum_incidents();
     test_cpu_cusum_gates();
     test_cpu_cusum_episode_latch();
+    test_cpu_setup_failure_retry();
+    test_cpu_setup_failure_retry_cap();
     test_cpu_cusum_floor_and_margin();
     test_cpu_cusum_coverage_flaps();
     test_cpu_cusum_incomplete_saturation_monotone();

--- a/tests/test_anomaly.c
+++ b/tests/test_anomaly.c
@@ -858,10 +858,12 @@ static void test_cpu_setup_failure_retry(void)
     CHECK(d.action == PGWT_ANOMALY_FIRE && !a.cpu_armed,
           "initial saturation did not fire and latch");
 
-    bool retry = pgwt_anomaly_retry_after_setup_failure(
+    enum pgwt_anomaly_setup_retry_result retry =
+        pgwt_anomaly_retry_after_setup_failure(
         &a, d.fired_mask, clk);
-    CHECK(retry && a.cpu_armed && a.cpu_cusum == 0.0 &&
-          a.last_fire_ns == 0 && a.cpu_setup_retries == 1,
+    CHECK(retry == PGWT_ANOMALY_SETUP_RETRY_SCHEDULED &&
+          a.cpu_armed && a.cpu_cusum == 0.0 &&
+          a.last_fire_ns == 0 && a.setup_retries == 1,
           "setup rollback did not reset CPU evidence/cooldown");
 
     d = cpu_tick(&a, 4.0, 4.0, 4.0,
@@ -884,7 +886,7 @@ static void test_cpu_setup_failure_retry(void)
           (unsigned long long)a.fires_total, a.cpu_armed);
 
     pgwt_anomaly_escalation_succeeded(&a);
-    CHECK(a.cpu_setup_retries == 0 && a.cpu_setup_retry_after_ns == 0,
+    CHECK(a.setup_retries == 0 && a.setup_retry_after_ns == 0,
           "successful escalation did not clear retry bookkeeping");
 
     int extra_fires = 0;
@@ -909,19 +911,22 @@ static void test_cpu_setup_failure_retry_cap(void)
     struct pgwt_anomaly_decision d = {0};
 
     for (unsigned attempt = 0;
-         attempt <= PGWT_ANOMALY_CPU_SETUP_MAX_RETRIES; attempt++) {
+         attempt <= PGWT_ANOMALY_SETUP_MAX_RETRIES; attempt++) {
         d.action = PGWT_ANOMALY_NONE;
         for (int t = 0; t < 200 && d.action != PGWT_ANOMALY_FIRE; t++)
             d = cpu_tick(&a, 4.0, 4.0, 4.0,
                          true, false, false, &clk);
         CHECK(d.action == PGWT_ANOMALY_FIRE,
               "setup attempt %u never earned fresh evidence", attempt + 1);
-        bool will_retry = pgwt_anomaly_retry_after_setup_failure(
+        enum pgwt_anomaly_setup_retry_result retry =
+            pgwt_anomaly_retry_after_setup_failure(
             &a, d.fired_mask, clk);
-        CHECK(will_retry ==
-              (attempt < PGWT_ANOMALY_CPU_SETUP_MAX_RETRIES),
-              "setup attempt %u retry decision=%d", attempt + 1,
-              will_retry);
+        enum pgwt_anomaly_setup_retry_result expected =
+            attempt < PGWT_ANOMALY_SETUP_MAX_RETRIES
+            ? PGWT_ANOMALY_SETUP_RETRY_SCHEDULED
+            : PGWT_ANOMALY_SETUP_RETRY_LIMIT_REACHED;
+        CHECK(retry == expected,
+              "setup attempt %u retry decision=%d", attempt + 1, retry);
     }
 
     int extra_fires = 0;
@@ -931,14 +936,79 @@ static void test_cpu_setup_failure_retry_cap(void)
         extra_fires += d.action == PGWT_ANOMALY_FIRE;
     }
     CHECK(extra_fires == 0 && !a.cpu_armed &&
-          a.cpu_setup_retries == PGWT_ANOMALY_CPU_SETUP_MAX_RETRIES,
+          a.setup_retries == PGWT_ANOMALY_SETUP_MAX_RETRIES,
           "retry cap did not latch failed episode (extra=%d retries=%u)",
-          extra_fires, a.cpu_setup_retries);
+          extra_fires, a.setup_retries);
 
     cpu_tick(&a, 0.0, 0.0, 4.0,
              true, false, false, &clk);
-    CHECK(a.cpu_armed && a.cpu_setup_retries == 0,
+    CHECK(a.cpu_armed && a.setup_retries == 0,
           "trusted recovery did not reset the capped retry episode");
+}
+
+static void test_non_cpu_setup_failure_retry(void)
+{
+    printf("--- AAS/lock: transient setup failure retries safely ---\n");
+
+    struct pgwt_anomaly aas;
+    pgwt_anomaly_init(&aas, true, 10);
+    aas.cpu_cusum_enabled = false;
+    aas.lock_fraction = 0.0;
+    aas.aas_ticks = 2;
+    uint64_t clk = TICK_NS;
+    warm_baseline(&aas, 2.0, &clk);
+    struct pgwt_anomaly_decision d =
+        feed(&aas, 10.0, 0.0, 2, &clk, NULL);
+    CHECK(d.action == PGWT_ANOMALY_FIRE &&
+          d.fired_mask == PGWT_RULE_AAS,
+          "pure AAS incident did not fire alone");
+    enum pgwt_anomaly_setup_retry_result retry =
+        pgwt_anomaly_retry_after_setup_failure(&aas, d.fired_mask, clk);
+    CHECK(retry == PGWT_ANOMALY_SETUP_RETRY_SCHEDULED &&
+          aas.setup_retries == 1 && aas.setup_retry_after_ns > clk &&
+          aas.aas_over_streak == 0 && aas.last_fire_ns == 0,
+          "pure AAS setup failure was not scheduled for bounded retry");
+    d = pgwt_anomaly_eval(&aas, 10.0, 0.0, clk);
+    CHECK(d.action != PGWT_ANOMALY_FIRE && aas.aas_over_streak == 0,
+          "pure AAS retried during setup backoff");
+    clk = aas.setup_retry_after_ns;
+    d = feed(&aas, 10.0, 0.0, 2, &clk, NULL);
+    CHECK(d.action == PGWT_ANOMALY_FIRE &&
+          d.fired_mask == PGWT_RULE_AAS,
+          "pure AAS retry did not require and earn fresh evidence");
+
+    struct pgwt_anomaly lock;
+    pgwt_anomaly_init(&lock, true, 10);
+    lock.cpu_cusum_enabled = false;
+    lock.aas_factor = 0.0;
+    lock.lock_ticks = 2;
+    clk = TICK_NS;
+    warm_baseline(&lock, 2.0, &clk);
+    d = feed(&lock, 5.0, 0.9, 2, &clk, NULL);
+    CHECK(d.action == PGWT_ANOMALY_FIRE &&
+          d.fired_mask == PGWT_RULE_LOCK,
+          "pure lock incident did not fire alone");
+    retry = pgwt_anomaly_retry_after_setup_failure(
+        &lock, d.fired_mask, clk);
+    CHECK(retry == PGWT_ANOMALY_SETUP_RETRY_SCHEDULED &&
+          lock.setup_retries == 1 && lock.setup_retry_after_ns > clk &&
+          lock.lock_over_streak == 0 && lock.last_fire_ns == 0,
+          "pure lock setup failure was not scheduled for bounded retry");
+    d = pgwt_anomaly_eval(&lock, 5.0, 0.9, clk);
+    CHECK(d.action != PGWT_ANOMALY_FIRE && lock.lock_over_streak == 0,
+          "pure lock retried during setup backoff");
+    clk = lock.setup_retry_after_ns;
+    d = feed(&lock, 5.0, 0.9, 2, &clk, NULL);
+    CHECK(d.action == PGWT_ANOMALY_FIRE &&
+          d.fired_mask == PGWT_RULE_LOCK,
+          "pure lock retry did not require and earn fresh evidence");
+
+    uint64_t last_fire = lock.last_fire_ns;
+    retry = pgwt_anomaly_retry_after_setup_failure(
+        &lock, PGWT_RULE_NONE, clk);
+    CHECK(retry == PGWT_ANOMALY_SETUP_RETRY_NOT_APPLICABLE &&
+          lock.last_fire_ns == last_fire,
+          "no-rule setup outcome was mislabeled as retry-limit exhaustion");
 }
 
 /* ── AAS-1 Stage 3 fix: activity floor + affinity-only margin ────────── */
@@ -1534,6 +1604,7 @@ int main(void)
     test_cpu_cusum_episode_latch();
     test_cpu_setup_failure_retry();
     test_cpu_setup_failure_retry_cap();
+    test_non_cpu_setup_failure_retry();
     test_cpu_cusum_floor_and_margin();
     test_cpu_cusum_coverage_flaps();
     test_cpu_cusum_incomplete_saturation_monotone();

--- a/tests/test_backend_status_layout.c
+++ b/tests/test_backend_status_layout.c
@@ -623,6 +623,15 @@ static void test_fail_safe_and_pid_exclusion(void)
           "fail-safe fixture row");
     struct pgwt_pgbs_exclusion_set exclusions = {0};
     pid_t unknown_identity = (pid_t)2147483647;
+    struct pgwt_pgbs_exclusion_set live_only = {0};
+    uint64_t missing_start_time = 1;
+    bool already_retired = false;
+    CHECK(pgwt_pgbs_exclusion_add_live(
+              &live_only, unknown_identity, &missing_start_time,
+              &already_retired) == 0 &&
+          already_retired && missing_start_time == 0 &&
+          live_only.count == 0,
+          "dead observer identity race leaves no permanent PID exclusion");
     CHECK(pgwt_pgbs_exclusion_add(&exclusions, unknown_identity) == 0 &&
           pgwt_pgbs_exclusion_contains(&exclusions, unknown_identity),
           "missing /proc identity remains conservatively excluded");

--- a/tests/test_capture_smoke.py
+++ b/tests/test_capture_smoke.py
@@ -44,6 +44,8 @@ import json
 import os
 import re
 import secrets
+import select
+import signal
 import subprocess
 import sys
 import tempfile
@@ -81,6 +83,61 @@ def psql(sql, timeout=15):
     return result.stdout.strip()
 
 
+def wait_for_tagged_active_backend(application_name, timeout_s=30):
+    """Return a tagged backend PID only after PostgreSQL reports it active."""
+    quoted = application_name.replace("'", "''")
+    deadline = time.monotonic() + timeout_s
+    while True:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return None
+        try:
+            out = psql(
+                "SELECT pid FROM pg_stat_activity "
+                f"WHERE application_name = '{quoted}' AND state = 'active'",
+                timeout=min(10, max(1, remaining)))
+        except subprocess.TimeoutExpired:
+            out = ""
+        if re.fullmatch(r'\d+', out or ''):
+            return int(out)
+        time.sleep(min(0.05, max(0.0, deadline - time.monotonic())))
+
+
+def wait_for_tagged_backend_count(application_name, predicate, timeout_s=30,
+                                  active_only=False):
+    """Wait for a valid pg_stat_activity count; SQL errors never mean zero."""
+    quoted = application_name.replace("'", "''")
+    deadline = time.monotonic() + timeout_s
+    while True:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return None
+        try:
+            output = psql(
+                "SELECT count(*) FROM pg_stat_activity "
+                f"WHERE application_name = '{quoted}' "
+                "AND datname = 'postgres'" +
+                (" AND state = 'active'" if active_only else ""),
+                timeout=min(10, max(1, remaining)))
+        except subprocess.TimeoutExpired:
+            output = ""
+        if re.fullmatch(r'\d+', output or ''):
+            count = int(output)
+            if predicate(count):
+                return count
+        time.sleep(min(0.05, max(0.0, deadline - time.monotonic())))
+
+
+def proc_start_ticks(pid):
+    """Return /proc starttime for PID-reuse-safe targeted cleanup."""
+    try:
+        with open(f"/proc/{pid}/stat", encoding="utf-8") as stat_file:
+            tail = stat_file.read().rsplit(") ", 1)[1].split()
+        return int(tail[19])  # field 22; tail[0] is field 3
+    except (OSError, IndexError, ValueError):
+        return None
+
+
 def cleanup_stale_backends():
     try:
         psql("SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
@@ -102,6 +159,24 @@ def pgss_query_ids():
     the pgbench workload — the ground truth for attribution asserts."""
     out = psql("SELECT queryid FROM pg_stat_statements "
                "WHERE queryid IS NOT NULL AND calls >= 3")
+    ids = set()
+    for line in out.split('\n'):
+        line = line.strip()
+        if re.fullmatch(r'-?\d+', line):
+            ids.add(int(line) & 0xFFFFFFFFFFFFFFFF)
+    return ids
+
+
+def pgbench_pgss_query_ids():
+    """Real pgbench query IDs, excluding this lookup from its own result."""
+    out = psql(
+        "SELECT queryid FROM pg_stat_statements "
+        "WHERE queryid IS NOT NULL AND calls >= 3 "
+        "AND query NOT LIKE '%pg_stat_statements%' "
+        "AND (query LIKE '%pgbench_accounts%' "
+        "OR query LIKE '%pgbench_branches%' "
+        "OR query LIKE '%pgbench_tellers%' "
+        "OR query LIKE '%pgbench_history%')")
     ids = set()
     for line in out.split('\n'):
         line = line.strip()
@@ -144,18 +219,22 @@ class Workload:
         self.sleeper = None
         self.holder = None
         self.waiter = None
+        self.tag_base = f"pgwt_wl_{secrets.token_hex(8)}"
+        self.backend_pids = {}
 
-    def _session(self):
+    def _session(self, role):
+        env = os.environ.copy()
+        env["PGAPPNAME"] = f"{self.tag_base}_{role}"
         return subprocess.Popen(
             ["psql", "-U", "postgres", "-d", "postgres"],
             stdin=subprocess.PIPE, stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL, text=True)
+            stderr=subprocess.DEVNULL, text=True, env=env)
 
-    def open_sessions(self):
+    def open_sessions(self, discover_pids=False):
         psql(f"CREATE TABLE IF NOT EXISTS {self.LOCK_TABLE} (id int)")
-        self.sleeper = self._session()
-        self.holder = self._session()
-        self.waiter = self._session()
+        self.sleeper = self._session("sleeper")
+        self.holder = self._session("holder")
+        self.waiter = self._session("waiter")
         self.holder.stdin.write(
             f"BEGIN; LOCK TABLE {self.LOCK_TABLE} IN ACCESS EXCLUSIVE MODE;\n")
         self.holder.stdin.flush()
@@ -165,6 +244,33 @@ class Workload:
             f"WHERE relation = '{self.LOCK_TABLE}'::regclass AND granted")
         check(held != "" and int(held) >= 1,
               f"workload: holder acquired AccessExclusiveLock (held={held!r})")
+
+        def discover_backend_pids():
+            apps = [f"{self.tag_base}_{role}"
+                    for role in ("sleeper", "holder", "waiter")]
+            quoted_apps = ",".join(
+                "'" + app.replace("'", "''") + "'" for app in apps)
+            rows = psql(
+                "SELECT application_name, pid FROM pg_stat_activity "
+                f"WHERE application_name IN ({quoted_apps}) "
+                "AND datname = 'postgres'")
+            found = {}
+            for row in rows.splitlines():
+                parts = row.split('|', 1)
+                if len(parts) != 2 or not parts[1].isdigit():
+                    continue
+                role = parts[0].rsplit('_', 1)[-1]
+                if role in ("sleeper", "holder", "waiter"):
+                    found[role] = int(parts[1])
+            return found if len(found) == 3 else None
+
+        if discover_pids:
+            # PID identities let exact-mode assertions distinguish the
+            # controlled waits from unrelated background events on a shared
+            # PostgreSQL. Opt-in matters: Phase 4 opens these sessions inside
+            # an already-running short tracer window.
+            self.backend_pids = wait_for_observation(
+                self.holder, discover_backend_pids, 30, interval_s=0.2) or {}
 
     def fire(self, sleep_s=3):
         """Start the observable waits (call after the tracer attached)."""
@@ -248,17 +354,86 @@ def run_tracer(args, timeout):
     return out, err
 
 
+def temp_output_text(stream):
+    """Read a subprocess TemporaryFile without moving its shared file offset."""
+    size = os.fstat(stream.fileno()).st_size
+    data = os.pread(stream.fileno(), size, 0) if size else b""
+    return data.decode('utf-8', errors='replace')
+
+
+def wait_for_observation(proc, observe, timeout_s, interval_s=0.05):
+    """Poll an observable until it becomes truthy or a bounded deadline ends."""
+    deadline = time.monotonic() + timeout_s
+    last = None
+    while True:
+        try:
+            last = observe()
+        except (OSError, subprocess.TimeoutExpired):
+            last = None
+        if last or proc.poll() is not None:
+            return last
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return last
+        time.sleep(min(interval_s, remaining))
+
+
+def wait_for_control_socket(proc, trace_dir, timeout_s=30):
+    """Wait until the daemon run loop services a control round-trip.
+
+    The socket pathname is created before the sampled provider starts.  Path
+    existence alone therefore leaves a runner-stall window where a short test
+    workload can finish before capture is live.
+    """
+    status = wait_for_control_observation(
+        proc, trace_dir, "status", lambda value: value.get("ok") is True,
+        timeout_s=timeout_s)
+    return status.get("ok") is True
+
+
+def terminate_and_wait(proc, timeout_s=30):
+    if proc.poll() is None:
+        proc.terminate()
+    try:
+        proc.wait(timeout=timeout_s)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait(timeout=5)
+
+
+def wait_for_natural_exit(proc, timeout_s=60):
+    """Allow the tracer to finalize its trace; kill only after the hard cap."""
+    try:
+        proc.wait(timeout=timeout_s)
+        return True
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait(timeout=5)
+        return False
+
+
 # ── pgwt-server trace-file reader ──────────────────────────────────
 
-def server_query(trace_dir, cmd, extra=None):
+def server_query(trace_dir, cmd, extra=None, timeout_s=None):
     """One-shot pgwt-server JSON query against a trace dir."""
     proc = subprocess.Popen([SERVER, trace_dir],
                             stdin=subprocess.PIPE, stdout=subprocess.PIPE,
                             stderr=subprocess.PIPE, text=True)
+    deadline = (time.monotonic() + timeout_s
+                if timeout_s is not None else None)
+
+    def read_response():
+        if deadline is not None:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0 or not select.select(
+                    [proc.stdout], [], [], remaining)[0]:
+                raise subprocess.TimeoutExpired(proc.args, timeout_s)
+        return json.loads(proc.stdout.readline())
+
     try:
         proc.stdin.write(json.dumps({"id": 1, "cmd": "info"}) + "\n")
         proc.stdin.flush()
-        info = json.loads(proc.stdout.readline())
+        info = read_response()
         req = {"id": 2, "cmd": cmd,
                "from": max(0, info.get("from_ns", 0) - 30_000_000_000),
                "to": info.get("to_ns", 0) + 30_000_000_000}
@@ -266,13 +441,17 @@ def server_query(trace_dir, cmd, extra=None):
             req.update(extra)
         proc.stdin.write(json.dumps(req) + "\n")
         proc.stdin.flush()
-        resp = json.loads(proc.stdout.readline())
+        resp = read_response()
     finally:
-        proc.stdin.close()
         try:
-            proc.wait(timeout=5)
+            proc.stdin.close()
+        except BrokenPipeError:
+            pass
+        try:
+            proc.wait(timeout=1 if deadline is not None else 5)
         except subprocess.TimeoutExpired:
             proc.kill()
+            proc.wait(timeout=5)
     return resp
 
 
@@ -312,6 +491,11 @@ def parse_time_model(output):
         if m:
             model[m.group(1).strip()] = float(m.group(2))
     return model
+
+
+def time_model_cpu_snapshot_count(output):
+    return sum(1 for line in STRIP_ANSI.sub('', output).splitlines()
+               if re.match(r'^CPU\*\s{2,}[\d.]+\s+', line.strip()))
 
 
 def proc_oncpu_ns(pid):
@@ -369,7 +553,11 @@ def assert_wait_events(events, source, sleep_hi=6000, core=False):
     sleep_ev = [e for e in events if e['name'] == 'Timeout:PgSleep']
     check(len(sleep_ev) > 0, f"{source}: Timeout:PgSleep present (saw: {names})")
     if sleep_ev:
-        total = sleep_ev[0]['total_ms']
+        # Live output may contain several cumulative display snapshots.  A
+        # runner stall can let the workload straddle the first tick, so verify
+        # the most complete observation rather than whichever row printed
+        # first.  Trace-file output has one snapshot and is unchanged.
+        total = max(e['total_ms'] for e in sleep_ev)
         # One pg_sleep(3), fired after attach, session idle afterwards.
         # Sampled tier quantizes at the sample period; bounded either way:
         # zero and wildly-wrong both fail. core mode drops the exact-tier
@@ -384,7 +572,7 @@ def assert_wait_events(events, source, sleep_hi=6000, core=False):
     lock_ev = [e for e in events if e['name'] == 'Lock:relation']
     check(len(lock_ev) > 0, f"{source}: Lock:relation present (saw: {names})")
     if lock_ev:
-        total = lock_ev[0]['total_ms']
+        total = max(e['total_ms'] for e in lock_ev)
         # The waiter blocks from fire() until the phase ends (>= ~8s of
         # observation); open-interval accounting reports it at tick time.
         # core mode drops the floor: without firing watchpoints the trace holds
@@ -402,25 +590,55 @@ def phase_live_system_event(pm_pid, mode, core=False):
     print(f"--- Phase 1: live view (system_event, --mode {mode}) ---")
     wl = Workload()
     wl.open_sessions()
+    trace_dir = tempfile.mkdtemp(prefix="pgwt_smoke_live_")
+    os.chmod(trace_dir, 0o755)
+    tracer_stdout = tempfile.TemporaryFile()
+    tracer_stderr = tempfile.TemporaryFile()
     tracer = subprocess.Popen(
         [TRACER, "--mode", mode, "--pid", str(pm_pid),
-         "--interval", "12", "--duration", "15",
+         "-T", trace_dir,
+         "--interval", "12", "--duration", "60",
          "--view", "system_event"],
-        stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    time.sleep(2.5)   # BPF load + initial scan + (full) watchpoint attach
+        stdout=tracer_stdout, stderr=tracer_stderr)
+    # A fixed 2.5s launch delay raced a cold BPF load on overloaded runners:
+    # the workload could mostly finish before capture was ready.  The startup
+    # control socket is created only after discovery/attach, so wait for that
+    # real boundary instead. The 180s hard cap covers one 90s global
+    # validation budget, its separately bounded failure cleanup, and BPF
+    # startup; a stuck tracer still
+    # fails at a finite boundary.
+    tracer_ready = wait_for_control_socket(tracer, trace_dir, timeout_s=180)
+    check(tracer_ready,
+          f"live/{mode}: tracer reached the post-attach startup boundary")
     try:
-        wl.fire(sleep_s=3)     # t≈2.5: pg_sleep(3) + lock wait begin
+        wl.fire(sleep_s=3)
         time.sleep(6.5)
-        wl.release()           # t≈10.5: lock wait ends (~8s) before the tick
-        stdout, stderr = tracer.communicate(timeout=40)
-    except subprocess.TimeoutExpired:
-        tracer.kill()
-        stdout, stderr = tracer.communicate()
+        wl.release()
+        # Wait for a display snapshot that carries the asserted lower bounds,
+        # not merely an early snapshot where both rows have just appeared.
+        # The second tick is bounded headroom for the observed ~20s runner
+        # stall.  If accounting is broken and the totals never materialize,
+        # the unchanged assertions below still fail.
+        wait_for_observation(
+            tracer,
+            lambda: (lambda events: (
+                max((e['total_ms'] for e in events
+                     if e['name'] == 'Timeout:PgSleep'), default=0) >=
+                (100 if core else 1200) and
+                max((e['total_ms'] for e in events
+                     if e['name'] == 'Lock:relation'), default=0) >=
+                (100 if core else 4000)
+            ))(parse_system_events(temp_output_text(tracer_stdout))),
+            30)
     finally:
+        terminate_and_wait(tracer)
         wl.stop()
 
-    out = STRIP_ANSI.sub('', stdout.decode('utf-8', errors='replace'))
-    err = stderr.decode('utf-8', errors='replace')
+    out = STRIP_ANSI.sub('', temp_output_text(tracer_stdout))
+    err = temp_output_text(tracer_stderr)
+    tracer_stdout.close()
+    tracer_stderr.close()
+    subprocess.run(["rm", "-rf", trace_dir])
     events = parse_system_events(out)
     # THE zero-event guard: an empty view here means capture is dead (#30).
     check(len(events) > 0,
@@ -445,27 +663,52 @@ def phase_live_query_event(pm_pid, mode, pg_major, core=False):
           f"pgbench -i succeeded: {pgb_init.stderr[-200:]}")
     psql("SELECT pg_stat_statements_reset()")
 
-    # pgbench starts FIRST so its backends are found by the initial scan
-    # (keeps this phase deterministic; the fork-after-attach path has its
-    # own dedicated phase 4).
+    # pgbench starts FIRST and remains live until query output is observed, so
+    # a slow validator cannot let the fixed workload expire before capture.
+    pgbench_tag = f"pgwt_query_{secrets.token_hex(8)}"
+    pgbench_env = os.environ.copy()
+    pgbench_env["PGAPPNAME"] = pgbench_tag
     pgbench = subprocess.Popen(
-        ["pgbench", "-U", "postgres", "-d", "postgres", "-c", "4", "-T", "14"],
-        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
-    time.sleep(1)
+        ["pgbench", "-U", "postgres", "-d", "postgres", "-c", "4",
+         # Safety cap exceeds the 180s startup + 40s output deadlines; the
+         # process is explicitly stopped as soon as query output is proven.
+         "-T", "300"],
+        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+        env=pgbench_env)
+    pgbench_ready = wait_for_tagged_backend_count(
+        pgbench_tag, lambda count: count >= 4, timeout_s=30,
+        active_only=True)
+    check(pgbench_ready is not None,
+          "query-attribution workload is active before tracer attach")
 
+    trace_dir = tempfile.mkdtemp(prefix="pgwt_smoke_query_")
+    os.chmod(trace_dir, 0o755)
+    tracer_stdout = tempfile.TemporaryFile()
+    tracer_stderr = tempfile.TemporaryFile()
     tracer = subprocess.Popen(
         [TRACER, "--mode", mode, "--pid", str(pm_pid),
-         "--interval", "10", "--duration", "12",
+         "-T", trace_dir, "--interval", "10", "--duration", "60",
          "--view", "query_event"],
-        stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        stdout=tracer_stdout, stderr=tracer_stderr)
     try:
-        stdout, stderr = tracer.communicate(timeout=40)
-    except subprocess.TimeoutExpired:
-        tracer.kill()
-        stdout, stderr = tracer.communicate()
-    pgbench.wait(timeout=30)
+        tracer_ready = wait_for_control_socket(
+            tracer, trace_dir, timeout_s=180)
+        check(tracer_ready,
+              f"query/{mode}: tracer reached the post-attach startup boundary")
+        wait_for_observation(
+            tracer,
+            lambda: len(parse_query_event_ids(
+                temp_output_text(tracer_stdout))) > 0,
+            timeout_s=40)
+    finally:
+        terminate_and_wait(pgbench)
+        terminate_and_wait(tracer)
 
-    out = STRIP_ANSI.sub('', stdout.decode('utf-8', errors='replace'))
+    out = STRIP_ANSI.sub('', temp_output_text(tracer_stdout))
+    err = temp_output_text(tracer_stderr)
+    tracer_stdout.close()
+    tracer_stderr.close()
+    subprocess.run(["rm", "-rf", trace_dir])
     view_ids = parse_query_event_ids(out)
     truth = pgss_query_ids()
     check(len(truth) > 0,
@@ -474,7 +717,8 @@ def phase_live_query_event(pm_pid, mode, pg_major, core=False):
     if pg_major == 13 and mode == "tiered":
         check(len(view_ids) > 0,
               f"PG13 sampled query_event has synthetic grouping keys "
-              f"(view={len(view_ids)}; intentionally not joined to pgss ids)")
+              f"(view={len(view_ids)}; intentionally not joined to pgss ids)"
+              + ("" if view_ids else f" (stderr tail: {err[-300:]!r})"))
     elif core:
         check(not view_ids or len(matched) > 0,
               f"[core] query_event view ids, if any, cross-check against "
@@ -492,28 +736,323 @@ def phase_trace_file(pm_pid, mode, pg_major, core=False):
     trace_dir = tempfile.mkdtemp(prefix=f"pgwt_smoke_{mode}_")
     os.chmod(trace_dir, 0o755)
 
+    pg13_sampled_text = pg_major == 13 and mode == "tiered"
+
+    synthetic_witness_text = (
+        "SELECT sum(i),?,? FROM generate_series(?,?)AS g(i)")
+
+    def synthetic_text_persisted():
+        """Observe the PG13 worker's durable output, tolerating a partial tail."""
+        try:
+            with open(os.path.join(trace_dir, "query_texts.jsonl"),
+                      encoding="utf-8") as qtf:
+                for line in qtf:
+                    try:
+                        rec = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    if (rec.get("s") == "synthetic" and
+                            rec.get("v") == "pg13-synth-v1" and
+                            rec.get("t") == synthetic_witness_text):
+                        return True
+        except OSError:
+            pass
+        return False
+
+    def pgbench_text_persisted():
+        """A PG13 synthetic record tied specifically to pgbench tables."""
+        try:
+            with open(os.path.join(trace_dir, "query_texts.jsonl"),
+                      encoding="utf-8") as qtf:
+                for line in qtf:
+                    try:
+                        rec = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    if (rec.get("s") == "synthetic" and
+                            rec.get("v") == "pg13-synth-v1" and
+                            "pgbench_" in rec.get("t", "")):
+                        return True
+        except OSError:
+            pass
+        return False
+
     wl = Workload()
-    wl.open_sessions()
-    psql("SELECT pg_stat_statements_reset()")
-    # pgbench starts first so its backends are found by the initial scan
-    # (the fork-after-attach path is covered by phase 4).
-    pgbench = subprocess.Popen(
-        ["pgbench", "-U", "postgres", "-d", "postgres", "-c", "2", "-T", "16"],
-        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
-    time.sleep(1)
-    tracer = subprocess.Popen(
-        [TRACER, "--mode", mode, "--pid", str(pm_pid),
-         "-T", trace_dir, "--duration", "18", "--quiet",
-         "--interval", "5"],
-        stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    time.sleep(2.5)
+    pgbench = None
+    synthetic_source = None
+    synthetic_tag = None
+    synthetic_backend_pid = None
+    synthetic_backend_start = None
+    tracer = None
+    pgbench_truth = set()
+    persisted_pgbench_matches = set()
+    query_match_deadline = None
+
+    def trace_pgss_match_persisted():
+        """Return real sampled query IDs only after they reach the trace.
+
+        Aggregate sample progress is not a query-attribution barrier: on a
+        starved runner the first serviced tick can sample an unrelated backend,
+        after which stopping pgbench removes the only repeatable query-ID
+        producer.  Poll the durable trace against independent pgss truth while
+        that producer is still alive.  This is deliberately tiered/PG14+ only;
+        PG13 uses its synthetic-text barrier and full mode was not flaky.
+        """
+        nonlocal persisted_pgbench_matches
+        remaining = query_match_deadline - time.monotonic()
+        if remaining <= 0:
+            return None
+        try:
+            # One attempt may span the observed 20s runner stall, but can
+            # never outlive the enclosing 60s barrier.
+            qresp = server_query(trace_dir, "top_queries",
+                                 timeout_s=min(25, remaining))
+        except (OSError, subprocess.TimeoutExpired, json.JSONDecodeError,
+                BrokenPipeError):
+            return None
+        trace_ids = set()
+        for row in qresp.get("rows", []):
+            try:
+                query_id = int(str(row.get("query_id", "0")), 10)
+            except ValueError:
+                continue
+            if query_id:
+                trace_ids.add(query_id & 0xFFFFFFFFFFFFFFFF)
+        persisted_pgbench_matches = trace_ids & pgbench_truth
+        return persisted_pgbench_matches
+
+    def cleanup_phase():
+        # Stop producers first: the tracer's final drain is deliberately
+        # exhaustive and must not race a pgbench process still adding events.
+        if synthetic_tag is not None:
+            quoted_synthetic_tag = synthetic_tag.replace("'", "''")
+            try:
+                psql("SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
+                     f"WHERE application_name = '{quoted_synthetic_tag}'",
+                     timeout=30)
+            except subprocess.TimeoutExpired:
+                pass
+            stopped = wait_for_tagged_backend_count(
+                synthetic_tag, lambda count: count == 0, timeout_s=10)
+            # SQL itself can be starved beyond the measured ~20s stall. The
+            # exact tagged PID plus its /proc starttime makes the fallback
+            # targeted and PID-reuse safe; never leave the 2B-row witness on
+            # the shared validation box after an early assertion/exception.
+            if (stopped is None and synthetic_backend_pid and
+                    proc_start_ticks(synthetic_backend_pid) ==
+                    synthetic_backend_start):
+                try:
+                    os.kill(synthetic_backend_pid, signal.SIGTERM)
+                except ProcessLookupError:
+                    pass
+                wait_for_tagged_backend_count(
+                    synthetic_tag, lambda count: count == 0, timeout_s=10)
+        if synthetic_source is not None:
+            terminate_and_wait(synthetic_source)
+        if pgbench is not None:
+            terminate_and_wait(pgbench)
+        if tracer is not None:
+            terminate_and_wait(tracer)
+        wl.stop()
+        subprocess.run(["rm", "-rf", trace_dir])
+
     try:
-        wl.fire(sleep_s=3)     # t≈2.5 after attach
+        wl.open_sessions(discover_pids=(mode == "full"))
+        if mode == "full":
+            check(set(wl.backend_pids) == {"sleeper", "holder", "waiter"},
+                  f"trace/full: controlled backend identities are known "
+                  f"(pids={wl.backend_pids})")
+        psql("SELECT pg_stat_statements_reset()")
+        # pgbench starts first so its backends are found by the initial scan
+        # (the fork-after-attach path is covered by phase 4).
+        pgbench_tag = f"pgwt_trace_{secrets.token_hex(8)}"
+        pgbench_env = os.environ.copy()
+        pgbench_env["PGAPPNAME"] = pgbench_tag
+        pgbench = subprocess.Popen(
+            ["pgbench", "-U", "postgres", "-d", "postgres", "-c", "2",
+             # Safety cap exceeds every bounded startup/progress/text poll;
+             # the process is explicitly stopped after pgbench-specific
+             # persisted text is proven.
+             "-T", "420"],
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+            env=pgbench_env)
+        pgbench_ready = wait_for_tagged_backend_count(
+            pgbench_tag, lambda count: count >= 2, timeout_s=30,
+            active_only=True)
+        check(pgbench_ready is not None,
+              ("PG13 sampled-text" if pg13_sampled_text else "trace query") +
+              " workload is active before tracer attach")
+        if mode == "tiered" and pg_major >= 14 and not core:
+            # Freeze independent pgbench-only ground truth before the tracer
+            # exists. The lookup excludes pg_stat_statements itself, so neither
+            # the barrier nor the final assertion can match their observer SQL.
+            pgbench_truth = wait_for_observation(
+                pgbench, pgbench_pgss_query_ids, 30, interval_s=0.5) or set()
+            check(bool(pgbench_truth),
+                  f"trace/tiered: pg_stat_statements recorded pgbench ground "
+                  f"truth before tracer startup (ids={len(pgbench_truth)})")
+        if pg13_sampled_text:
+            # PG13's st_activity_raw layout is validated from coherent live
+            # rows during startup. pgbench micro-statements can all cross a
+            # command boundary during that scan under load, making validation
+            # correctly degrade and leaving no activity-text source. Keep one
+            # stable, exact text witness active across tracer attach so the
+            # test establishes the capability it later asserts.
+            synthetic_tag = f"pgwt_synth_{secrets.token_hex(8)}"
+            synthetic_env = os.environ.copy()
+            synthetic_env["PGAPPNAME"] = synthetic_tag
+            synthetic_env["PGOPTIONS"] = "-c max_parallel_workers_per_gather=0"
+            synthetic_source = subprocess.Popen(
+                ["psql", "-U", "postgres", "-d", "postgres", "-c",
+                 "SELECT sum(i), 'literal', 8675309 "
+                 "FROM generate_series(1, 2000000000) AS g(i) "
+                 "/* pgwt synthetic smoke */"],
+                stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+                env=synthetic_env)
+            synthetic_backend_pid = wait_for_tagged_active_backend(
+                synthetic_tag, timeout_s=30)
+            synthetic_backend_start = proc_start_ticks(synthetic_backend_pid)
+            check(synthetic_backend_pid is not None and
+                  synthetic_backend_start is not None,
+                  "PG13 persistent synthetic-text witness is active across "
+                  "tracer attach")
+        tracer = subprocess.Popen(
+            [TRACER, "--mode", mode, "--pid", str(pm_pid),
+             "-T", trace_dir,
+             # Hard cap only: the phase explicitly terminates after its
+             # post-workload control barrier. 360s covers the complete bounded
+             # sequence (five 30s control/lifecycle polls, PG13's two 60s text
+             # polls, and the controlled workload) for every version/mode.
+             "--duration", "360", "--quiet",
+             "--interval", "5"],
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        tracer_ready = wait_for_control_socket(
+            tracer, trace_dir, timeout_s=180)
+        check(tracer_ready,
+              ("PG13 sampled-text" if pg13_sampled_text else
+               f"trace/{mode}") +
+              " tracer reached the post-attach startup boundary")
+        before_workload_metrics = wait_for_control_observation(
+            tracer, trace_dir, "metrics",
+            lambda value: value.get("ok") is True, timeout_s=30)
+        check(before_workload_metrics.get("ok") is True,
+              f"trace/{mode}: baseline capture metrics are observable")
+        progress_field = "events_total" if mode == "full" else "samples_total"
+        query_capture_metrics = wait_for_control_observation(
+            tracer, trace_dir, "metrics",
+            lambda value: (
+                value.get(progress_field, 0) >
+                before_workload_metrics.get(progress_field, 0)),
+            timeout_s=30)
+        check(query_capture_metrics.get(progress_field, 0) >
+              before_workload_metrics.get(progress_field, 0),
+              f"trace/{mode}: pre-existing query workloads advanced capture")
+        if pg13_sampled_text:
+            # Aggregate samples can be supplied by the stable layout witness;
+            # require a durable pgbench-table statement before stopping
+            # pgbench so that witness cannot mask broken OLTP attribution.
+            pgbench_text_ready = wait_for_observation(
+                tracer, pgbench_text_persisted, 60)
+            check(pgbench_text_ready,
+                  "PG13 sampled trace persisted pgbench-specific normalized "
+                  "text before pgbench teardown")
+        elif mode == "tiered" and pg_major >= 14 and not core:
+            # Three observed ~20s event-loop stalls still leave multiple
+            # opportunities for a sampled tick and worker flush.  The exact
+            # pgss intersection must appear; a dead/phantom attribution path
+            # remains absent until the bounded deadline and fails here.
+            query_match_deadline = time.monotonic() + 60
+            matched_ready = wait_for_observation(
+                tracer, trace_pgss_match_persisted, 60, interval_s=1)
+            check(bool(matched_ready),
+                  f"trace/tiered: a pg_stat_statements query ID persisted "
+                  f"before producer teardown (matched="
+                  f"{len(persisted_pgbench_matches)})")
+        # Query-attribution coverage has now crossed the capture boundary.
+        # Stop pgbench before the PG13 durable-text witness: its microstatement
+        # churn can otherwise monopolize a severely starved sampler/worker.
+        # Full mode also needs the high-rate NMI producer gone before its exact
+        # controlled-wait interval.
+        terminate_and_wait(pgbench)
+        query_workload_stopped = wait_for_tagged_backend_count(
+            pgbench_tag, lambda count: count == 0, timeout_s=30)
+        check(query_workload_stopped is not None,
+              f"trace/{mode}: query producers stopped after capture proof")
+        if pg13_sampled_text:
+            # The stable pre-attach row removes the validation race; bounded
+            # polling still allows three observed 20s event-loop stalls for a
+            # coherent sampled tick and durable worker flush. A broken/absent
+            # text path reaches the deadline and fails every exact assertion.
+            text_ready = wait_for_observation(
+                tracer, synthetic_text_persisted, 60)
+            check(text_ready,
+                  "PG13 sampled trace persisted synthetic text before "
+                  "query-workload teardown")
+            quoted_synthetic_tag = synthetic_tag.replace("'", "''")
+            psql("SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
+                 f"WHERE application_name = '{quoted_synthetic_tag}'")
+            terminate_and_wait(synthetic_source)
+            synthetic_stopped = wait_for_tagged_backend_count(
+                synthetic_tag, lambda count: count == 0, timeout_s=30)
+            check(synthetic_stopped is not None,
+                  "PG13 persistent synthetic-text witness stopped before "
+                  "controlled waits")
+        # Full-tier watchpoints run from perf-event/NMI context.  The shared
+        # kernel ring can fail a reservation on lock contention even with free
+        # capacity, so a high-rate pgbench burst must not overlap the small
+        # deterministic waits whose exact magnitudes this phase verifies.
+        # Preserve query-attribution coverage above and open the controlled
+        # interval only after all high-rate producers are gone.
+        # ringbuf_drops_total increments in producer BPF context, so this
+        # snapshot is precise even while userspace drains older records.
+        controlled_baseline_metrics = wait_for_control_observation(
+            tracer, trace_dir, "metrics",
+            lambda value: value.get("ok") is True, timeout_s=30)
+        check(controlled_baseline_metrics.get("ok") is True,
+              f"trace/{mode}: controlled-interval loss baseline is observable")
+    except BaseException:
+        cleanup_phase()
+        raise
+    try:
+        wl.fire(sleep_s=3)
         time.sleep(8)
         wl.release()           # lock wait ends (~10s) inside the trace window
+        post_workload_metrics = wait_for_control_observation(
+            tracer, trace_dir, "metrics",
+            lambda value: (
+                value.get(progress_field, 0) >
+                controlled_baseline_metrics.get(progress_field, 0)),
+            timeout_s=30)
+        check(post_workload_metrics.get(progress_field, 0) >
+              controlled_baseline_metrics.get(progress_field, 0),
+              f"trace/{mode}: daemon consumed post-workload events before "
+              f"teardown")
+        if mode == "full":
+            drops_before = controlled_baseline_metrics.get(
+                "ringbuf_drops_total", -1)
+            drops_after = post_workload_metrics.get(
+                "ringbuf_drops_total", -2)
+            check(drops_before >= 0 and drops_after >= drops_before,
+                  f"trace/full: event-ring loss counter is observable and "
+                  f"monotonic (drops={drops_before}->{drops_after})")
+            if drops_after != drops_before:
+                print(f"  INFO: trace/full: global ring drops advanced "
+                      f"{drops_before}->{drops_after}; PID-scoped exact "
+                      f"checks below determine whether controlled records "
+                      f"were lost")
+        if tracer.poll() is None:
+            tracer.terminate()
         _, stderr = tracer.communicate(timeout=45)
         err = stderr.decode('utf-8', errors='replace')
-        pgbench.wait(timeout=30)
+
+        clean_finalization = tracer.returncode == 0
+        check(clean_finalization,
+              f"trace/{mode}: single-shot tracer finalized cleanly "
+              f"(rc={tracer.returncode})" if clean_finalization else
+              f"trace/{mode}: single-shot tracer finalized cleanly "
+              f"(rc={tracer.returncode}, stderr tail={err[-300:]!r})")
+        if not clean_finalization:
+            return
 
         resp = server_query(trace_dir, "top_events")
         rows = resp.get("rows", [])
@@ -523,6 +1062,51 @@ def phase_trace_file(pm_pid, mode, pg_major, core=False):
         events = [{'name': r.get('name'), 'count': r.get('count', 0),
                    'total_ms': r.get('total_ms', 0.0)} for r in rows]
         assert_wait_events(events, f"trace/{mode}", core=core)
+
+        if mode == "full" and set(wl.backend_pids) == {
+                "sleeper", "holder", "waiter"}:
+            # ringbuf_drops_total is global: background checkpointer/autovacuum
+            # events can lose an NMI-context reservation without touching this
+            # phase's records. Prove the real invariant directly—each tagged
+            # backend contributes its one exact wait, at the exact magnitude.
+            sleeper_resp = server_query(
+                trace_dir, "top_events",
+                extra={"filters": {"pid": wl.backend_pids["sleeper"]}})
+            waiter_resp = server_query(
+                trace_dir, "top_events",
+                extra={"filters": {"pid": wl.backend_pids["waiter"]}})
+            sleeper_rows = [
+                row for row in sleeper_resp.get("rows", [])
+                if row.get("name") == "Timeout:PgSleep"]
+            waiter_rows = [
+                row for row in waiter_resp.get("rows", [])
+                if row.get("name") == "Lock:relation"]
+            sleeper_count = sum(int(row.get("count", 0))
+                                for row in sleeper_rows)
+            waiter_count = sum(int(row.get("count", 0))
+                               for row in waiter_rows)
+            sleeper_ms = sum(float(row.get("total_ms", 0.0))
+                             for row in sleeper_rows)
+            waiter_ms = sum(float(row.get("total_ms", 0.0))
+                            for row in waiter_rows)
+            check(sleeper_count == 1,
+                  f"trace/full: controlled sleeper has exactly one PgSleep "
+                  f"record (pid={wl.backend_pids['sleeper']}, "
+                  f"count={sleeper_count})")
+            check(1200 <= sleeper_ms <= 6000,
+                  f"trace/full: controlled sleeper PgSleep is ~3000ms "
+                  f"(pid={wl.backend_pids['sleeper']}, total={sleeper_ms:.0f}ms)")
+            # A single SELECT can expose more than one relation-lock edge in
+            # PostgreSQL (observed count=2); the long blocking interval is the
+            # invariant. If that record is lost, the unchanged 4s duration
+            # floor below cannot be met by the additional short edge.
+            check(waiter_count >= 1,
+                  f"trace/full: controlled waiter has relation-lock records "
+                  f"(pid={wl.backend_pids['waiter']}, "
+                  f"count={waiter_count})")
+            check(4000 <= waiter_ms <= 25000,
+                  f"trace/full: controlled waiter lock is complete "
+                  f"(pid={wl.backend_pids['waiter']}, total={waiter_ms:.0f}ms)")
 
         # Query attribution must land in the trace too — and cross-check
         # against pg_stat_statements so phantom ids can't satisfy it.
@@ -535,7 +1119,9 @@ def phase_trace_file(pm_pid, mode, pg_major, core=False):
                 continue
             if qid != 0:
                 trace_ids.add(qid & 0xFFFFFFFFFFFFFFFF)
-        truth = pgss_query_ids()
+        truth = (pgbench_truth
+                 if mode == "tiered" and pg_major >= 14 and not core
+                 else pgss_query_ids())
         matched = trace_ids & truth
         text_rows = [r for r in qresp.get("rows", []) if r.get("text")]
         if pg_major == 13 and mode == "tiered":
@@ -578,6 +1164,11 @@ def phase_trace_file(pm_pid, mode, pg_major, core=False):
             ]
             check(len(synth_records) > 0,
                   "PG13 sidecar pins synthetic source/version and db/user context")
+            pgbench_records = [
+                rec for rec in synth_records if "pgbench_" in rec.get("t", "")
+            ]
+            check(len(pgbench_records) > 0,
+                  "PG13 sidecar retains a pgbench-specific sampled record")
             normalized_ok = any("?" in rec.get("t", "")
                                 for rec in synth_records) and all(
                 "/*" not in rec.get("t", "") and
@@ -607,8 +1198,7 @@ def phase_trace_file(pm_pid, mode, pg_major, core=False):
                       f"PG{pg_major} sampled query text resolved lazily from "
                       f"pg_stat_statements (text rows={len(text_rows)})")
     finally:
-        wl.stop()
-        subprocess.run(["rm", "-rf", trace_dir])
+        cleanup_phase()
 
 
 def phase_fork_after_attach(pm_pid, mode):
@@ -741,19 +1331,27 @@ class CpuStorm:
         cleanup_stale_backends()
 
 
-def sample_active_sessions(duration_s, interval=0.5):
-    """pg_stat_activity 1-per-interval ground truth: count of client
-    backends with state='active', excluding the sampling connection."""
+def sample_active_sessions(expected_pids, target_samples=12,
+                           deadline_s=30, interval=0.5):
+    """Collect a bounded quorum for one fixed pg_stat_activity population."""
     counts = []
-    end = time.time() + duration_s
-    while time.time() < end:
-        out = psql("SELECT count(*) FROM pg_stat_activity "
-                   "WHERE state = 'active' "
-                   "AND backend_type = 'client backend' "
-                   "AND pid != pg_backend_pid()", timeout=10)
+    pid_list = ",".join(str(int(pid)) for pid in expected_pids)
+    deadline = time.monotonic() + deadline_s
+    while len(counts) < target_samples and time.monotonic() < deadline:
+        remaining = deadline - time.monotonic()
+        try:
+            out = psql("SELECT count(*) FROM pg_stat_activity "
+                       "WHERE state = 'active' "
+                       "AND backend_type = 'client backend' "
+                       f"AND pid IN ({pid_list})",
+                       timeout=min(5, max(1, remaining)))
+        except subprocess.TimeoutExpired:
+            out = ""
         if re.fullmatch(r'\d+', out or ''):
             counts.append(int(out))
-        time.sleep(interval)
+            if len(counts) >= target_samples:
+                break
+        time.sleep(min(interval, max(0.0, deadline - time.monotonic())))
     return counts
 
 
@@ -764,26 +1362,39 @@ def cpu_storm_state(expected_pids, timeout=10):
     pid_list = ",".join(str(pid) for pid in expected_pids)
     out = psql(
         "SELECT pid, state, COALESCE(wait_event_type, 'CPU'), "
-        "COALESCE(wait_event, 'CPU') FROM pg_stat_activity "
+        "COALESCE(wait_event, 'CPU'), "
+        "(extract(epoch FROM state_change) * 1000000000)::bigint "
+        "FROM pg_stat_activity "
         f"WHERE pid IN ({pid_list}) ORDER BY pid", timeout=timeout)
     rows = []
     for line in out.splitlines():
         fields = line.split('|')
-        if len(fields) == 4 and re.fullmatch(r'\d+', fields[0]):
-            rows.append((int(fields[0]), fields[1], fields[2], fields[3]))
+        if (len(fields) == 5 and re.fullmatch(r'\d+', fields[0]) and
+                re.fullmatch(r'\d+', fields[4])):
+            rows.append((int(fields[0]), fields[1], fields[2], fields[3],
+                         int(fields[4])))
     return rows
 
 
 def cpu_storm_state_is_sustained(rows, expected_pids):
+    return (cpu_storm_state_is_active(rows, expected_pids)
+            and all(cpu_storm_row_is_waitless(row) for row in rows))
+
+
+def cpu_storm_state_is_active(rows, expected_pids):
     return ({row[0] for row in rows} == set(expected_pids)
             and len(rows) == len(expected_pids)
-            and all(row[1:] == ('active', 'CPU', 'CPU') for row in rows))
+            and all(row[1] == 'active' for row in rows))
+
+
+def cpu_storm_row_is_waitless(row):
+    return row[1:4] == ('active', 'CPU', 'CPU')
 
 
 def cpu_storm_state_is_idle(rows, expected_pids):
     return ({row[0] for row in rows} == set(expected_pids)
             and len(rows) == len(expected_pids)
-            and all(row[1:] == ('idle', 'Client', 'ClientRead')
+            and all(row[1:4] == ('idle', 'Client', 'ClientRead')
                     for row in rows))
 
 
@@ -797,17 +1408,26 @@ def sample_cpu_storm_state(expected_pids, duration_s, interval=0.5,
     return snapshots
 
 
+def wait_for_cpu_storm_state(proc, expected_pids, timeout_s):
+    def observe():
+        rows = cpu_storm_state(expected_pids, timeout=timeout_s)
+        return rows if cpu_storm_state_is_sustained(
+            rows, expected_pids) else None
+
+    return wait_for_observation(proc, observe, timeout_s)
+
+
 def aas_bucket_total(bucket):
     return sum(v for k, v in bucket.items()
                if k not in ("t", "total", "cat") and isinstance(v, (int, float)))
 
 
-def ctl_request(trace_dir, obj):
+def ctl_request(trace_dir, obj, timeout=5):
     """One arbitrary JSON request over the daemon control socket."""
     import socket
     path = os.path.join(trace_dir, "pgwt.sock")
     s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-    s.settimeout(5)
+    s.settimeout(timeout)
     try:
         s.connect(path)
         s.sendall((json.dumps(obj) + "\n").encode())
@@ -822,9 +1442,32 @@ def ctl_request(trace_dir, obj):
         s.close()
 
 
-def ctl_query(trace_dir, cmd):
+def ctl_query(trace_dir, cmd, timeout=5):
     """One JSON request over the daemon control socket."""
-    return ctl_request(trace_dir, {"cmd": cmd})
+    return ctl_request(trace_dir, {"cmd": cmd}, timeout=timeout)
+
+
+def wait_for_control_observation(proc, trace_dir, cmd, predicate,
+                                 timeout_s=30, interval_s=0.05):
+    """Bounded-poll a control response, tolerating transient runner stalls."""
+    deadline = time.monotonic() + timeout_s
+    last = {}
+    while True:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0 or proc.poll() is not None:
+            return last
+        if os.path.exists(os.path.join(trace_dir, "pgwt.sock")):
+            try:
+                last = ctl_query(trace_dir, cmd,
+                                 timeout=min(5, max(0.1, remaining)))
+                if predicate(last):
+                    return last
+            except (OSError, ValueError, json.JSONDecodeError):
+                pass
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return last
+        time.sleep(min(interval_s, remaining))
 
 
 def phase_cpu_straddle(pm_pid, mode):
@@ -905,20 +1548,24 @@ def phase_pure_cpu_straddle(pm_pid, mode):
     accumulator makes it visible LIVE (open-interval schedstat delta) and the
     terminal flush writes its on-CPU stretch to the trace at daemon shutdown.
 
-    Asserted in BOTH tiers: CPU present in the live view AND in the trace, with
-    the magnitude cross-checked against the backend's /proc on-CPU delta over
-    the same [attach, shutdown] window (±20%). The loop count is huge so it
-    straddles capture end on any box; it starts BEFORE the tracer so its
-    command start-edge is already past at attach."""
+    Asserted in BOTH tiers: CPU present in the live view AND in the trace. Full
+    mode's measured CPU is cross-checked against the backend's /proc on-CPU
+    delta (±20%). Sampled mode is ASH demand (we==0 includes runnable time), so
+    its magnitude is cross-checked against the command's active wall interval;
+    comparing it with consumed /proc CPU falsely fails under CPU contention.
+    The loop count is huge so it straddles capture end on any box; it starts
+    BEFORE the tracer so its command start-edge is already past at attach."""
     print(f"--- Phase: PURE-CPU straddle, --mode {mode} (no waits — empty-trace "
           f"repro) ---")
     trace_dir = tempfile.mkdtemp(prefix="pgwt_smoke_purecpu_")
     os.chmod(trace_dir, 0o755)
 
+    hog_app = f"pgwt_purecpu_{os.getpid()}_{secrets.token_hex(8)}"
     hog = subprocess.Popen(
         ["psql", "-U", "postgres", "-d", "postgres"],
         stdin=subprocess.PIPE, stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL, text=True)
+        stderr=subprocess.DEVNULL, text=True,
+        env={**os.environ, "PGAPPNAME": hog_app})
     # Nested int4 loops: ~1e11 iterations of pure compute — minutes of runtime,
     # guaranteed to still be running at daemon shutdown so the terminal flush
     # has an open on-CPU stretch to close. Both bounds fit int4 (a single
@@ -932,17 +1579,20 @@ def phase_pure_cpu_straddle(pm_pid, mode):
         "FOR i IN 1..1000000 LOOP x := x + i; END LOOP; x := 0; "
         "END LOOP; END $$;\n")
     hog.stdin.flush()
-    time.sleep(2.5)   # the command is in flight; its start-edge is past
+    be_pid = wait_for_tagged_active_backend(hog_app, timeout_s=30)
+    check(be_pid is not None,
+          f"pure-CPU straddle backend is active before tracer attach "
+          f"(--mode {mode}, pid={be_pid})")
 
     argv = [TRACER, "--mode", mode, "--pid", str(pm_pid),
-            "-T", trace_dir, "--duration", "12", "--interval", "5",
+            "-T", trace_dir, "--duration", "35", "--interval", "5",
             "--view", "time_model"]
     if mode == "tiered":
         argv += ["--anomaly-aas-factor", "1000000"]   # keep it pure sampled
 
-    be_pid = None
     oncpu_before = oncpu_after = None
     win_from = win_shutdown = 0
+    natural_exit = False
     # Self-diagnosis (docs/ROADMAP_AND_STATUS.md "REOPENED 2026-08-04 — a
     # FOURTH straddle live-CPU mode exists"): this phase's live-CPU check is
     # the flake's only witness, so ALWAYS arm the daemon's shutdown state_map
@@ -951,31 +1601,45 @@ def phase_pure_cpu_straddle(pm_pid, mode):
     # stderr and prints nothing extra; a failing run surfaces it below, so
     # the next CI hit hands us the hog's actual end-state instead of another
     # inference cycle.
-    tracer = subprocess.Popen(argv, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-                              env={**os.environ, "PGWT_DEBUG_DUMP_STATE": "1"})
+    tracer_stdout = tempfile.TemporaryFile()
+    tracer_stderr = tempfile.TemporaryFile()
+    tracer = subprocess.Popen(
+        argv, stdout=tracer_stdout, stderr=tracer_stderr,
+        env={**os.environ, "PGWT_DEBUG_DUMP_STATE": "1"})
     try:
-        time.sleep(3.0)                 # BPF load + scan/attach seeds the backend
-        be_pid = find_active_do_backend()
+        wait_for_control_socket(tracer, trace_dir, timeout_s=180)
         win_from = time.time_ns()
         oncpu_before = proc_oncpu_ns(be_pid) if be_pid else None  # ≈ the seed instant
-        # Let the tracer run out its 12s duration and flush its open interval.
-        stdout, stderr = tracer.communicate(timeout=45)
+        # A 12s process lifetime could end wholly inside an observed 20s runner
+        # stall, leaving no display tick even though the terminal trace and
+        # /proc accounting were correct.  Wait up to 35s for the live invariant
+        # itself, then stop early and exercise the same terminal flush.
+        wait_for_observation(
+            tracer,
+            lambda: parse_time_model(
+                temp_output_text(tracer_stdout)).get('CPU*', 0.0),
+            timeout_s=35)
+        natural_exit = wait_for_natural_exit(tracer, timeout_s=50)
         win_shutdown = time.time_ns()
         oncpu_after = proc_oncpu_ns(be_pid) if be_pid else None    # ≈ the flush instant
-    except subprocess.TimeoutExpired:
-        tracer.kill()
-        stdout, stderr = tracer.communicate()
-        win_shutdown = time.time_ns()
-        oncpu_after = proc_oncpu_ns(be_pid) if be_pid else None
     finally:
+        if tracer.poll() is None:
+            tracer.kill()
+            tracer.wait(timeout=5)
         try:
             hog.stdin.write("\\q\n"); hog.stdin.flush()
         except (BrokenPipeError, ValueError):
             pass
         hog.terminate()
         cleanup_stale_backends()
-    out = STRIP_ANSI.sub('', stdout.decode('utf-8', errors='replace'))
-    err = stderr.decode('utf-8', errors='replace')
+    out = STRIP_ANSI.sub('', temp_output_text(tracer_stdout))
+    err = temp_output_text(tracer_stderr)
+    tracer_stdout.close()
+    tracer_stderr.close()
+
+    check(natural_exit and tracer.returncode == 0,
+          f"pure-CPU tracer reached its bounded natural shutdown "
+          f"(--mode {mode}, rc={tracer.returncode})")
 
     # 1) LIVE VIEW: the periodic time_model print must show measured CPU>0.
     #    Pre-T8 this row was 0.0 for a waitless command (the exact symptom).
@@ -1006,18 +1670,10 @@ def phase_pure_cpu_straddle(pm_pid, mode):
           f"(--mode {mode}): cpu_ms = {trace_cpu_ms:.0f} "
           f"(has_measured_cpu={resp.get('has_measured_cpu')})")
 
-    # 3) MAGNITUDE: the DO backend's measured CPU over [win_from, shutdown] must
-    #    match its /proc on-CPU delta over the SAME span (both read the same
-    #    se.sum_exec_runtime counter). Isolate the backend with a pid filter and
-    #    integrate the aas cpu (avg-sessions × window = cpu-seconds): the integral
-    #    is window-length-invariant, so querying THROUGH shutdown+margin includes
-    #    the --mode full flush record (timestamped at shutdown — a sub-window
-    #    ending earlier would time-prune its block) while still measuring only
-    #    the CPU it actually spent. ±20% absorbs attach/seed timing slack and
-    #    sampled-tier estimator noise.
-    if be_pid and oncpu_before is not None and oncpu_after is not None \
-            and oncpu_after > oncpu_before and win_shutdown > win_from:
-        proc_ms = (oncpu_after - oncpu_before) / 1e6
+    # 3) MAGNITUDE: isolate the DO backend and integrate AAS CPU
+    #    (avg-sessions × window = CPU/demand seconds). Querying through a
+    #    shutdown margin includes the full-mode terminal-flush block.
+    if be_pid and win_shutdown > win_from:
         win_to = win_shutdown + 3_000_000_000   # margin so the flush block is in range
         aresp = server_query(trace_dir, "aas",
                              extra={"from": win_from, "to": win_to,
@@ -1026,11 +1682,22 @@ def phase_pure_cpu_straddle(pm_pid, mode):
         cpu_mean = (sum(b.get("cpu", 0.0) for b in abuckets) / len(abuckets)
                     if abuckets else 0.0)
         trace_win_ms = cpu_mean * (win_to - win_from) / 1e9 * 1000.0
-        ratio = trace_win_ms / proc_ms if proc_ms > 0 else 0.0
-        check(0.8 <= ratio <= 1.2,
-              f"pure-CPU straddle measured CPU {trace_win_ms:.0f}ms within ±20% "
-              f"of /proc on-CPU {proc_ms:.0f}ms over [attach,shutdown] "
-              f"(ratio {ratio:.2f}, --mode {mode})")
+        if mode == "full":
+            proc_ms = ((oncpu_after - oncpu_before) / 1e6
+                       if oncpu_before is not None and oncpu_after is not None
+                       and oncpu_after > oncpu_before else 0.0)
+            ratio = trace_win_ms / proc_ms if proc_ms > 0 else 0.0
+            check(0.8 <= ratio <= 1.2,
+                  f"pure-CPU straddle measured CPU {trace_win_ms:.0f}ms within "
+                  f"±20% of /proc on-CPU {proc_ms:.0f}ms over "
+                  f"[attach,shutdown] (ratio {ratio:.2f}, --mode {mode})")
+        else:
+            demand_ms = (win_shutdown - win_from) / 1e6
+            ratio = trace_win_ms / demand_ms if demand_ms > 0 else 0.0
+            check(0.8 <= ratio <= 1.2,
+                  f"pure-CPU straddle sampled demand {trace_win_ms:.0f}ms "
+                  f"within ±20% of active wall time {demand_ms:.0f}ms "
+                  f"(ratio {ratio:.2f}; runnable time intentionally counts)")
     else:
         # Never silently pass the magnitude gate — record why it could not run.
         check(be_pid is not None,
@@ -1393,46 +2060,81 @@ def run_stale_seed_capture(pm_pid, extra_env):
     guarantees never comes — or by the sweep's repair reseed (the one
     sanctioned non-fire opener; see preseed_state_map), so the CPU*
     discriminator isolates the sweep as the repairing agent in BOTH runs.
-    Returns (out, err)."""
+    Returns output, diagnostics, tagged PID, pid-scoped CPU, observation
+    readiness, and clean bounded completion."""
     trace_dir = tempfile.mkdtemp(prefix="pgwt_smoke_stale_")
     os.chmod(trace_dir, 0o755)
 
+    hog_app = f"pgwt_staleseed_{os.getpid()}_{secrets.token_hex(8)}"
     hog = subprocess.Popen(
         ["psql", "-U", "postgres", "-d", "postgres"],
         stdin=subprocess.PIPE, stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL, text=True)
+        stderr=subprocess.DEVNULL, text=True,
+        env={**os.environ, "PGAPPNAME": hog_app})
     hog.stdin.write(
         "DO $$ DECLARE x bigint := 0; BEGIN "
         "FOR o IN 1..100000 LOOP "
         "FOR i IN 1..1000000 LOOP x := x + i; END LOOP; x := 0; "
         "END LOOP; END $$;\n")
     hog.stdin.flush()
-    time.sleep(2.5)   # the command is in flight; its start-edge is past
+    hog_pid = wait_for_tagged_active_backend(hog_app, timeout_s=30)
 
     argv = [TRACER, "--mode", "full", "--pid", str(pm_pid),
-            "-T", trace_dir, "--duration", "16", "--interval", "4",
+            "-T", trace_dir, "--duration", "35", "--interval", "4",
             "--view", "time_model"]
     env = {**os.environ, "PGWT_TEST_STALE_SEED": "1",
            "PGWT_TEST_NO_SCHED_ONCPU": "1", **extra_env}
     win_from = time.time_ns()
-    tracer = subprocess.Popen(argv, stdout=subprocess.PIPE,
-                              stderr=subprocess.PIPE, env=env)
-    hog_pid = None
+    tracer_stdout = tempfile.TemporaryFile()
+    tracer_stderr = tempfile.TemporaryFile()
+    tracer = subprocess.Popen(argv, stdout=tracer_stdout,
+                              stderr=tracer_stderr, env=env)
     hog_cpu_ms = 0.0
+    observation_ready = False
+    natural_exit = False
     try:
-        time.sleep(3.0)                 # BPF load + scan seeds the backend
-        hog_pid = find_active_do_backend()
-        stdout, stderr = tracer.communicate(timeout=50)
-    except subprocess.TimeoutExpired:
-        tracer.kill()
-        stdout, stderr = tracer.communicate()
+        wait_for_control_socket(tracer, trace_dir, timeout_s=180)
+        observation_deadline = time.monotonic() + 35
+        if "PGWT_TEST_NO_STALE_SWEEP" in extra_env:
+            # Prove the negative across three real display ticks; wall time
+            # alone says nothing when the event loop itself is starved.
+            observation_ready = bool(wait_for_observation(
+                tracer,
+                lambda: (time_model_cpu_snapshot_count(
+                    temp_output_text(tracer_stdout)) >= 3),
+                timeout_s=max(0.0, observation_deadline - time.monotonic())))
+        else:
+            # Wait for the actual repair counter, then for a later live snapshot
+            # to carry multiple seconds of the repaired CPU interval.  Both are
+            # bounded, and either stays absent when the product regression is
+            # reintroduced.
+            reseed_metrics = wait_for_control_observation(
+                tracer, trace_dir, "metrics",
+                lambda metrics: metrics.get("state_reseeds_total", 0) > 0,
+                timeout_s=max(0.0, observation_deadline - time.monotonic()))
+            live_ready = wait_for_observation(
+                tracer,
+                lambda: (parse_time_model(temp_output_text(
+                    tracer_stdout)).get('CPU*', 0.0) > 2000.0),
+                timeout_s=max(0.0, observation_deadline - time.monotonic()))
+            observation_ready = (
+                reseed_metrics.get("state_reseeds_total", 0) > 0 and
+                bool(live_ready))
+        natural_exit = wait_for_natural_exit(tracer, timeout_s=50)
     finally:
+        if tracer.poll() is None:
+            tracer.kill()
+            tracer.wait(timeout=5)
         try:
             hog.stdin.write("\\q\n"); hog.stdin.flush()
         except (BrokenPipeError, ValueError):
             pass
         hog.terminate()
         cleanup_stale_backends()
+    out = STRIP_ANSI.sub('', temp_output_text(tracer_stdout))
+    err = temp_output_text(tracer_stderr)
+    tracer_stdout.close()
+    tracer_stderr.close()
     # Pid-scoped trace CPU for THE HOG (the phase_pure_cpu_straddle integral
     # pattern): busy CI runners inflate the GLOBAL live CPU* through OTHER
     # firing backends — under the sched-inert hook, any backend's we==0 gap
@@ -1450,9 +2152,8 @@ def run_stale_seed_capture(pm_pid, extra_env):
                     if abuckets else 0.0)
         hog_cpu_ms = cpu_mean * (win_to - win_from) / 1e9 * 1000.0
     subprocess.run(["rm", "-rf", trace_dir])
-    return (STRIP_ANSI.sub('', stdout.decode('utf-8', errors='replace')),
-            stderr.decode('utf-8', errors='replace'),
-            hog_pid, hog_cpu_ms)
+    return (out, err, hog_pid, hog_cpu_ms, observation_ready,
+            natural_exit and tracer.returncode == 0)
 
 
 def phase_stale_seed_sweep(pm_pid):
@@ -1496,7 +2197,14 @@ def phase_stale_seed_sweep(pm_pid):
           "poisoned attach seed) ---")
 
     # Positive: sweep enabled — it must repair the poisoned seed.
-    out, err, hog_pid, hog_cpu_ms = run_stale_seed_capture(pm_pid, {})
+    out, err, hog_pid, hog_cpu_ms, observed, completed = \
+        run_stale_seed_capture(pm_pid, {})
+    check(hog_pid is not None,
+          f"positive: stale-seed hog active before tracer attach (pid={hog_pid})")
+    check(observed,
+          "positive: reseed counter and repaired live CPU appeared before deadline")
+    check(completed,
+          "positive: stale-seed tracer reached bounded natural shutdown")
     check("PGWT_TEST_STALE_SEED" in err,
           "attach seed poisoned with a fake stale wait (test hook active)")
     check("PGWT_TEST_NO_SCHED_ONCPU" in err,
@@ -1520,8 +2228,14 @@ def phase_stale_seed_sweep(pm_pid):
     # measured 13074ms global while the hog contributed nothing), so the
     # global time_model figure cannot discriminate — the hog's own pid-scoped
     # trace CPU can, deterministically on any host.
-    out, err, hog_pid, hog_cpu_ms = run_stale_seed_capture(
+    out, err, hog_pid, hog_cpu_ms, observed, completed = run_stale_seed_capture(
         pm_pid, {"PGWT_TEST_NO_STALE_SWEEP": "1"})
+    check(hog_pid is not None,
+          f"negative: stale-seed hog active before tracer attach (pid={hog_pid})")
+    check(observed,
+          "negative: three real display snapshots appeared before deadline")
+    check(completed,
+          "negative: stale-seed tracer reached bounded natural shutdown")
     check("PGWT_TEST_STALE_SEED" in err,
           "negative: attach seed poisoned (test hook active)")
     check("PGWT_TEST_NO_SCHED_ONCPU" in err,
@@ -1548,65 +2262,193 @@ def phase_sampled_aas_truth(pm_pid):
     print("--- Phase 5: CPU observability in pure sampled AAS ---")
     trace_dir = tempfile.mkdtemp(prefix="pgwt_smoke_aas_")
     os.chmod(trace_dir, 0o755)
+    storm = None
+    sleeper = None
+    tracer = None
+    resources_cleaned = False
 
-    storm = CpuStorm(3)
-    sleeper = subprocess.Popen(
-        ["psql", "-U", "postgres", "-d", "postgres"],
-        stdin=subprocess.PIPE, stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL, text=True)
-    time.sleep(1.0)
+    def cleanup_resources():
+        nonlocal resources_cleaned
+        if resources_cleaned:
+            return
+        if tracer is not None:
+            try:
+                terminate_and_wait(tracer)
+            except (OSError, subprocess.TimeoutExpired):
+                pass
+        if sleeper is not None:
+            try:
+                terminate_and_wait(sleeper)
+            except (OSError, subprocess.TimeoutExpired):
+                pass
+        if storm is not None:
+            try:
+                storm.stop()
+            except OSError:
+                pass
+        resources_cleaned = True
 
-    tracer = subprocess.Popen(
-        [TRACER, "--mode", "tiered", "--pid", str(pm_pid),
-         "-T", trace_dir, "--duration", "17", "--quiet",
-         "--interval", "5", "--anomaly-aas-factor", "1000000"],
-        stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    time.sleep(3.0)   # BPF load + scan + first ticks
+    expected_pids = []
+    psa = []
+    win_from = win_to = time.time_ns()
+    err = ""
+    tracer_completed = False
+
     try:
-        win_from = time.time_ns()
-        storm.fire()
-        sleeper.stdin.write("SELECT pg_sleep(10);\n")
+        storm = CpuStorm(3)
+        sleeper_app = f"pgwt_aas_sleep_{os.getpid()}_{secrets.token_hex(8)}"
+        sleeper = subprocess.Popen(
+            ["psql", "-U", "postgres", "-d", "postgres"],
+            stdin=subprocess.PIPE, stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL, text=True,
+            env={**os.environ, "PGAPPNAME": sleeper_app})
+
+        def controlled_backend_pids():
+            app_names = storm.application_names + [sleeper_app]
+            quoted_apps = ",".join(
+                "'" + app.replace("'", "''") + "'"
+                for app in app_names)
+            rows = psql(
+                "SELECT pid FROM pg_stat_activity "
+                f"WHERE application_name IN ({quoted_apps}) "
+                "AND datname = 'postgres' ORDER BY application_name",
+                timeout=5)
+            pids = sorted({int(row) for row in rows.splitlines()
+                           if re.fullmatch(r'\d+', row)})
+            return pids if len(pids) == 4 else None
+
+        expected_pids = wait_for_observation(
+            sleeper, controlled_backend_pids, 30) or []
+        check(len(expected_pids) == 4,
+              f"sampled-AAS workload has four tagged backends "
+              f"(pids={expected_pids})")
+
+        tracer = subprocess.Popen(
+            [TRACER, "--mode", "tiered", "--pid", str(pm_pid),
+             "-T", trace_dir, "--duration", "150", "--quiet",
+             "--interval", "5", "--anomaly-aas-factor", "1000000"],
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        tracer_ready = wait_for_control_socket(
+            tracer, trace_dir, timeout_s=180)
+        check(tracer_ready,
+              "sampled-AAS tracer reached the post-attach startup boundary")
+
+        storm.fire_continuous(160)
+        sleeper.stdin.write("SELECT pg_sleep(160);\n")
         sleeper.stdin.flush()
-        time.sleep(0.5)
-        psa = sample_active_sessions(9.0, interval=0.5)
+        expected_set = set(expected_pids)
+
+        def wait_for_exact_active(timeout_s):
+            deadline = time.monotonic() + timeout_s
+            last = set()
+            while time.monotonic() < deadline and tracer.poll() is None:
+                if not expected_set:
+                    return set()
+                remaining = deadline - time.monotonic()
+                pid_list = ",".join(str(pid) for pid in expected_set)
+                try:
+                    rows = psql(
+                        "SELECT pid FROM pg_stat_activity "
+                        "WHERE state = 'active' "
+                        "AND backend_type = 'client backend' "
+                        f"AND pid IN ({pid_list})",
+                        timeout=min(5, max(1, remaining)))
+                except subprocess.TimeoutExpired:
+                    rows = ""
+                last = {int(row) for row in rows.splitlines()
+                        if re.fullmatch(r'\d+', row)}
+                if last == expected_set:
+                    return last
+                time.sleep(min(0.05, max(0.0,
+                                         deadline - time.monotonic())))
+            return last
+
+        active_pids = wait_for_exact_active(30)
+        check(active_pids == expected_set and len(expected_set) == 4,
+              f"all four sampled-AAS backends became active "
+              f"(active={sorted(active_pids)})")
+
+        win_from = time.time_ns()
+        start_metrics = wait_for_control_observation(
+            tracer, trace_dir, "metrics",
+            lambda m: isinstance(m.get("samples_total"), (int, float)), 30)
+        samples_at_start = int(start_metrics.get("samples_total", 0))
+        check("samples_total" in start_metrics,
+              "sampled-AAS baseline metrics are observable")
+
+        psa = sample_active_sessions(expected_pids, interval=0.5)
+        progress_metrics = wait_for_control_observation(
+            tracer, trace_dir, "metrics",
+            lambda m: int(m.get("samples_total", 0)) >=
+                      samples_at_start + 4,
+            30)
+        samples_after = int(progress_metrics.get("samples_total", 0))
+        check(samples_after >= samples_at_start + 4,
+              f"sampled-AAS tracer advanced after the window opened "
+              f"(samples={samples_at_start}->{samples_after})")
+        end_active = wait_for_exact_active(10)
+        check(end_active == expected_set and len(expected_set) == 4,
+              f"all four sampled-AAS backends remained active through the "
+              f"observation window (active={sorted(end_active)})")
         win_to = time.time_ns()
-        _, stderr = tracer.communicate(timeout=40)
+
+        try:
+            _, stderr = tracer.communicate(timeout=180)
+            natural_exit = True
+        except subprocess.TimeoutExpired:
+            tracer.kill()
+            _, stderr = tracer.communicate()
+            natural_exit = False
         err = stderr.decode('utf-8', errors='replace')
-    except subprocess.TimeoutExpired:
-        tracer.kill()
-        _, stderr = tracer.communicate()
-        err = stderr.decode('utf-8', errors='replace')
+        tracer_completed = natural_exit and tracer.returncode == 0
+
+        cleanup_resources()
+        check(tracer_completed,
+              f"sampled-AAS tracer finalized cleanly (rc={tracer.returncode})")
+
+        psa_mean = sum(psa) / len(psa) if psa else 0.0
+        check(len(psa) >= 8 and all(count == 4 for count in psa),
+              f"ground truth: four tagged backends stayed active across a "
+              f"bounded quorum (mean={psa_mean:.2f}, n={len(psa)}, "
+              f"counts={psa})")
+
+        responses = [
+            server_query(
+                trace_dir, "aas",
+                extra={"from": win_from, "to": win_to, "buckets": 9,
+                       "filters": {"pid": pid}})
+            for pid in expected_pids
+        ]
+        bucket_sets = [resp.get("buckets", []) for resp in responses]
+        have_pid_buckets = (len(bucket_sets) == 4 and
+                            all(len(buckets) > 0 for buckets in bucket_sets))
+        check(have_pid_buckets,
+              "AAS view has buckets for all four controlled backends"
+              if have_pid_buckets else
+              f"AAS view has per-PID buckets "
+              f"(sets={list(map(len, bucket_sets))}, "
+              f"stderr tail: {err[-300:]!r})")
+        if have_pid_buckets:
+            tracer_mean = sum(
+                sum(aas_bucket_total(b) for b in buckets) / len(buckets)
+                for buckets in bucket_sets)
+            cpu_mean = sum(
+                sum(b.get("cpu", 0.0) for b in buckets) / len(buckets)
+                for buckets in bucket_sets)
+            tol = max(0.9, 0.35 * psa_mean)
+            check(abs(tracer_mean - psa_mean) <= tol,
+                  f"sampled AAS matches pg_stat_activity ground truth: "
+                  f"tracer={tracer_mean:.2f} vs psa={psa_mean:.2f} "
+                  f"(tol ±{tol:.2f}) [AAS-1 definition of done]")
+            check(cpu_mean >= 1.0,
+                  f"CPU class carries the storm: cpu AAS = {cpu_mean:.2f} "
+                  f"(pre-T2 sampler reported ~0 here)")
+            fidelities = [resp.get("fidelity") for resp in responses]
+            check(all(fidelity == "sampled" for fidelity in fidelities),
+                  f"window is pure sampled tier (fidelity={fidelities!r})")
     finally:
-        storm.stop()
-        sleeper.terminate()
-
-    psa_mean = sum(psa) / len(psa) if psa else 0.0
-    check(psa_mean >= 2.0,
-          f"ground truth: pg_stat_activity mean active = {psa_mean:.2f} "
-          f"(storm running; n={len(psa)})")
-
-    resp = server_query(trace_dir, "aas",
-                        extra={"from": win_from, "to": win_to, "buckets": 9})
-    buckets = resp.get("buckets", [])
-    check(len(buckets) > 0,
-          "aas view has buckets over the storm window" if buckets else
-          f"aas view has buckets (stderr tail: {err[-300:]!r})")
-    if buckets:
-        totals = [aas_bucket_total(b) for b in buckets]
-        tracer_mean = sum(totals) / len(totals)
-        cpu_mean = sum(b.get("cpu", 0.0) for b in buckets) / len(buckets)
-        tol = max(0.9, 0.35 * psa_mean)
-        check(abs(tracer_mean - psa_mean) <= tol,
-              f"sampled AAS matches pg_stat_activity ground truth: "
-              f"tracer={tracer_mean:.2f} vs psa={psa_mean:.2f} (tol ±{tol:.2f}) "
-              f"[AAS-1 definition of done]")
-        check(cpu_mean >= 1.0,
-              f"CPU class carries the storm: cpu AAS = {cpu_mean:.2f} "
-              f"(pre-T2 sampler reported ~0 here)")
-        check(resp.get("fidelity") == "sampled",
-              f"window is pure sampled tier (fidelity={resp.get('fidelity')!r})")
-
-    subprocess.run(["rm", "-rf", trace_dir])
+        cleanup_resources()
+        subprocess.run(["rm", "-rf", trace_dir])
 
 
 def phase_cpu_storm_escalation(pm_pid):
@@ -1618,16 +2460,14 @@ def phase_cpu_storm_escalation(pm_pid):
     trace_dir = tempfile.mkdtemp(prefix="pgwt_smoke_esc_")
     os.chmod(trace_dir, 0o755)
 
-    # Timing invariant: C=2 reaches h in 1.5/(1.25-0.80) = 3.34s. The 30s
+    # Timing invariant: C=2 reaches h in 1.5/(1.25-0.80) = 3.34s. The 45s
     # command covers the 5s readiness allowance, the 10s/0.5s ground-truth
-    # sweep including one final 5s query + sleep (15.5s worst case), and the
-    # 5s before-metrics state proof: 5 + 15.5 + 5 = 25.5s, leaving 4.5s.
-    # Control-socket latency is intentionally outside the required-sustained
-    # window: bad_states plus before_metrics_state already prove the incident
-    # reached collection. Completion still has 10s grace. The 75s tracer
-    # leaves 21s after the conservative 3 + 5 + 30 + 10 + 5 + 1 = 54s
-    # startup/readiness/burn/grace/final-state-query/writer-drain bound.
-    burn_duration_s = 30
+    # sweep, and a full fresh 3.34s evidence horizon after a transient exact
+    # setup rollback even across the observed ~20s event-loop stall.  The
+    # window assertion polls that real outcome for at most 30s; it still fails
+    # if no exact window opens. Completion has another 10s grace, all within
+    # the existing 75s tracer lifetime.
+    burn_duration_s = 45
     readiness_timeout_s = 5
     ground_truth_duration_s = 10
     state_query_timeout_s = 5
@@ -1652,14 +2492,25 @@ def phase_cpu_storm_escalation(pm_pid):
         else subprocess.PIPE
     tracer = subprocess.Popen(
         tracer_argv,
-        stdout=subprocess.PIPE, stderr=tracer_stderr)
-    time.sleep(3.0)   # BPF load + scan; CPU guard needs no baseline warmup
+        stdout=subprocess.PIPE, stderr=tracer_stderr,
+        env={**os.environ, "PGWT_TEST_EXACT_PRESEED_FAIL_ONCE": "1"})
+    tracer_ready = wait_for_control_socket(tracer, trace_dir, timeout_s=180)
+    startup_metrics = wait_for_control_observation(
+        tracer, trace_dir, "metrics",
+        lambda value: (
+            value.get("tier") == "sampled" and
+            value.get("effective_cpu_capacity_cores") == 2 and
+            value.get("effective_cpu_capacity_source") == "override"),
+        timeout_s=30)
+    check(tracer_ready and startup_metrics.get("tier") == "sampled",
+          "CPU-saturation tracer reached sampled/capacity-ready startup")
     storm_from = time.time_ns()
     storm_to = storm_from
     storm_states = []
     before_metrics_state = []
     metrics = {}
     status = {}
+    escalated_state = []
     try:
         storm.fire_continuous(duration_s=burn_duration_s)
         ready_state = []
@@ -1682,20 +2533,29 @@ def phase_cpu_storm_escalation(pm_pid):
               f"(state={ready_state})")
 
         storm_from = time.time_ns()
-        # C=2 reaches h after roughly 3.3s at capped demand. Every ground-truth
-        # snapshot must see all three exact PIDs active and waitless: unlike the
-        # old discrete generate_series burst, this proves the test supplied a
-        # sustained saturation incident rather than assuming it did.
+        # C=2 reaches h after roughly 3.3s at capped demand. Ground-truth
+        # snapshots must show all three exact PIDs staying in their one active
+        # command, with waitless demand at or above C across the sweep. Unlike
+        # the old discrete generate_series burst, this proves the test supplied
+        # a sustained saturation incident rather than assuming it did.
         storm_states = sample_cpu_storm_state(
             storm_pids, ground_truth_duration_s, interval=0.5,
             timeout=state_query_timeout_s)
         storm_to = time.time_ns()
-        before_metrics_state = cpu_storm_state(
-            storm_pids, timeout=state_query_timeout_s)
+        before_metrics_state = wait_for_cpu_storm_state(
+            tracer, storm_pids, state_query_timeout_s)
         try:
-            metrics = ctl_query(trace_dir, "metrics")
+            metrics = wait_for_control_observation(
+                tracer, trace_dir, "metrics",
+                lambda value: (
+                    value.get("anomaly_cpu_saturation_fires_total", 0) >= 1
+                    and value.get("escalation_windows_total", 0) >= 1
+                    and value.get("tier") == "escalated"),
+                timeout_s=30)
             status = ctl_query(trace_dir, "status")
-        except OSError as e:
+            escalated_state = wait_for_cpu_storm_state(
+                tracer, storm_pids, state_query_timeout_s)
+        except (OSError, ValueError, json.JSONDecodeError) as e:
             print(f"  (control socket: {e})")
 
         # Exact-tier CPU is an interval closed by the command's transition to
@@ -1716,9 +2576,13 @@ def phase_cpu_storm_escalation(pm_pid):
         check(cpu_storm_state_is_idle(completed_state, storm_pids),
               f"all three CPU commands closed into ClientRead before the "
               f"trace query (state={completed_state})")
-        # End the AAS window at the observed active->ClientRead boundary. The
-        # following writer-drain delay must not dilute the last of 8 buckets.
-        storm_to = time.time_ns()
+        # End the AAS window at PostgreSQL's actual active->ClientRead state
+        # boundary, not when this potentially delayed observer returned.  A
+        # small inclusion margin covers ordering between the activity edge and
+        # PgBackendStatus publication; edge buckets are excluded below.
+        state_change_times = [row[4] for row in completed_state]
+        if state_change_times:
+            storm_to = max(state_change_times) + 100_000_000
         time.sleep(1.0)  # let the closed exact intervals drain to the writer
         _, stderr = tracer.communicate(timeout=40)
         if debug_cpu_ticks:
@@ -1741,14 +2605,46 @@ def phase_cpu_storm_escalation(pm_pid):
         print("--- PGWT_DEBUG_ANOMALY_CPU_TICK tracer stderr ---")
         print(err)
 
-    bad_states = [state for state in storm_states
-                  if not cpu_storm_state_is_sustained(state, storm_pids)]
-    check(not bad_states and len(storm_states) > 0,
-          f"all three tagged backends stayed active and waitless on every "
-          f"storm poll (snapshots={len(storm_states)}, bad={bad_states[:2]})")
-    check(cpu_storm_state_is_sustained(before_metrics_state, storm_pids),
+    active_states = [state for state in storm_states
+                     if cpu_storm_state_is_active(state, storm_pids)]
+    joint_waitless_states = [state for state in storm_states
+                             if cpu_storm_state_is_sustained(
+                                 state, storm_pids)]
+    waitless_by_pid = {
+        pid: sum(any(row[0] == pid and cpu_storm_row_is_waitless(row)
+                     for row in state)
+                 for state in storm_states)
+        for pid in storm_pids
+    }
+    waitless_slots = sum(waitless_by_pid.values())
+    capacity_slot_quorum = 2 * len(storm_states)
+    per_backend_quorum = max(3, (len(storm_states) + 2) // 3)
+    # PostgreSQL may briefly enter a housekeeping wait such as ProcArray even
+    # inside this CPU-only command.  Joint-waitless snapshot ratios varied from
+    # 10/18 to 17/17 under load even though all three commands stayed active and
+    # the CPU rule/window fired.  Assert the saturation invariant directly:
+    # every command stays active; waitless slots average at least the configured
+    # C=2; and every backend contributes across at least one third of the sweep.
+    # The bounded start/window gates immediately below still require all three
+    # to be jointly waitless at two distinct milestones.  A missing command, a
+    # permanently stuck backend, or demand below capacity therefore still fails.
+    check(len(storm_states) > 0 and len(active_states) == len(storm_states),
+          f"all three tagged CPU commands stayed active on every storm poll "
+          f"(active={len(active_states)}/{len(storm_states)})")
+    check(waitless_slots >= capacity_slot_quorum and
+          all(count >= per_backend_quorum
+              for count in waitless_by_pid.values()),
+          f"storm poll quorum averaged at least C=2 waitless demand and every "
+          f"backend contributed (slots={waitless_slots}/"
+          f"{3 * len(storm_states)}, required={capacity_slot_quorum}; "
+          f"per_pid={waitless_by_pid}, required_each={per_backend_quorum}; "
+          f"joint={len(joint_waitless_states)}/{len(storm_states)})")
+    check(cpu_storm_state_is_sustained(before_metrics_state or [], storm_pids),
           f"CPU-only saturation reaches metrics collection "
           f"(before={before_metrics_state})")
+    check(cpu_storm_state_is_sustained(escalated_state or [], storm_pids),
+          f"tagged CPU saturation still held when the exact window appeared "
+          f"(state={escalated_state})")
 
     cpu_fires = metrics.get("anomaly_cpu_saturation_fires_total", 0)
     windows = metrics.get("escalation_windows_total", 0)
@@ -1770,26 +2666,49 @@ def phase_cpu_storm_escalation(pm_pid):
           f"reason={status.get('escalation_reason')!r})")
     check("rule=cpu-saturation" in err,
           "CPU saturation fire is distinct in the daemon log")
+    check("PGWT_TEST_EXACT_PRESEED_FAIL_ONCE" in err and
+          "retry 1/3 after backoff and fresh evidence" in err and
+          "anomaly AUTO-escalation: rule=cpu-saturation" in err,
+          "one-shot exact preseed rollback retried through the full product path")
 
-    # No step artifact: every interior 1s bucket across the tier switch
-    # must show the storm. With C=2 the CUSUM switch occurs during this >=10s
-    # window, without relying on a sub-second firing assumption. Pre-T2,
-    # sampled buckets read ~0.0 while exact buckets read ~3 — a hard step.
+    # No sustained step artifact: at least 95% of the interior ~1s buckets,
+    # with no adjacent misses, and the aggregate window must show the storm.
+    # Requiring EVERY wall bucket falsely failed when an overloaded runner
+    # starved one sampler interval even though the tagged commands stayed
+    # active and both tiers otherwise reported them.  The tight miss budget
+    # still rejects sustained or broadly intermittent loss across the tier
+    # switch; Phase 5 independently guards sampled CPU attribution.  With C=2
+    # the CUSUM switch occurs in this window without relying on a sub-second
+    # firing assumption.
+    aas_from = storm_from + 500_000_000
+    aas_range_ns = max(1, storm_to - aas_from)
+    aas_bucket_count = max(
+        3, min(90, (aas_range_ns + 999_999_999) // 1_000_000_000))
     resp = server_query(trace_dir, "aas",
-                        extra={"from": storm_from + 500_000_000,
-                               "to": storm_to,
-                               "buckets": 8})
+                        extra={"from": aas_from, "to": storm_to,
+                               "buckets": aas_bucket_count})
     buckets = resp.get("buckets", [])
-    check(len(buckets) >= 3, f"aas buckets across the tier switch "
-          f"(got {len(buckets)}, fidelity={resp.get('fidelity')!r})")
-    if buckets:
+    check(len(buckets) >= 5 and resp.get("fidelity") == "mixed",
+          f"~1s AAS buckets span both tiers (got {len(buckets)}, "
+          f"fidelity={resp.get('fidelity')!r})")
+    if len(buckets) >= 3:
         totals = [aas_bucket_total(b) for b in buckets]
-        lo = min(totals)
+        interior_totals = totals[1:-1]
+        lo = min(interior_totals)
+        mean = sum(interior_totals) / len(interior_totals)
+        good = sum(value >= 1.2 for value in interior_totals)
+        required = (95 * len(interior_totals) + 99) // 100
+        bad_run = max_bad_run = 0
+        for value in interior_totals:
+            bad_run = 0 if value >= 1.2 else bad_run + 1
+            max_bad_run = max(max_bad_run, bad_run)
         truth = min((len(state) for state in storm_states), default=0)
-        check(lo >= 1.2,
-              f"no AAS step artifact at the tier switch: min bucket = "
-              f"{lo:.2f}, buckets = {[f'{t:.1f}' for t in totals]}, "
-              f"minimum tagged pg_stat_activity count = {truth}")
+        check(good >= required and max_bad_run <= 1 and mean >= 1.2,
+              f"no sustained AAS step artifact at the tier switch: "
+              f"quorum={good}/{len(interior_totals)} (required={required}), "
+              f"longest miss run={max_bad_run}, mean={mean:.2f}, "
+              f"min={lo:.2f}; minimum tagged "
+              f"pg_stat_activity count = {truth}")
 
     subprocess.run(["rm", "-rf", trace_dir])
 

--- a/tests/test_capture_smoke.py
+++ b/tests/test_capture_smoke.py
@@ -603,10 +603,9 @@ def phase_live_system_event(pm_pid, mode, core=False):
     # A fixed 2.5s launch delay raced a cold BPF load on overloaded runners:
     # the workload could mostly finish before capture was ready.  The startup
     # control socket is created only after discovery/attach, so wait for that
-    # real boundary instead. The 180s hard cap covers one 90s global
-    # validation budget, its separately bounded failure cleanup, and BPF
-    # startup; a stuck tracer still
-    # fails at a finite boundary.
+    # real boundary instead. The 180s hard cap covers the observed loaded
+    # startup even though controlled observations now receive independent
+    # budgets; the product retains a separate finite outer bound.
     tracer_ready = wait_for_control_socket(tracer, trace_dir, timeout_s=180)
     check(tracer_ready,
           f"live/{mode}: tracer reached the post-attach startup boundary")

--- a/tests/test_data_esc_coverage.py
+++ b/tests/test_data_esc_coverage.py
@@ -17,9 +17,10 @@ daemon already writes:
     the last TRANSITIONS-block timestamp actually committed — never beyond.
   * END with no START (window opened before this file / older file deleted):
     coverage starts at the file's first block timestamp.
-  * boundary rule (FID-6): a sample represents (ts − period, ts]; it is
-    dropped iff its interval MIDPOINT (ts − period/2) falls inside a covered
-    span (inclusive). Worst-case error per window edge ≤ period/2.
+  * boundary rule (FID-6): a sample represents (ts − period, ts]; exact
+    coverage is subtracted from that interval. Fully covered samples vanish;
+    boundary-straddling samples retain only their uncovered weight. This is
+    exact even when a delayed SMP-3 tick carries seconds of elapsed time.
   * files with transitions and no SAMPLES blocks (--mode full) are covered
     whole-file; files with samples+transitions but no markers anywhere fall
     back to per-block spans (legacy traces).
@@ -71,14 +72,16 @@ def sample_range(pid, start_ts, end_ts, event, qid=0):
     return out
 
 
+def uncovered_sample_ns(sample, spans, period=PERIOD):
+    """Sample weight left after subtracting normalized exact spans."""
+    start = sample["ts"] - period
+    end = sample["ts"]
+    covered = sum(max(0, min(end, e) - max(start, s)) for s, e in spans)
+    return max(0, period - covered)
+
+
 def dropped_by_rule(samples, spans):
-    """Apply the documented boundary rule: drop iff midpoint in any span."""
-    n = 0
-    for smp in samples:
-        mid = smp["ts"] - PERIOD // 2
-        if any(s <= mid <= e for (s, e) in spans):
-            n += 1
-    return n
+    return sum(uncovered_sample_ns(smp, spans) == 0 for smp in samples)
 
 
 def lock_ms(resp):
@@ -144,7 +147,7 @@ def test_long_wait_window(t):
 # ── 2. FID-6: boundary rule at window edges ───────────────────────────
 
 def test_boundary_rule(t):
-    print("\n### 2. FID-6: sample-interval midpoint rule at window edges ###")
+    print("\n### 2. FID-6: exact sample clipping at window edges ###")
     w0 = BASE + 10 * S
     w1 = w0 + 10 * S
 
@@ -163,9 +166,8 @@ def test_boundary_rule(t):
     n_kept = len(samples) - n_dropped
     expected_lock_ms = n_kept * (PERIOD / 1e6)
 
-    # Sanity of the rule itself: a sample AT w0 has midpoint w0 - period/2,
-    # outside the window → kept; a sample at w0+period has midpoint inside →
-    # dropped; a sample at w1+period has midpoint w1+period/2 → kept.
+    # A sample AT w0 lies wholly before the window; the first whole interval
+    # inside is dropped; the first interval after w1 is kept.
     t.check(dropped_by_rule([sample_at(1, w0, 0)], [(w0, w1)]) == 0,
             "rule: sample exactly at window start is kept (mass before w0)")
     t.check(dropped_by_rule([sample_at(1, w0 + PERIOD, 0)], [(w0, w1)]) == 1,
@@ -188,10 +190,177 @@ def test_boundary_rule(t):
             tm = srv.query("time_model")
             t.check_approx(lock_ms(tm), expected_lock_ms, 0.001,
                            f"Lock = {expected_lock_ms:.0f}ms "
-                           f"({n_kept} samples kept by the midpoint rule)")
+                           f"({n_kept} samples kept after exact clipping)")
             rows = {r["name"]: r for r in tm["rows"]}
             t.check_approx(rows.get("IO", {}).get("ms", -1), 500.0, 0.001,
                            "exact IO interval inside the window = 500ms")
+    finally:
+        cleanup_traces(trace_dir)
+
+
+def test_delayed_tick_clipping(t):
+    print("\n### 2b. SMP-3 delayed tick is clipped, not wholly dropped ###")
+    w0 = BASE + 30 * S
+    w1 = w0 + 4 * S
+    # Every observation has its midpoint inside exact coverage, so the old
+    # all-or-nothing rule dropped its entire elapsed weight. Exercise either
+    # boundary and one tick spanning the whole exact window (two output
+    # fragments).
+    cases = [
+        ("start", w0 + 3 * S, 5 * S),
+        ("end", w1 + 2 * S, 5 * S),
+        ("both", w1 + 2 * S, 8 * S),
+    ]
+    for edge, tick, delayed_period in cases:
+        # Same PID as the exact interval exercises chronological merge order,
+        # not just additive totals from unrelated sessions.
+        sample = sample_at(1000, tick, LOCK_RELATION, 200)
+        expected_lock_ns = uncovered_sample_ns(
+            sample, [(w0, w1)], delayed_period)
+        scenario = {
+            "backends": [
+                {"pid": 1000, "type": "client", "user": "u", "db": "d"},
+                {"pid": 1001, "type": "client", "user": "u", "db": "d"},
+            ],
+            "queries": [{"id": 100, "text": "Q1"},
+                        {"id": 200, "text": "Q2"}],
+            "events": [
+                esc_marker(w0, MARKER_ESC_START, 4, 0),
+                {"pid": 1000, "ts": w1, "dur": 4 * S,
+                 "old": IO_DATA_FILE_READ, "new": CPU, "qid": 100},
+                esc_marker(w1, MARKER_ESC_END, 4, 2),
+            ],
+            "sample_period_ns": delayed_period,
+            "samples": [sample],
+            "interleave": 1,
+        }
+        trace_dir = generate_traces(scenario)
+        try:
+            with ServerHarness(trace_dir) as srv:
+                query_from = w0 - 3 * S
+                query_to = w1 + 3 * S
+                tm = srv.query("time_model", from_=query_from, to_=query_to)
+                t.check_eq(tm.get("fidelity"), "mixed",
+                           f"{edge}-straddling delayed tick stays mixed")
+                t.check_approx(lock_ms(tm), expected_lock_ns / 1e6, 0.001,
+                               f"{edge}-straddling delayed tick keeps exactly "
+                               f"{expected_lock_ns / 1e6:.0f}ms uncovered")
+                rows = {r["name"]: r for r in tm["rows"]}
+                t.check_approx(rows.get("IO", {}).get("ms", -1),
+                               4000.0, 0.001,
+                               f"{edge}-straddling exact interval remains 4s")
+
+                top_events = srv.query(
+                    "top_events", from_=query_from, to_=query_to)
+                event_rows = {r["name"]: r
+                              for r in top_events.get("rows", [])}
+                t.check_eq(event_rows.get("Lock:relation", {}).get("count"),
+                           1, f"{edge}-straddling tick counts one observation")
+
+                if edge == "both":
+                    top_queries = srv.query(
+                        "top_queries", from_=query_from, to_=query_to)
+                    query_rows = {r["query_id"]: r
+                                  for r in top_queries.get("rows", [])}
+                    t.check_eq(query_rows.get("200", {}).get("count"), 1,
+                               "two fragments count as one query observation")
+                    t.check_approx(
+                        query_rows.get("200", {}).get("total_ms", -1),
+                        expected_lock_ns / 1e6, 0.001,
+                        "two fragments conserve query sampled weight")
+
+                    transitions = srv.query(
+                        "transitions", from_=query_from, to_=query_to)
+                    t.check_eq(transitions.get("total"), 1,
+                               "mixed transition view ignores sample fragments")
+                    fingerprints = srv.query(
+                        "fingerprints", from_=query_from, to_=query_to)
+                    fp_rows = {r["query_id"]: r
+                               for r in fingerprints.get("rows", [])}
+                    t.check_eq(sorted(fp_rows), [100],
+                               "mixed fingerprints exclude sampled query")
+                    t.check_eq(fp_rows.get(100, {}).get("transitions"), 1,
+                               "mixed fingerprint counts only exact edge")
+
+                    timeline = srv.query(
+                        "session_timeline", from_=query_from, to_=query_to)
+                    visible = timeline.get("events", [])
+                    t.check_eq(len(visible), 3,
+                               "same-PID split timeline has three ordered bars")
+                    if len(visible) == 3:
+                        expected = [
+                            (w0 - 2 * S, 2 * S, LOCK_RELATION),
+                            (w0, 4 * S, IO_DATA_FILE_READ),
+                            (w1, 2 * S, LOCK_RELATION),
+                        ]
+                        actual = [(e["s"], e["d"], e["e"])
+                                  for e in visible]
+                        t.check_eq(actual, expected,
+                                   "split fragments retain chronological order")
+
+                    # The left slice clips a pre-window fragment at `from`;
+                    # the right slice requires loading a delayed sample whose
+                    # physical timestamp is AFTER `to`.
+                    for side, narrow_from, narrow_to in [
+                        ("left", w0 - S, w0 + S),
+                        ("right", w1, w1 + S),
+                    ]:
+                        narrow = srv.query(
+                            "top_events", from_=narrow_from, to_=narrow_to)
+                        narrow_rows = {r["name"]: r
+                                       for r in narrow.get("rows", [])}
+                        lock = narrow_rows.get("Lock:relation", {})
+                        t.check_approx(lock.get("total_ms", -1), 1000.0,
+                                       0.001,
+                                       f"{side} request slice clips delayed "
+                                       "sample weight to 1s")
+                        t.check_eq(lock.get("count"), 1,
+                                   f"{side} request slice counts one sample")
+        finally:
+            cleanup_traces(trace_dir)
+
+
+def test_lookahead_respects_load_bound(t):
+    print("\n### 2c. delayed-sample lookahead excludes exact records ###")
+    w0 = BASE + 50 * S
+    w1 = w0 + 4 * S
+    events = [
+        esc_marker(w0, MARKER_ESC_START, 4, 0),
+        {"pid": 1000, "ts": w1, "dur": 4 * S,
+         "old": IO_DATA_FILE_READ, "new": CPU, "qid": 100},
+        esc_marker(w1, MARKER_ESC_END, 4, 2),
+    ]
+    # These records fall outside the tiny request but inside its 8s sample
+    # lookahead. They must be rejected before PGWT_LOAD_MAX_EVENTS accounting.
+    for i in range(10):
+        events.append({
+            "pid": 1000,
+            "ts": w1 + 2 * S + i * 100_000_000,
+            "dur": 50_000_000,
+            "old": IO_DATA_FILE_READ,
+            "new": CPU,
+            "qid": 100,
+        })
+    scenario = {
+        "backends": [{"pid": 1000, "type": "client", "user": "u", "db": "d"}],
+        "queries": [{"id": 100, "text": "Q1"},
+                    {"id": 200, "text": "Q2"}],
+        "events": events,
+        "sample_period_ns": 8 * S,
+        "samples": [sample_at(1000, w1 + 2 * S, LOCK_RELATION, 200)],
+        "interleave": 1,
+    }
+    trace_dir = generate_traces(scenario)
+    try:
+        with ServerHarness(
+                trace_dir, env={"PGWT_LOAD_MAX_EVENTS": "5"}) as srv:
+            resp = srv.query("top_events", from_=w1, to_=w1 + S)
+            t.check("error" not in resp,
+                    "lookahead-only exact records do not false-refuse range")
+            rows = {r["name"]: r for r in resp.get("rows", [])}
+            t.check_approx(rows.get("Lock:relation", {}).get("total_ms", -1),
+                           1000.0, 0.001,
+                           "lookahead still loads and clips overlapping sample")
     finally:
         cleanup_traces(trace_dir)
 
@@ -318,10 +487,10 @@ def test_cross_file_offsets(t):
              sample_range(1001, m1 + PERIOD, m1 + 5 * S, LOCK_RELATION, 200))
     smp_b.sort(key=lambda s: s["ts"])
 
-    # Ground truth in the MONO domain: every lock sample whose midpoint is in
-    # [m0, m1] is covered by the window — regardless of which file it is in
-    # and regardless of the files' disagreeing wall offsets. File A's
-    # unclosed portion is closed by file B's END marker (same clock domain).
+    # Ground truth in the MONO domain: lock-sample weight inside [m0, m1] is
+    # covered by the window — regardless of its file or that file's wall
+    # offset. File A's unclosed portion is closed by file B's END marker (same
+    # clock domain). Grid alignment makes each sample wholly kept or dropped.
     all_samples = smp_a + smp_b
     n_dropped = dropped_by_rule(all_samples, [(m0, m1)])
     n_kept = len(all_samples) - n_dropped
@@ -358,9 +527,13 @@ def test_cross_file_offsets(t):
             ev = srv.query("top_events",
                            from_=m1 + PERIOD // 2, to_=m1 + 6 * S)
             evrows = {r["name"]: r for r in ev["rows"]}
+            # The first post-window sample represents [m1,m1+PERIOD]; this
+            # request starts halfway through it, so only half its weight is in
+            # range. The remaining tail samples contribute their full period.
             tail = [s for s in smp_b if s["ts"] > m1]
+            expected_tail_ms = (len(tail) - 0.5) * (PERIOD / 1e6)
             t.check_approx(evrows.get("Lock:relation", {}).get("total_ms", -1),
-                           len(tail) * (PERIOD / 1e6), 0.05,
+                           expected_tail_ms, 0.001,
                            "post-window slice sees only the sampled tail "
                            "(consistent re-anchored wall mapping)")
     finally:
@@ -372,6 +545,8 @@ def main():
     print(f"=== {t.name} ===")
     test_long_wait_window(t)
     test_boundary_rule(t)
+    test_delayed_tick_clipping(t)
+    test_lookahead_respects_load_bound(t)
     test_crash_mid_window(t)
     test_multiple_windows(t)
     test_cross_file_offsets(t)

--- a/tests/test_data_esc_coverage.py
+++ b/tests/test_data_esc_coverage.py
@@ -236,10 +236,14 @@ def test_delayed_tick_clipping(t):
         }
         trace_dir = generate_traces(scenario)
         try:
-            with ServerHarness(trace_dir) as srv:
+            env = ({"PGWT_LOAD_MAX_EVENTS": "4"}
+                   if edge == "both" else None)
+            with ServerHarness(trace_dir, env=env) as srv:
                 query_from = w0 - 3 * S
                 query_to = w1 + 3 * S
                 tm = srv.query("time_model", from_=query_from, to_=query_to)
+                t.check("error" not in tm,
+                        f"{edge}-straddling merge fits raw-event bound")
                 t.check_eq(tm.get("fidelity"), "mixed",
                            f"{edge}-straddling delayed tick stays mixed")
                 t.check_approx(lock_ms(tm), expected_lock_ns / 1e6, 0.001,
@@ -316,6 +320,21 @@ def test_delayed_tick_clipping(t):
                                        "sample weight to 1s")
                         t.check_eq(lock.get("count"), 1,
                                    f"{side} request slice counts one sample")
+
+            if edge == "both":
+                for failpoint in ("merge_grow", "sort"):
+                    with ServerHarness(
+                            trace_dir,
+                            env={"PGWT_LOAD_MAX_EVENTS": "4",
+                                 "PGWT_TEST_LOAD_ALLOC_FAIL": failpoint}) as srv:
+                        failed = srv.query(
+                            "time_model", from_=w0 - 3 * S, to_=w1 + 3 * S)
+                        t.check_eq(
+                            failed.get("code"), "allocation_failed",
+                            f"{failpoint} OOM is not mislabeled window-too-large")
+                        t.check("max_events" not in failed and
+                                "rows" not in failed,
+                                f"{failpoint} OOM returns no bound or partial data")
         finally:
             cleanup_traces(trace_dir)
 

--- a/tests/test_data_fidelity.py
+++ b/tests/test_data_fidelity.py
@@ -186,9 +186,9 @@ def build_mixed():
 
     SAMPLES (10 Hz) of Lock:relation run continuously over
     [BASE+1.0s .. BASE+4.0s] (31 samples). Boundary rule (FID-6): a sample
-    represents (ts − period, ts] and is dropped iff its MIDPOINT
-    (ts − period/2) lies inside the covered span. Surviving samples each
-    add 100ms of Lock. No double counting in the overlap.
+    represents (ts − period, ts], and coverage is subtracted from that
+    interval. These grid-aligned samples are therefore wholly kept or dropped;
+    each survivor adds 100ms of Lock. No double counting in the overlap.
     """
     one_s = 1_000_000_000
     trans_start = BASE_TS + one_s
@@ -213,10 +213,11 @@ def build_mixed():
         ts += PERIOD
     samples.sort(key=lambda s: s["ts"])
 
-    # Midpoint rule: dropped iff (ts - PERIOD/2) in [first_ts, last_ts].
-    in_range = sum(1 for s in samples
-                   if trans_start <= s["ts"] - PERIOD // 2 <= trans_end)
-    out_range = len(samples) - in_range
+    # Grid-aligned samples wholly after exact coverage survive, as does the
+    # sample ending exactly at the window start (its interval precedes exact
+    # coverage and the trace's default range begins earlier).
+    out_range = sum(1 for s in samples
+                    if s["ts"] == trans_start or s["ts"] > trans_end)
 
     return ({
         "backends": [

--- a/tests/test_data_window_bound.py
+++ b/tests/test_data_window_bound.py
@@ -87,6 +87,15 @@ def main():
             resp = srv.query("time_model")
             t.check("error" not in resp,
                     "default bound loads the full window")
+
+        with ServerHarness(
+                trace_dir,
+                env={"PGWT_TEST_LOAD_ALLOC_FAIL": "merge_initial"}) as srv:
+            resp = srv.query("time_model")
+            t.check_eq(resp.get("code"), "allocation_failed",
+                       "merge malloc failure has a distinct error code")
+            t.check("max_events" not in resp and "rows" not in resp,
+                    "allocation failure is neither a range refusal nor partial data")
     finally:
         cleanup_traces(trace_dir)
 

--- a/tests/test_deterministic.py
+++ b/tests/test_deterministic.py
@@ -2,13 +2,13 @@
 """test_deterministic.py — Deterministic accuracy tests with controlled backends.
 
 Tests:
-  1. pg_sleep exact count: N × pg_sleep(1) in a loop → count=N, total≈N*1000ms
+  1. pg_sleep exact count: N × pg_sleep(2) in a loop → count=N, total≈N*2000ms
   2. Lock wait duration: Session B blocks on Lock:relation for a measured time
 
 The key technique: keep the backend ALIVE past the timer tick so BPF map
 entries are not deleted by handle_exit().
 
-Requires: root, running PostgreSQL 18.
+Requires: root, running supported PostgreSQL (PG13/17/18 in capture-smoke).
 Usage: sudo python3 tests/test_deterministic.py [--pid POSTMASTER_PID]
 """
 import subprocess
@@ -17,6 +17,10 @@ import os
 import re
 import time
 import argparse
+import json
+import shutil
+import socket
+import tempfile
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from testutil import find_postmaster
@@ -48,6 +52,51 @@ def psql(sql, timeout=10):
         capture_output=True, text=True, timeout=timeout
     )
     return result.stdout.strip()
+
+
+def wait_for_control_socket(proc, trace_dir, timeout=30):
+    path = os.path.join(trace_dir, "pgwt.sock")
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if os.path.exists(path):
+            remaining = deadline - time.monotonic()
+            client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            client.settimeout(min(5, max(0.1, remaining)))
+            try:
+                client.connect(path)
+                client.sendall(b'{"cmd":"status"}\n')
+                data = b""
+                while b"\n" not in data:
+                    chunk = client.recv(65536)
+                    if not chunk:
+                        break
+                    data += chunk
+                if json.loads(data.splitlines()[0]).get("ok") is True:
+                    return True
+            except (OSError, ValueError, json.JSONDecodeError, IndexError):
+                pass
+            finally:
+                client.close()
+        if proc.poll() is not None:
+            return False
+        time.sleep(min(0.05, max(0.0, deadline - time.monotonic())))
+    return False
+
+
+def wait_for_application_backend(application_name, timeout=30):
+    quoted = application_name.replace("'", "''")
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            out = psql(
+                "SELECT pid FROM pg_stat_activity "
+                f"WHERE application_name = '{quoted}'", timeout=10)
+        except subprocess.TimeoutExpired:
+            out = ""
+        if re.fullmatch(r'\d+', out or ''):
+            return int(out)
+        time.sleep(min(0.05, max(0.0, deadline - time.monotonic())))
+    return None
 
 
 def cleanup_stale_backends():
@@ -96,67 +145,89 @@ def parse_system_events(output):
 def test_pg_sleep_exact_count(pm_pid):
     """Execute N × pg_sleep(2) in a loop. Verify exact count and total duration.
 
-    Start DO block BEFORE the tracer so the initial scan finds the backend
-    already in PgSleep.  This avoids the race window in fork detection →
-    watchpoint setup that causes flakiness under suite load.
-
-    Using SLEEP_EACH_S=2 gives the tracer 1.5s after startup before the
-    first PgSleep→CPU transition fires — enough time for BPF load and
-    watchpoint setup even under load.
+    Start an idle tagged backend BEFORE the tracer so initial discovery and
+    watchpoint setup cover it, but do not start the five measured sleeps until
+    the post-attach control socket exists.  The old fixed 0.5s head start left
+    only 1.5s before the first PgSleep→CPU transition; a cold/CPU-starved BPF
+    load could miss that transition and report an otherwise-exact count of 4.
 
     Timeline:
-      t=0    start psql: DO block (5×pg_sleep(2)) + pg_sleep(60)
-      t=0.5  start tracer (interval=14, duration=18)
-      t=0.5  initial scan finds backend in PgSleep, sets watchpoint
-      t=2    first PgSleep→CPU transition fires watchpoint (1.5s margin)
+      t=0    start persistent tagged psql; backend is idle/ClientRead
+      t≈0    start tracer (interval=14, duration=35)
+      ready  control socket proves scan/attach completed; send 5×pg_sleep(2)
+      ready+2 first PgSleep→CPU transition fires watchpoint
       ...    each pg_sleep transition fires watchpoint
-      t=10   DO block done, pg_sleep(60) keeps backend alive
-      t=14.5 timer tick → PgSleep count=5, total≈9500ms
-      t=18.5 tracer exits, kill psql
+      ready+10 DO block done; interactive psql stays alive in ClientRead
+      tick   system_event reports exactly five closed PgSleep intervals
     """
     print("--- Test 1: pg_sleep Exact Count ---")
 
     N = 5
     SLEEP_EACH_S = 2
 
-    # Start deterministic workload BEFORE tracer:
-    #   -c "DO block" executes 5×pg_sleep(1) → ~5s of Timeout:PgSleep
-    #   -c "pg_sleep(60)" keeps the backend alive past the timer tick
+    # Keep one backend alive across discovery, the measured transitions, and
+    # the display tick. Tag it so readiness cannot observe an unrelated suite
+    # backend.
     sql = (f"DO $$ BEGIN "
            f"FOR i IN 1..{N} LOOP PERFORM pg_sleep({SLEEP_EACH_S}); END LOOP; "
            f"END $$")
+    application_name = (
+        f"pgwt_deterministic_sleep_{os.getpid()}_{time.time_ns()}")
     psql_proc = subprocess.Popen(
-        ["psql", "-U", "postgres", "-d", "postgres",
-         "-c", sql,
-         "-c", "SELECT pg_sleep(60)"],
-        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
+        ["psql", "-U", "postgres", "-d", "postgres"],
+        stdin=subprocess.PIPE, stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL, text=True,
+        env={**os.environ, "PGAPPNAME": application_name}
     )
 
-    time.sleep(0.5)  # let backend enter first pg_sleep
-
-    # Start tracer — initial scan finds backend in PgSleep
-    tracer = subprocess.Popen(
-        [TRACER, "--mode", "full", "--pid", str(pm_pid),
-         "--interval", "14", "--duration", "18",
-         "--view", "system_event"],
-        stdout=subprocess.PIPE, stderr=subprocess.PIPE
-    )
-
-    # Wait for tracer to finish
+    trace_dir = None
+    tracer = None
+    stdout = stderr = b""
     try:
-        stdout, stderr = tracer.communicate(timeout=30)
-    except subprocess.TimeoutExpired:
-        tracer.kill()
-        stdout, _ = tracer.communicate()
+        backend_pid = wait_for_application_backend(application_name, timeout=30)
+        check(backend_pid is not None,
+              f"tagged PgSleep backend exists before tracer attach "
+              f"(pid={backend_pid})")
+
+        trace_dir = tempfile.mkdtemp(prefix="pgwt_deterministic_count_")
+        os.chmod(trace_dir, 0o755)
+        tracer = subprocess.Popen(
+            [TRACER, "--mode", "full", "--pid", str(pm_pid),
+             "-T", trace_dir, "--interval", "14", "--duration", "35",
+             "--view", "system_event"],
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE
+        )
+
+        tracer_ready = wait_for_control_socket(tracer, trace_dir, timeout=30)
+        check(tracer_ready,
+              "exact-count tracer reached the post-attach startup boundary")
+        if tracer_ready and backend_pid is not None:
+            try:
+                psql_proc.stdin.write(sql + ";\n")
+                psql_proc.stdin.flush()
+            except (BrokenPipeError, OSError):
+                check(False, "tagged PgSleep backend accepted the workload")
+
+        try:
+            stdout, stderr = tracer.communicate(timeout=70)
+        except subprocess.TimeoutExpired:
+            tracer.kill()
+            stdout, stderr = tracer.communicate()
+    finally:
+        if tracer is not None and tracer.poll() is None:
+            tracer.kill()
+            stdout, stderr = tracer.communicate()
+        if psql_proc.poll() is None:
+            psql_proc.terminate()
+            try:
+                psql_proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                psql_proc.kill()
+                psql_proc.wait(timeout=5)
+        if trace_dir is not None:
+            shutil.rmtree(trace_dir, ignore_errors=True)
 
     output = STRIP_ANSI.sub('', stdout.decode('utf-8', errors='replace'))
-
-    # Cleanup
-    psql_proc.terminate()
-    try:
-        psql_proc.wait(timeout=5)
-    except subprocess.TimeoutExpired:
-        psql_proc.kill()
 
     # Parse
     events = parse_system_events(output)
@@ -168,19 +239,22 @@ def test_pg_sleep_exact_count(pm_pid):
     if not pg_sleep_ev:
         return
 
-    ev = pg_sleep_ev[0]
+    # Duration 35 produces more than one snapshot. Use the latest completed
+    # accumulator so a delayed backend transition before the first tick cannot
+    # turn an in-progress fifth sleep into another instantaneous false failure.
+    ev = pg_sleep_ev[-1]
 
     # All 5 PgSleep→CPU transitions should fire the watchpoint
     check(ev['count'] == N,
           f"count = {ev['count']} (expected exactly {N})")
 
-    # Total ≈ 9500ms (10000ms minus ~0.5s before attachment)
-    # Use generous tolerance: 7000-12000ms
+    # All five waits start after attachment, so total is ≈10000ms. Keep the
+    # existing ±3000ms product-accuracy bound.
     check(7000 <= ev['total_ms'] <= 12000,
           f"total = {ev['total_ms']:.1f}ms "
           f"(expected {N * SLEEP_EACH_S * 1000}ms ±3000ms)")
 
-    # Avg should be close to 2s (first sleep is shorter due to partial capture)
+    # Avg should be close to 2s; every sleep begins after attachment.
     check(ev['avg_us'] > 1000000,
           f"avg = {ev['avg_us']:.0f}us (expected ≈ {SLEEP_EACH_S * 1e6:.0f}us)")
 

--- a/tests/test_spawn.c
+++ b/tests/test_spawn.c
@@ -1,0 +1,91 @@
+/* test_spawn.c -- child signal state must not inherit daemon signalfd policy. */
+#include "spawn.h"
+
+#include <signal.h>
+#include <stdio.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+#include <sys/wait.h>
+
+static int report_signal_state(void)
+{
+    sigset_t current;
+    struct sigaction int_action, term_action;
+    if (sigprocmask(SIG_SETMASK, NULL, &current) != 0 ||
+        sigaction(SIGINT, NULL, &int_action) != 0 ||
+        sigaction(SIGTERM, NULL, &term_action) != 0)
+        return 2;
+    printf("%d %d %d %d\n",
+           sigismember(&current, SIGINT),
+           sigismember(&current, SIGTERM),
+           int_action.sa_handler == SIG_DFL,
+           term_action.sa_handler == SIG_DFL);
+    return 0;
+}
+
+int main(int argc, char **argv)
+{
+    if (argc == 2 && strcmp(argv[1], "--report-signal-state") == 0)
+        return report_signal_state();
+    if (argc == 2 && strcmp(argv[1], "--stall") == 0) {
+        for (;;)
+            pause();
+    }
+
+    sigset_t shutdown_signals, old_mask;
+    struct sigaction ignored = { .sa_handler = SIG_IGN };
+    struct sigaction old_int, old_term;
+    sigemptyset(&shutdown_signals);
+    sigaddset(&shutdown_signals, SIGINT);
+    sigaddset(&shutdown_signals, SIGTERM);
+    sigemptyset(&ignored.sa_mask);
+
+    if (sigprocmask(SIG_BLOCK, &shutdown_signals, &old_mask) != 0 ||
+        sigaction(SIGINT, &ignored, &old_int) != 0 ||
+        sigaction(SIGTERM, &ignored, &old_term) != 0) {
+        fprintf(stderr, "FAIL: cannot arrange parent signal state\n");
+        return 1;
+    }
+
+    struct pgwt_proc proc;
+    char *child_argv[] = {
+        "/proc/self/exe", "--report-signal-state", NULL
+    };
+    char output[64] = {0};
+    int opened = pgwt_proc_open(&proc, child_argv) == 0;
+    int read_ok = opened && fgets(output, sizeof(output), proc.out) != NULL;
+    int status = opened ? pgwt_proc_close(&proc) : -1;
+
+    sigaction(SIGINT, &old_int, NULL);
+    sigaction(SIGTERM, &old_term, NULL);
+    sigprocmask(SIG_SETMASK, &old_mask, NULL);
+
+    int int_blocked = -1, term_blocked = -1;
+    int int_default = -1, term_default = -1;
+    int parsed = sscanf(output, "%d %d %d %d", &int_blocked, &term_blocked,
+                        &int_default, &term_default) == 4;
+    int passed = opened && read_ok && status >= 0 && WIFEXITED(status) &&
+                 WEXITSTATUS(status) == 0 && parsed &&
+                 int_blocked == 0 && term_blocked == 0 &&
+                 int_default == 1 && term_default == 1;
+
+    struct pgwt_proc stalled;
+    char *stall_argv[] = { "/proc/self/exe", "--stall", NULL };
+    struct timespec begin, end;
+    clock_gettime(CLOCK_MONOTONIC, &begin);
+    int stall_opened = pgwt_proc_open(&stalled, stall_argv) == 0;
+    int stall_status = stall_opened
+        ? pgwt_proc_close_bounded(&stalled, 50) : 0;
+    clock_gettime(CLOCK_MONOTONIC, &end);
+    long elapsed_ms = (end.tv_sec - begin.tv_sec) * 1000L +
+                      (end.tv_nsec - begin.tv_nsec) / 1000000L;
+    int bounded = stall_opened && stall_status == -1 && elapsed_ms < 2000;
+    printf("=== test_spawn ===\n");
+    printf("  %s: exec child restores SIGINT/SIGTERM mask and disposition "
+           "(got %s)", passed ? "PASS" : "FAIL",
+           read_ok ? output : "no output\n");
+    printf("  %s: bounded close kills/reaps a stalled helper (%ldms)\n",
+           bounded ? "PASS" : "FAIL", elapsed_ms);
+    return passed && bounded ? 0 : 1;
+}

--- a/tests/test_uprobe_fired.py
+++ b/tests/test_uprobe_fired.py
@@ -70,10 +70,34 @@ def workload(n=8):
     return True
 
 
-def ctl(trace_dir, request):
+def wait_for_active_application(application_name, timeout=10):
+    """Return the backend PID only after PostgreSQL reports the tag active."""
+    quoted = application_name.replace("'", "''")
+    deadline = time.monotonic() + timeout
+    while True:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return None
+        try:
+            result = subprocess.run(
+                ["psql", "-U", "postgres", "-d", "postgres", "-tAc",
+                 "SELECT pid FROM pg_stat_activity "
+                 f"WHERE application_name = '{quoted}' "
+                 "AND state = 'active'"],
+                capture_output=True, text=True,
+                timeout=min(5, max(0.1, remaining)))
+            out = result.stdout.strip() if result.returncode == 0 else ""
+        except subprocess.TimeoutExpired:
+            out = ""
+        if out.isdigit():
+            return int(out)
+        time.sleep(min(0.05, max(0.0, deadline - time.monotonic())))
+
+
+def ctl(trace_dir, request, timeout=5):
     path = os.path.join(trace_dir, "pgwt.sock")
     client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-    client.settimeout(5)
+    client.settimeout(timeout)
     try:
         client.connect(path)
         client.sendall((json.dumps(request) + "\n").encode())
@@ -88,27 +112,117 @@ def ctl(trace_dir, request):
         client.close()
 
 
-def wait_for_socket(proc, trace_dir, timeout=8):
+def wait_for_socket(proc, trace_dir, timeout=30):
     path = os.path.join(trace_dir, "pgwt.sock")
-    deadline = time.time() + timeout
-    while time.time() < deadline:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
         if os.path.exists(path):
-            return True
+            remaining = deadline - time.monotonic()
+            try:
+                status = ctl(
+                    trace_dir, {"cmd": "status"},
+                    timeout=min(5, max(0.1, remaining)))
+                if status.get("ok") is True:
+                    return True
+            except (OSError, ValueError, json.JSONDecodeError, IndexError):
+                pass
         if proc.poll() is not None:
             return False
-        time.sleep(0.05)
+        time.sleep(min(0.05, max(0.0, deadline - time.monotonic())))
     return False
 
 
-def start_tracer(pm_pid, fail_at=None):
+def wait_for_status(proc, trace_dir, predicate, timeout=30):
+    """Bounded-poll status while tolerating transient event-loop stalls."""
+    deadline = time.monotonic() + timeout
+    last = {}
+    while True:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0 or proc.poll() is not None:
+            return last
+        try:
+            last = ctl(trace_dir, {"cmd": "status"},
+                       timeout=min(5, max(0.1, remaining)))
+            if predicate(last):
+                return last
+        except (OSError, ValueError, json.JSONDecodeError):
+            pass
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return last
+        time.sleep(min(0.05, remaining))
+
+
+def wait_for_exact_counts_quiescent(proc, trace_dir, timeout=30,
+                                    quiet_s=0.5):
+    """Wait until in-flight pre-detach firings have stopped changing."""
+    deadline = time.monotonic() + timeout
+    last = None
+    unchanged_since = None
+    while True:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0 or proc.poll() is not None:
+            return last if last is not None else (-1, -1)
+        try:
+            current = exact_counts(ctl(
+                trace_dir, {"cmd": "status"},
+                timeout=min(5, max(0.1, remaining))))
+            now = time.monotonic()
+            if current != last:
+                last = current
+                unchanged_since = now
+            elif unchanged_since is not None and now - unchanged_since >= quiet_s:
+                return current
+        except (OSError, ValueError, json.JSONDecodeError):
+            pass
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return last if last is not None else (-1, -1)
+        time.sleep(min(0.05, remaining))
+
+
+def restore_sampled_after_attempt(proc, trace_dir, timeout=30, quiet_s=0.5):
+    """Undo even a late, timed-out escalation before starting a new attempt."""
+    deadline = time.monotonic() + timeout
+    sampled_since = None
+    last = {}
+    while True:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0 or proc.poll() is not None:
+            return last
+        try:
+            last = ctl(trace_dir, {"cmd": "status"},
+                       timeout=min(5, max(0.1, remaining)))
+            now = time.monotonic()
+            if last.get("tier") == "escalated":
+                ctl(trace_dir, {"cmd": "deescalate"},
+                    timeout=min(5, max(0.1, deadline - now)))
+                sampled_since = None
+            elif last.get("tier") == "sampled":
+                if sampled_since is None:
+                    sampled_since = now
+                elif now - sampled_since >= quiet_s:
+                    return last
+            else:
+                sampled_since = None
+        except (OSError, ValueError, json.JSONDecodeError):
+            sampled_since = None
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return last
+        time.sleep(min(0.05, remaining))
+
+
+def start_tracer(pm_pid, escalation_fail_at=None):
     trace_dir = tempfile.mkdtemp(prefix="pgwt_exact_lifecycle_")
     os.chmod(trace_dir, 0o755)
     env = os.environ.copy()
-    if fail_at is not None:
-        env["PGWT_TEST_EXACT_PROBE_FAIL_AT"] = str(fail_at)
+    if escalation_fail_at is not None:
+        env["PGWT_TEST_EXACT_PROBE_ESCALATION_FAIL_AT"] = str(
+            escalation_fail_at)
     proc = subprocess.Popen(
         [TRACER, "--mode", "tiered", "--pid", str(pm_pid),
-         "--trace-dir", trace_dir, "--duration", "45", "--quiet",
+         "--trace-dir", trace_dir, "--duration", "180", "--quiet",
          "--interval", "1", "--escalation-budget", "120",
          "--anomaly-aas-factor", "1000000"],
         stdout=subprocess.DEVNULL, stderr=subprocess.PIPE, env=env)
@@ -119,7 +233,7 @@ def stop_tracer(proc, trace_dir):
     if proc.poll() is None:
         proc.terminate()
     try:
-        _, stderr = proc.communicate(timeout=8)
+        _, stderr = proc.communicate(timeout=30)
     except subprocess.TimeoutExpired:
         proc.kill()
         _, stderr = proc.communicate(timeout=5)
@@ -180,19 +294,73 @@ def run_cycles(pm_pid, pg_major):
         seen_generations = set()
         previous = (qfires, afires)
         for cycle in range(1, 4):
-            # The command is in flight before attach, exercising the coherent
-            # straddler seed and synthetic command-open boundary.
-            straddler = subprocess.Popen(
-                ["psql", "-U", "postgres", "-d", "postgres", "-tAc",
-                 "SELECT pg_sleep(1.0), count(*) "
-                 "FROM generate_series(1, 1000)"],
-                stdout=subprocess.DEVNULL, stderr=subprocess.PIPE, text=True)
-            time.sleep(0.20)
+            # A live backend can disappear during coherent preseed, for which
+            # the product correctly denies and rolls back the window.  Retry
+            # that transient fail-closed result within a bounded window, always
+            # with a fresh command that is demonstrably still in flight when a
+            # successful attach returns.  Permanent attach/preseed breakage
+            # still exhausts the 45s deadline and fails.
+            escalation_deadline = time.monotonic() + 45
+            response = {}
+            straddler = None
+            straddler_active_pid = None
+            attempt = 0
+            while time.monotonic() < escalation_deadline:
+                attempt += 1
+                response = {}
+                application_name = (
+                    f"pgwt_lifecycle_{os.getpid()}_{cycle}_{attempt}")
+                straddler = subprocess.Popen(
+                    ["psql", "-U", "postgres", "-d", "postgres", "-tAc",
+                     "SELECT pg_sleep(30.0), count(*) "
+                     "FROM generate_series(1, 1000)"],
+                    stdout=subprocess.DEVNULL, stderr=subprocess.PIPE,
+                    text=True,
+                    env={**os.environ, "PGAPPNAME": application_name})
+                remaining = escalation_deadline - time.monotonic()
+                straddler_active_pid = wait_for_active_application(
+                    application_name, timeout=max(0.1, min(5, remaining)))
+                if straddler_active_pid is None:
+                    if straddler.poll() is None:
+                        straddler.terminate()
+                    try:
+                        straddler.wait(timeout=5)
+                    except subprocess.TimeoutExpired:
+                        straddler.kill()
+                        straddler.wait(timeout=5)
+                    continue
+                remaining = escalation_deadline - time.monotonic()
+                if remaining <= 0:
+                    straddler.terminate()
+                    straddler.wait(timeout=5)
+                    break
+                try:
+                    response = ctl(
+                        trace_dir,
+                        {"cmd": "escalate", "duration_s": 30,
+                         "reason": "manual"},
+                        timeout=min(25, max(0.1, remaining)))
+                except (OSError, ValueError, json.JSONDecodeError) as exc:
+                    response = {"ok": False, "error": str(exc)}
+                if response.get("ok") is True and straddler.poll() is None:
+                    break
+                restore_sampled_after_attempt(
+                    proc, trace_dir,
+                    timeout=max(0.1, escalation_deadline - time.monotonic()))
+                if straddler.poll() is None:
+                    straddler.terminate()
+                try:
+                    straddler.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    straddler.kill()
+                    straddler.wait(timeout=5)
 
-            response = ctl(trace_dir, {
-                "cmd": "escalate", "duration_s": 8, "reason": "manual"})
-            check(response.get("ok") is True,
-                  f"cycle {cycle}: exact escalation granted")
+            escalated_with_straddler = (
+                response.get("ok") is True and straddler is not None and
+                straddler.poll() is None and straddler_active_pid is not None)
+            check(escalated_with_straddler,
+                  f"cycle {cycle}: exact escalation granted with an in-flight "
+                  f"straddler (response={response})")
             active = ctl(trace_dir, {"cmd": "metrics"})
             generation = int(active.get("exact_probe_generation", 0))
             check(active.get("tier") == "escalated" and
@@ -209,7 +377,7 @@ def run_cycles(pm_pid, pg_major):
             # generation is open. Both probes must fire in this interval.
             check(workload(4),
                   f"cycle {cycle}: fork/exit workload completed in window")
-            straddler.wait(timeout=10)
+            straddler.wait(timeout=45)
             check(straddler.returncode == 0,
                   f"cycle {cycle}: mid-query straddler completed")
             active = ctl(trace_dir, {"cmd": "status"})
@@ -221,20 +389,34 @@ def run_cycles(pm_pid, pg_major):
             response = ctl(trace_dir, {"cmd": "deescalate"})
             check(response.get("ok") is True,
                   f"cycle {cycle}: de-escalation acknowledged")
-            sampled = ctl(trace_dir, {"cmd": "metrics"})
-            check(sampled.get("tier") == "sampled" and
-                  sampled.get("exact_probe_attached_mask") == expected_mask and
-                  sampled.get("exact_probe_generation") == 0 and
-                  sampled.get("exact_cpu_active") is False,
+            sampled_status = wait_for_status(
+                proc, trace_dir,
+                lambda status: (
+                    status.get("tier") == "sampled" and
+                    status.get("exact_probe_attached_mask") == expected_mask and
+                    status.get("exact_probe_generation") == 0 and
+                    status.get("exact_cpu_active") is False),
+                timeout=30)
+            check(sampled_status.get("tier") == "sampled" and
+                  sampled_status.get("exact_probe_attached_mask") == expected_mask and
+                  sampled_status.get("exact_probe_generation") == 0 and
+                  sampled_status.get("exact_cpu_active") is False,
                   f"cycle {cycle}: sampled link policy restored")
-            check(sampled.get("exact_preseed_entries") == 0,
+            sampled_metrics = ctl(trace_dir, {"cmd": "metrics"})
+            check(sampled_metrics.get("exact_preseed_entries") == 0,
                   f"cycle {cycle}: generation preseed fully cleared")
 
-            after_detach = exact_counts(sampled)
+            if validated_tick_layout:
+                after_detach = wait_for_exact_counts_quiescent(
+                    proc, trace_dir, timeout=30)
+            else:
+                after_detach = exact_counts(sampled_metrics)
             check(workload(3),
                   f"cycle {cycle}: post-window sampled workload completed")
-            time.sleep(0.15)
-            after_work = exact_counts(ctl(trace_dir, {"cmd": "status"}))
+            after_work = exact_counts(wait_for_status(
+                proc, trace_dir,
+                lambda status: exact_counts(status) != (-1, -1),
+                timeout=30))
             if validated_tick_layout:
                 check(after_work == after_detach,
                       f"cycle {cycle}: detached probes do not fire in sampled "
@@ -252,30 +434,83 @@ def run_cycles(pm_pid, pg_major):
 
 def run_partial_failure(pm_pid):
     # Index 1 is activity, so query-id attaches first and must be rolled back.
-    proc, trace_dir = start_tracer(pm_pid, fail_at=1)
+    proc = None
+    trace_dir = None
     stderr = ""
+    baseline = {}
+    ready = False
+    attempts = 0
+    startup_deadline = time.monotonic() + 45
     try:
-        ready = wait_for_socket(proc, trace_dir)
-        check(ready, "rollback tracer reaches sampled baseline")
+        # Runtime PgBackendStatus validation is fail-closed per process.  Under
+        # runner starvation a fresh tracer can legitimately start degraded
+        # with both attribution probes pinned (mask 3); that policy will not
+        # later become mask 0, and a second-link attach fault cannot be reached
+        # because both links already exist.  Retry with a fresh tracer inside a
+        # bounded startup window until this subtest's validated mask-0
+        # precondition is observable.  The preceding lifecycle run already
+        # proved that the target layout is validation-capable.
+        while attempts < 5 and time.monotonic() < startup_deadline:
+            attempts += 1
+            baseline = {}
+            proc, trace_dir = start_tracer(pm_pid, escalation_fail_at=1)
+            remaining = startup_deadline - time.monotonic()
+            socket_ready = wait_for_socket(
+                proc, trace_dir, timeout=max(0.1, min(30, remaining)))
+            if socket_ready:
+                try:
+                    remaining = startup_deadline - time.monotonic()
+                    baseline = ctl(
+                        trace_dir, {"cmd": "status"},
+                        timeout=max(0.1, min(30, remaining)))
+                except (OSError, ValueError, json.JSONDecodeError):
+                    baseline = {}
+            ready = (baseline.get("tier") == "sampled" and
+                     baseline.get("exact_probe_attached_mask") == 0 and
+                     baseline.get("exact_probe_generation") == 0 and
+                     baseline.get("exact_cpu_active") is False)
+            if ready:
+                break
+            stderr += stop_tracer(proc, trace_dir)
+            proc = None
+            trace_dir = None
+
+        check(ready,
+              f"rollback tracer reaches reconciled sampled baseline "
+              f"(tier={baseline.get('tier')!r}, "
+              f"mask={baseline.get('exact_probe_attached_mask')!r}, "
+              f"generation={baseline.get('exact_probe_generation')!r}, "
+              f"validation={baseline.get('pgbackend_layout_validation')!r}, "
+              f"attempts={attempts})")
         if not ready:
             return
         response = ctl(trace_dir, {
-            "cmd": "escalate", "duration_s": 8, "reason": "manual"})
+            "cmd": "escalate", "duration_s": 8, "reason": "manual"},
+            timeout=30)
         check(response.get("ok") is False and
               "rolled back" in response.get("error", ""),
               "forced second-link failure denies exact escalation")
-        metrics = ctl(trace_dir, {"cmd": "metrics"})
+        # The escalation response is emitted only after synchronous atomic
+        # rollback.  Keep this an immediate snapshot so a real advertised
+        # partial window cannot be hidden by later polling.
+        metrics = ctl(trace_dir, {"cmd": "metrics"}, timeout=30)
         check(metrics.get("tier") == "sampled" and
               metrics.get("exact_probe_attached_mask") == 0 and
-              metrics.get("exact_probe_generation") == 0,
-              "partial attach rolls back to an unadvertised sampled window")
+              metrics.get("exact_probe_generation") == 0 and
+              metrics.get("exact_cpu_active") is False,
+              f"partial attach rolls back to an unadvertised sampled window "
+              f"(tier={metrics.get('tier')!r}, "
+              f"mask={metrics.get('exact_probe_attached_mask')!r}, "
+              f"generation={metrics.get('exact_probe_generation')!r}, "
+              f"exact_cpu_active={metrics.get('exact_cpu_active')!r})")
         check(metrics.get("exact_preseed_entries") == 0,
               "failed attach creates no generation preseed")
         check(metrics.get("escalation_denied_total", 0) >= 1 and
               metrics.get("escalation_windows_total", 0) == 0,
               "failed attach is counted as denied, never as an exact window")
     finally:
-        stderr = stop_tracer(proc, trace_dir)
+        if proc is not None:
+            stderr += stop_tracer(proc, trace_dir)
         check("forcing exact-link attach failure" in stderr,
               "integration hook reached the second exact-link attach")
 

--- a/tests/unit_tests.list
+++ b/tests/unit_tests.list
@@ -9,6 +9,7 @@
 # be built by `make -C tests` (tests/Makefile TESTS).
 test_wait_event
 test_cmdline
+test_spawn
 test_bucket
 test_event_writer
 test_event_reader


### PR DESCRIPTION
## Summary

- replace instantaneous startup, lifecycle, CPU-storm, stale-seed, and attribution checks with bounded outcome polling or evidence-based quorums
- preserve exact wait/count/CPU invariants with controlled workloads and PID-scoped trace checks
- make PG13 layout validation, exact escalation rollback, trace shutdown, and helper cleanup resilient to event-loop stalls
- document the full-tier NMI ring-buffer reservation limitation and expose loss without misattributing ambient drops to controlled waits
- add regression coverage for signal-safe helper spawning and bounded helper teardown

## Root causes

The observed flakes mixed test-timing bugs with product robustness bugs. Test failures came from treating one sampled tick, one transient ProcArray state, socket-path existence, or a global drop counter as proof of a controlled outcome. Product failures included delayed validation windows, signal/shutdown races, exact-window rollback, boundary normalization, and unbounded helper teardown.

## Validation

- clean build: pass
- `make -C tests check`: pass
- loaded full `ci_smoke`: PG13 8/8, PG17 8/8, PG18 8/8 with eight CPU hogs; 24/24 first-attempt passes
- no-load full `ci_smoke`: PG13/17/18, 3/3
- negative controls: absent live CPU fails the pure-CPU assertion; permanent exact-attach failure produces CPU fires but zero windows and fails the storm tier/reason assertions
- final adversarial review: pass

This PR is intentionally draft and must not be merged until supervisor review completes.
