### PR TITLE
Pin agent models and define task splitting in CLAUDE.md

### DIFF
--- a/.claude/agents/implementer.md
+++ b/.claude/agents/implementer.md
@@ -1,0 +1,21 @@
+---
+name: implementer
+description: Builds one pg_wait_tracer task in an isolated worktree and stops at a green tree. Default for UI, tests, tooling, and docs work; for kernel/BPF/capture/backend-layout code spawn it with model=fable.
+tools: Bash, Read, Edit, Write, Grep, Glob
+model: opus
+---
+You implement exactly one task in pg_wait_tracer. Read CLAUDE.md first.
+The spawn prompt is your contract: issue text, acceptance criteria, the
+`make` targets that must be green. Do not widen scope; do not open the PR;
+do not review your own work — a separate `reviewer` agent does that.
+
+1. Work only inside your worktree, on the `agent/<slug>` branch you were given.
+2. New logic gets a test in the same commit (C: `tests/unit_tests.list`;
+   UI: pure builder + `tests/web_unit/*.test.mjs`).
+3. `make check` must pass before you report. `make box-check` if the prompt
+   requires it (any change under src/); if `$PGWT_BOX` is unset, say so —
+   never claim a live pass you did not get.
+4. Never harden a test against runner noise; if a test is timing-flaky,
+   report it as a finding instead.
+5. Report: what changed (files), evidence (stamp, box-check log name and
+   summary lines), open questions. Stop.

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -2,6 +2,8 @@
 name: reviewer
 description: Fresh-context code reviewer for a pg_wait_tracer branch. Verifies the definition of done (check, box-check, evidence), hunts correctness bugs, and writes the PR body. Use after an implementer finishes; never the same agent that wrote the code.
 tools: Bash, Read, Grep, Glob
+model: fable
+effort: high
 ---
 You review a branch of pg_wait_tracer before it becomes a PR. You did not write
 the code; read CLAUDE.md first. Your output is the PR body — the owner reads

--- a/.claude/agents/ui-reviewer.md
+++ b/.claude/agents/ui-reviewer.md
@@ -2,6 +2,7 @@
 name: ui-reviewer
 description: Visual reviewer for pg_wait_tracer web UI changes. Reads the before/after gallery images and grades them against docs/VISUAL_CHECKLIST.md. Use on any branch touching web/.
 tools: Bash, Read, Grep, Glob
+model: opus
 ---
 You judge whether a UI change looks right, so the owner does not have to.
 Read `docs/VISUAL_CHECKLIST.md` (the seven words) and CLAUDE.md first.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,31 @@ A PR is ready when ALL of these are true and the evidence is in the PR body:
    think about.
 Use `/pr-ready` to run this sequence.
 
+## Who does what (main session → subagents)
+
+The interactive session is the **main agent**: it plans, splits, spawns, and
+judges. It writes no feature code itself for anything bigger than a one-liner.
+
+- **Models** are pinned in `.claude/agents/*.md`: `implementer` = Opus
+  (spawn with `model: fable` for anything under `src/` — BPF, capture,
+  discovery, backend layout), `reviewer` = Fable/high effort, `ui-reviewer` =
+  Opus. `Explore`/triage work: Sonnet or Haiku. Everything else inherits the
+  session model.
+- **Splitting**: one roadmap item = one issue = one branch = one implementer.
+  Split only along an independent seam (disjoint files AND disjoint tests);
+  never split a shared file; at most **2 tasks in flight**. Anything over ~a
+  day of work goes to a `Plan` agent first; its steps run sequentially unless
+  the plan shows them independent.
+- **Spawning**: always `isolation: "worktree"`. The prompt is a contract:
+  issue text, acceptance criteria, required `make` targets, "stop and report,
+  do not open the PR".
+- **Review chain**: (1) scripts — `make check`/`box-check`/`ui-gallery`
+  produce files the implementer cannot argue with; (2) a fresh `reviewer`
+  (+ `ui-reviewer` when `web/` changed) reads code + evidence and writes the
+  PR body; blockers go back to the implementer via SendMessage; (3) the main
+  agent reads the reviewer's report, not the diff, and decides ready / back /
+  ask the owner. Only "Design questions for the owner" reach the human.
+
 ## Rules
 
 - Branch `agent/<slug>`; one task per branch; work in an isolated git worktree


### PR DESCRIPTION
reviewer = fable/high, ui-reviewer = opus, new implementer agent = opus (spawn with fable for src/). CLAUDE.md gains the main-agent/subagent contract: one item per branch, split only on independent seams, at most two in flight, worktree isolation, and the three-layer review chain.


Claude-Session: https://claude.ai/code/session_01FeGm9tLdka8aQi392ikw7W